### PR TITLE
docs(readme): add project-level README and include NFTopia SVG logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 NFTopia is a multi-app, cross-platform project for creating, managing, and trading NFTs. This monorepo includes:
 - A Next.js web frontend
-- A Nest.js backend API (Starknet integration)
+- A Nest.js backend API (Stellar/Soroban integration)
 - A React Native mobile app (Expo)
 - Soroban (Stellar) smart contracts for on-chain NFT operations
 
@@ -14,21 +14,21 @@ This README provides a project-level overview, setup instructions, and developme
 
 ## Overview
 - Purpose: Deliver a full-stack NFT platform with secure minting, marketplace features, and rich user experiences.
-- Chains: Actively integrates with Starknet (frontend/backend). Soroban (Stellar) contracts are included for current and future on-chain capabilities.
+- Chains: Primary chain is Stellar with Soroban smart contracts. Migration is underway to Stellar across all apps.
 - Apps: Web (Next.js), Backend (Nest.js), Mobile (Expo RN), On-chain Contracts (Rust + Soroban).
 
 ## Repository Structure
 ```
 nftopia-stellar/
 ├── nftopia-frontend/     # Next.js web app (i18n, wallet, marketplace UI)
-├── nftopia-backend/      # Nest.js API (auth, NFTs, collections, Starknet)
-├── nftopia-mobile-app/   # Expo React Native app (ArgentX/Braavos integration)
+├── nftopia-backend/      # Nest.js API (auth, NFTs, collections, Stellar/Soroban)
+├── nftopia-mobile-app/   # Expo React Native app (Stellar wallet integration)
 └── nftopia-stellar/      # Soroban (Stellar) smart contracts (Rust)
 ```
 
 ## Tech Stack
-- Frontend: `Next.js`, `Tailwind`, `zustand`, `@starknet-react`
-- Backend: `Nest.js`, `TypeORM`, `PostgreSQL`, `BullMQ`, `JWT`, `Starknet.js`
+- Frontend: `Next.js`, `Tailwind`, `zustand`
+- Backend: `Nest.js`, `TypeORM`, `PostgreSQL`, `BullMQ`, `JWT`, `stellar-sdk`
 - Mobile: `React Native` + `Expo`, NativeWind
 - On-chain (Stellar): `Rust`, `Soroban`, `soroban-sdk`
 
@@ -37,13 +37,13 @@ nftopia-stellar/
 - pnpm (recommended) or npm
 - PostgreSQL 14+ (backend)
 - Redis (backend queues)
-- Starknet wallet (ArgentX/Braavos) for web/mobile testing
+- Stellar wallet for web testing (Freighter). Mobile can deep-link to Stellar wallets (e.g., xBull, Lobstr).
 - Rust 1.75+, Soroban CLI (contracts)
 
 ## Environment Configuration
 - Frontend: `apps/frontend/.env.local` (see `nftopia-frontend/.env.example` if present)
 - Backend: `apps/backend/.env` (copy from `nftopia-backend/.env.example`)
-  - Required: `STARKNET_RPC_URL`, `STARKNET_NFT_CONTRACT`, `STARKNET_MARKETPLACE_CONTRACT`, `STARKNET_AUCTION_CONTRACT`, `STARKNET_ACCOUNT_ADDRESS`, `STARKNET_PRIVATE_KEY`, `JWT_SECRET`, DB vars
+  - Required: `SOROBAN_RPC_URL`, `STELLAR_NETWORK`, `SOROBAN_NFT_CONTRACT_ID`, `SOROBAN_MARKETPLACE_CONTRACT_ID`, `SOROBAN_AUCTION_CONTRACT_ID`, `STELLAR_ACCOUNT_PUBLIC_KEY`, `STELLAR_SECRET_KEY`, `JWT_SECRET`, DB vars
 - Mobile: `nftopia-mobile-app/.env` (copy from `.env.example`)
 - Soroban: `nftopia-stellar/.env` (copy `.env.example`)
 
@@ -60,7 +60,7 @@ nftopia-stellar/
   - Validate i18n: `pnpm validate-translations`
 - Features:
   - i18n with EN/FR/ES/DE
-  - Starknet wallet connection (ArgentX/Braavos)
+  - Stellar wallet connection (Freighter)
   - Creator dashboard with minting UI and file upload
 
 ### Backend (Nest.js)
@@ -73,10 +73,10 @@ nftopia-stellar/
   - Dev: `pnpm start:dev` (typical Nest script; alternatively `pnpm start` if configured)
   - Tests: `pnpm test`
 - Highlights:
-  - JWT-based authentication and nonce signing (Starknet typed data)
+  - JWT-based authentication and challenge/nonce signing (Stellar SEP-0010-style)
   - NFT mint endpoints (upload to Firebase, metadata to IPFS via NFT.Storage)
   - Collections, transactions, auctions, stats
-  - Event listeners for Starknet contracts (marketplace, auction, transaction)
+  - Event listeners/log processing for Soroban contracts (marketplace, auction, transaction)
 
 #### Common API Endpoints
 - Mint NFT via file upload:
@@ -84,7 +84,7 @@ nftopia-stellar/
   - Multipart form with `file`; JSON fields: `title`, `description`, `price`, `currency`
 - Mint NFT from image URL (JWT required):
   - `POST /nfts/mint/from-url?collectionId=<id>`
-  - JSON body: `{ "title": "...", "description": "...", "imageUrl": "...", "price": 1.23, "currency": "STK" }`
+  - JSON body: `{ "title": "...", "description": "...", "imageUrl": "...", "price": 1.23, "currency": "XLM" }`
 
 ### Mobile App (Expo React Native)
 - Directory: `nftopia-mobile-app`
@@ -94,7 +94,7 @@ nftopia-stellar/
   - Android: `pnpm android`
   - iOS: `pnpm ios`
 - Features:
-  - Wallet connectivity (ArgentX/Braavos)
+  - Wallet connectivity via Stellar-compatible wallets (e.g., Freighter web, deep-links to xBull/Lobstr)
   - Mobile-optimized minting and marketplace browsing
 
 ### Soroban Contracts (Stellar)
@@ -114,9 +114,9 @@ nftopia-stellar/
   - Workspace: `cargo test --all`
 
 ## Authentication Flow (Web)
-- Connect wallet (ArgentX/Braavos)
-- Backend issues a nonce
-- User signs typed data message with nonce
+- Connect Stellar wallet (Freighter or compatible)
+- Backend issues a challenge/nonce
+- User signs the challenge/nonce with their Stellar key
 - Backend verifies signature and issues JWT
 
 ## Internationalization
@@ -131,7 +131,7 @@ nftopia-stellar/
 
 ## Development Tips
 - Keep envs in sync with backend validation (`src/config/validation.ts`)
-- For Starknet listeners, ensure required `STARKNET_*` vars are set
+- Ensure Soroban RPC and contract IDs are configured (`SOROBAN_*`, `STELLAR_*`)
 - Use the provided scripts and avoid modifying unrelated modules
 
 ## Contributing


### PR DESCRIPTION
- Description:
  
  - Adds a comprehensive project-level README at the repository root to document the NFTopia monorepo: frontend (Next.js), backend (Nest.js + Starknet), mobile (Expo RN), and Soroban (Stellar) contracts.
  - Centers the NFTopia SVG logo at the top using nftopia-frontend/public/nftopia-04.svg .
  - Includes quick-start commands, environment variable guidance, authentication flow (nonce + typed-data → JWT), mint endpoints, Soroban CLI setup, and testing instructions.
- Motivation:
  
  - Provides a single source of truth for contributors and users, improves onboarding, and aligns documentation across subprojects.
- Changes:
  
  - README.md : New project-level documentation + logo.
- Testing:
  
  - Verified markdown sections render correctly.
  - Confirmed SVG path is valid in this monorepo. If upstream lacks the nftopia-frontend/public asset, I can move the SVG to a root assets/ folder and update the path.
- Notes:
  
  - No code or runtime changes.
  - Maintains existing subproject documentation; this README acts as an entry point.
- Checklist:
  
  - Docs render on GitHub with logo.
  - Commands validated for a typical Node/Rust/Soroban setup.
  - No breaking changes.