### PR TITLE
test(bid): add unit tests for BidGateway WebSocket service and fix Horizon mock in bid.service.spec

### DIFF
--- a/nftopia-backend/package-lock.json
+++ b/nftopia-backend/package-lock.json
@@ -531,6 +531,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2520,6 +2521,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2579,6 +2581,7 @@
       "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2771,6 +2774,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.17.tgz",
       "integrity": "sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3053,6 +3057,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.17.tgz",
       "integrity": "sha512-BSOAsENdmTtsnDL0hb4takbWzPy9WoPybjlM57ab3/rQgm0biMFYUupH2uzmCjmmIXJL/EFbAWznVl8xw2Sa6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3257,6 +3262,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.17.tgz",
       "integrity": "sha512-YbwQ0QfVj0lxkKQhdIIgk14ZSVWDqGk1J8nNSN6SLjf36sVv58Ma5ro+dtQua8wj3l2Ub7JJCVFixEhKtYc/rQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3456,6 +3462,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -3773,6 +3780,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3930,6 +3938,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4126,6 +4135,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -4854,6 +4864,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4903,6 +4914,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5513,6 +5525,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5612,6 +5625,7 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -5803,13 +5817,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -6629,6 +6645,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6689,6 +6706,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7645,6 +7663,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -7960,6 +7979,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -8244,6 +8264,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -9171,6 +9192,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -9987,6 +10009,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -10104,6 +10127,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10213,6 +10237,7 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -10244,6 +10269,7 @@
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
       "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^10.0.0",
@@ -10446,6 +10472,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10746,7 +10773,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-addon": {
       "version": "1.2.0",
@@ -10897,6 +10925,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11773,6 +11802,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12137,6 +12167,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12302,6 +12333,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -12521,6 +12553,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12821,6 +12854,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -12890,6 +12924,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13113,6 +13148,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/nftopia-backend/src/modules/bid/bid.gateway.spec.ts
+++ b/nftopia-backend/src/modules/bid/bid.gateway.spec.ts
@@ -1,0 +1,301 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { Server, Socket } from 'socket.io';
+import { BidGateway } from './bid.gateway';
+import { BidSorobanStatus } from '../auction/entities/bid.entity';
+import type { BidPlacedEvent } from './interfaces/bid.interface';
+
+const makeMockRoom = () => ({ emit: jest.fn() });
+
+const makeMockServer = (room: ReturnType<typeof makeMockRoom>): jest.Mocked<Server> =>
+  ({ to: jest.fn().mockReturnValue(room) } as unknown as jest.Mocked<Server>);
+
+const makeMockClient = (id = 'client-abc'): jest.Mocked<Socket> =>
+  ({
+    id,
+    join: jest.fn().mockResolvedValue(undefined),
+    leave: jest.fn().mockResolvedValue(undefined),
+    emit: jest.fn(),
+  } as unknown as jest.Mocked<Socket>);
+
+const makeBidPayload = (override: Partial<BidPlacedEvent> = {}): BidPlacedEvent => ({
+  auctionId: 'auction-123',
+  bidderId: 'user-456',
+  stellarPublicKey: 'GABC1234567890EXAMPLESTELLARKEY0000000000000000000000000',
+  amount: 1_000_000,
+  amountXlm: '100.0000000',
+  txHash: 'abc123txhash',
+  ledgerSequence: 100,
+  sorobanStatus: BidSorobanStatus.CONFIRMED,
+  timestamp: new Date('2024-01-01T00:00:00Z'),
+  ...override,
+});
+
+describe('BidGateway', () => {
+  let gateway: BidGateway;
+  let mockRoom: ReturnType<typeof makeMockRoom>;
+  let mockServer: jest.Mocked<Server>;
+  let mockClient: jest.Mocked<Socket>;
+
+  beforeEach(async () => {
+    mockRoom = makeMockRoom();
+    mockServer = makeMockServer(mockRoom);
+    mockClient = makeMockClient();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BidGateway],
+    }).compile();
+
+    gateway = module.get<BidGateway>(BidGateway);
+    (gateway as any).server = mockServer;
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ─── Lifecycle hooks ────────────────────────────────────────────────────────
+
+  describe('afterInit', () => {
+    it('logs server initialisation', () => {
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+      gateway.afterInit();
+      expect(logSpy).toHaveBeenCalledWith('BidGateway WebSocket server initialised');
+    });
+  });
+
+  describe('handleConnection', () => {
+    it('logs the connected client id', () => {
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+      gateway.handleConnection(mockClient);
+      expect(debugSpy).toHaveBeenCalledWith(`Client connected: ${mockClient.id}`);
+    });
+
+    it('handles clients with different ids without throwing', () => {
+      const clients = [makeMockClient('c-1'), makeMockClient('c-2'), makeMockClient('c-3')];
+      clients.forEach((c) => expect(() => gateway.handleConnection(c)).not.toThrow());
+    });
+  });
+
+  describe('handleDisconnect', () => {
+    it('logs the disconnected client id', () => {
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+      gateway.handleDisconnect(mockClient);
+      expect(debugSpy).toHaveBeenCalledWith(`Client disconnected: ${mockClient.id}`);
+    });
+
+    it('handles multiple disconnecting clients without throwing', () => {
+      const clients = [makeMockClient('d-1'), makeMockClient('d-2')];
+      clients.forEach((c) => expect(() => gateway.handleDisconnect(c)).not.toThrow());
+    });
+  });
+
+  // ─── Room management ────────────────────────────────────────────────────────
+
+  describe('handleJoinAuction', () => {
+    it('joins client to auction:<id> room', () => {
+      gateway.handleJoinAuction({ auctionId: 'auction-123' }, mockClient);
+      expect(mockClient.join).toHaveBeenCalledWith('auction:auction-123');
+    });
+
+    it('returns joined event with the auctionId', () => {
+      const result = gateway.handleJoinAuction({ auctionId: 'auction-123' }, mockClient);
+      expect(result).toEqual({ event: 'joined', data: { auctionId: 'auction-123' } });
+    });
+
+    it('logs the join with client id and room', () => {
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+      gateway.handleJoinAuction({ auctionId: 'auction-456' }, mockClient);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `${mockClient.id} joined room auction:auction-456`,
+      );
+    });
+
+    it('works with UUID-formatted auction ids', () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440000';
+      const result = gateway.handleJoinAuction({ auctionId: uuid }, mockClient);
+      expect(mockClient.join).toHaveBeenCalledWith(`auction:${uuid}`);
+      expect(result).toEqual({ event: 'joined', data: { auctionId: uuid } });
+    });
+
+    it('allows one client to join multiple auction rooms', () => {
+      gateway.handleJoinAuction({ auctionId: 'a-1' }, mockClient);
+      gateway.handleJoinAuction({ auctionId: 'a-2' }, mockClient);
+      expect(mockClient.join).toHaveBeenCalledTimes(2);
+      expect(mockClient.join).toHaveBeenCalledWith('auction:a-1');
+      expect(mockClient.join).toHaveBeenCalledWith('auction:a-2');
+    });
+
+    it('allows multiple clients to join the same auction room', () => {
+      const client2 = makeMockClient('client-2');
+      gateway.handleJoinAuction({ auctionId: 'shared' }, mockClient);
+      gateway.handleJoinAuction({ auctionId: 'shared' }, client2);
+      expect(mockClient.join).toHaveBeenCalledWith('auction:shared');
+      expect(client2.join).toHaveBeenCalledWith('auction:shared');
+    });
+  });
+
+  describe('handleLeaveAuction', () => {
+    it('removes client from auction:<id> room', () => {
+      gateway.handleLeaveAuction({ auctionId: 'auction-123' }, mockClient);
+      expect(mockClient.leave).toHaveBeenCalledWith('auction:auction-123');
+    });
+
+    it('returns left event with the auctionId', () => {
+      const result = gateway.handleLeaveAuction({ auctionId: 'auction-123' }, mockClient);
+      expect(result).toEqual({ event: 'left', data: { auctionId: 'auction-123' } });
+    });
+
+    it('logs the leave with client id and room', () => {
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+      gateway.handleLeaveAuction({ auctionId: 'auction-789' }, mockClient);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `${mockClient.id} left room auction:auction-789`,
+      );
+    });
+
+    it('works with UUID-formatted auction ids', () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440000';
+      const result = gateway.handleLeaveAuction({ auctionId: uuid }, mockClient);
+      expect(mockClient.leave).toHaveBeenCalledWith(`auction:${uuid}`);
+      expect(result).toEqual({ event: 'left', data: { auctionId: uuid } });
+    });
+
+    it('leaves independently from other joined rooms', () => {
+      gateway.handleJoinAuction({ auctionId: 'stay' }, mockClient);
+      gateway.handleJoinAuction({ auctionId: 'exit' }, mockClient);
+      gateway.handleLeaveAuction({ auctionId: 'exit' }, mockClient);
+      expect(mockClient.leave).toHaveBeenCalledTimes(1);
+      expect(mockClient.leave).toHaveBeenCalledWith('auction:exit');
+    });
+  });
+
+  describe('join then leave round-trip', () => {
+    it('join and leave call the correct socket methods in order', () => {
+      const auctionId = 'auction-xyz';
+      gateway.handleJoinAuction({ auctionId }, mockClient);
+      gateway.handleLeaveAuction({ auctionId }, mockClient);
+      expect(mockClient.join).toHaveBeenCalledWith(`auction:${auctionId}`);
+      expect(mockClient.leave).toHaveBeenCalledWith(`auction:${auctionId}`);
+    });
+  });
+
+  // ─── Bid broadcast ──────────────────────────────────────────────────────────
+
+  describe('handleBidPlacedEvent', () => {
+    it('broadcasts bid-placed to the correct auction room', () => {
+      const payload = makeBidPayload({ auctionId: 'auction-abc' });
+      gateway.handleBidPlacedEvent(payload);
+      expect(mockServer.to).toHaveBeenCalledWith('auction:auction-abc');
+      expect(mockRoom.emit).toHaveBeenCalledWith('bid-placed', expect.any(Object));
+    });
+
+    it('broadcasts all required bid fields', () => {
+      const payload = makeBidPayload();
+      gateway.handleBidPlacedEvent(payload);
+      expect(mockRoom.emit).toHaveBeenCalledWith('bid-placed', {
+        auctionId: payload.auctionId,
+        bidderId: payload.bidderId,
+        amount: payload.amount,
+        amountXlm: payload.amountXlm,
+        txHash: payload.txHash,
+        ledgerSequence: payload.ledgerSequence,
+        sorobanStatus: payload.sorobanStatus,
+        timestamp: payload.timestamp,
+      });
+    });
+
+    it('does not expose stellarPublicKey in the broadcast payload', () => {
+      const payload = makeBidPayload();
+      gateway.handleBidPlacedEvent(payload);
+      const broadcasted = mockRoom.emit.mock.calls[0][1] as Record<string, unknown>;
+      expect(broadcasted).not.toHaveProperty('stellarPublicKey');
+    });
+
+    it('logs the broadcast with room and amount', () => {
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+      const payload = makeBidPayload({ amountXlm: '150.0000000' });
+      gateway.handleBidPlacedEvent(payload);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `Broadcast bid-placed to room auction:${payload.auctionId}: ${payload.amountXlm} XLM`,
+      );
+    });
+
+    it('routes different auction events to their respective rooms', () => {
+      const room2 = makeMockRoom();
+      mockServer.to
+        .mockReturnValueOnce(mockRoom as any)
+        .mockReturnValueOnce(room2 as any);
+
+      gateway.handleBidPlacedEvent(makeBidPayload({ auctionId: 'auction-A' }));
+      gateway.handleBidPlacedEvent(makeBidPayload({ auctionId: 'auction-B' }));
+
+      expect(mockServer.to).toHaveBeenCalledWith('auction:auction-A');
+      expect(mockServer.to).toHaveBeenCalledWith('auction:auction-B');
+      expect(mockRoom.emit).toHaveBeenCalledTimes(1);
+      expect(room2.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles PENDING soroban status', () => {
+      const payload = makeBidPayload({ sorobanStatus: BidSorobanStatus.PENDING });
+      gateway.handleBidPlacedEvent(payload);
+      expect(mockRoom.emit).toHaveBeenCalledWith(
+        'bid-placed',
+        expect.objectContaining({ sorobanStatus: BidSorobanStatus.PENDING }),
+      );
+    });
+
+    it('handles FAILED soroban status', () => {
+      const payload = makeBidPayload({ sorobanStatus: BidSorobanStatus.FAILED });
+      gateway.handleBidPlacedEvent(payload);
+      expect(mockRoom.emit).toHaveBeenCalledWith(
+        'bid-placed',
+        expect.objectContaining({ sorobanStatus: BidSorobanStatus.FAILED }),
+      );
+    });
+
+    it('handles SKIPPED soroban status', () => {
+      const payload = makeBidPayload({ sorobanStatus: BidSorobanStatus.SKIPPED });
+      gateway.handleBidPlacedEvent(payload);
+      expect(mockRoom.emit).toHaveBeenCalledWith(
+        'bid-placed',
+        expect.objectContaining({ sorobanStatus: BidSorobanStatus.SKIPPED }),
+      );
+    });
+
+    it('handles payload without optional txHash and ledgerSequence', () => {
+      const payload = makeBidPayload({ txHash: undefined, ledgerSequence: undefined });
+      expect(() => gateway.handleBidPlacedEvent(payload)).not.toThrow();
+      expect(mockRoom.emit).toHaveBeenCalledWith(
+        'bid-placed',
+        expect.objectContaining({ txHash: undefined, ledgerSequence: undefined }),
+      );
+    });
+
+    it('emits exactly once per event', () => {
+      gateway.handleBidPlacedEvent(makeBidPayload());
+      expect(mockRoom.emit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── Connection / disconnection lifecycle edge cases ───────────────────────
+
+  describe('connection lifecycle', () => {
+    it('connection followed by disconnection does not throw', () => {
+      expect(() => {
+        gateway.handleConnection(mockClient);
+        gateway.handleDisconnect(mockClient);
+      }).not.toThrow();
+    });
+
+    it('disconnect without prior connection does not throw', () => {
+      const freshClient = makeMockClient('orphan');
+      expect(() => gateway.handleDisconnect(freshClient)).not.toThrow();
+    });
+  });
+});

--- a/nftopia-backend/src/modules/bid/bid.gateway.spec.ts
+++ b/nftopia-backend/src/modules/bid/bid.gateway.spec.ts
@@ -5,6 +5,8 @@ import { BidGateway } from './bid.gateway';
 import { BidSorobanStatus } from '../auction/entities/bid.entity';
 import type { BidPlacedEvent } from './interfaces/bid.interface';
 
+type RoomLike = ReturnType<Server['to']>;
+
 const makeMockRoom = () => ({ emit: jest.fn() });
 
 const makeMockServer = (room: ReturnType<typeof makeMockRoom>): jest.Mocked<Server> =>
@@ -47,7 +49,7 @@ describe('BidGateway', () => {
     }).compile();
 
     gateway = module.get<BidGateway>(BidGateway);
-    (gateway as any).server = mockServer;
+    Object.assign(gateway, { server: mockServer });
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
     jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
@@ -213,7 +215,8 @@ describe('BidGateway', () => {
     it('does not expose stellarPublicKey in the broadcast payload', () => {
       const payload = makeBidPayload();
       gateway.handleBidPlacedEvent(payload);
-      const broadcasted = mockRoom.emit.mock.calls[0][1] as Record<string, unknown>;
+      const callArgs = mockRoom.emit.mock.calls[0] as unknown as [string, Record<string, unknown>];
+      const broadcasted = callArgs[1];
       expect(broadcasted).not.toHaveProperty('stellarPublicKey');
     });
 
@@ -229,8 +232,8 @@ describe('BidGateway', () => {
     it('routes different auction events to their respective rooms', () => {
       const room2 = makeMockRoom();
       mockServer.to
-        .mockReturnValueOnce(mockRoom as any)
-        .mockReturnValueOnce(room2 as any);
+        .mockReturnValueOnce(mockRoom as unknown as RoomLike)
+        .mockReturnValueOnce(room2 as unknown as RoomLike);
 
       gateway.handleBidPlacedEvent(makeBidPayload({ auctionId: 'auction-A' }));
       gateway.handleBidPlacedEvent(makeBidPayload({ auctionId: 'auction-B' }));

--- a/nftopia-backend/src/modules/bid/bid.service.spec.ts
+++ b/nftopia-backend/src/modules/bid/bid.service.spec.ts
@@ -11,6 +11,23 @@ import {
 } from '@nestjs/common';
 import { Keypair } from 'stellar-sdk';
 
+// Prevent real Horizon HTTP calls — verifyBalance falls back to testnet URL even
+// when STELLAR_HORIZON_URL is undefined, so we stub the server at module level.
+jest.mock('stellar-sdk', () => {
+  const actual = jest.requireActual<typeof import('stellar-sdk')>('stellar-sdk');
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: jest.fn().mockImplementation(() => ({
+        loadAccount: jest.fn().mockResolvedValue({
+          balances: [{ asset_type: 'native', balance: '1000.0000000' }],
+        }),
+      })),
+    },
+  };
+});
+
 import { BidService } from './bid.service';
 import { Bid, BidSorobanStatus } from '../auction/entities/bid.entity';
 import { Auction } from '../auction/entities/auction.entity';
@@ -150,9 +167,7 @@ describe('BidService', () => {
 
       mockCache.get.mockResolvedValue(null); // no rate limit hit
       mockAuctionRepo.findOne.mockResolvedValue(auction);
-      mockBidRepo.findOne
-        .mockResolvedValueOnce(null) // validate amount: no existing highest
-        .mockResolvedValueOnce(null); // no Horizon balance check (STELLAR_HORIZON_URL = undefined)
+      mockBidRepo.findOne.mockResolvedValueOnce(null); // validate amount: no existing highest bid
       mockBidRepo.create.mockReturnValue(persisted);
       mockBidRepo.save.mockResolvedValue(persisted);
       mockAuctionRepo.save.mockResolvedValue(auction);


### PR DESCRIPTION
### Summary
- Add bid.gateway.spec.ts with 29 unit tests covering all WebSocket lifecycle hooks, room management, and bid broadcast logic — achieves 100% coverage on
bid.gateway.ts
- Fix pre-existing timeout in bid.service.spec.ts caused by verifyBalance making a live HTTP call to Horizon testnet; stub Horizon.Server at module level via jest.mock 
All tests run in isolation with no real WebSocket or network connections.
Closes #166