### PR TITLE
feat(graphql): add marketplace Listing resolvers, types, inputs, and tests

### DIFF
--- a/nftopia-backend/package-lock.json
+++ b/nftopia-backend/package-lock.json
@@ -531,7 +531,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2521,7 +2520,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2581,7 +2579,6 @@
       "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2774,7 +2771,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.17.tgz",
       "integrity": "sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3057,7 +3053,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.17.tgz",
       "integrity": "sha512-BSOAsENdmTtsnDL0hb4takbWzPy9WoPybjlM57ab3/rQgm0biMFYUupH2uzmCjmmIXJL/EFbAWznVl8xw2Sa6Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3262,7 +3257,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.17.tgz",
       "integrity": "sha512-YbwQ0QfVj0lxkKQhdIIgk14ZSVWDqGk1J8nNSN6SLjf36sVv58Ma5ro+dtQua8wj3l2Ub7JJCVFixEhKtYc/rQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3462,7 +3456,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -3780,7 +3773,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3938,7 +3930,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4135,7 +4126,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -4864,7 +4854,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4914,7 +4903,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5525,7 +5513,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5625,7 +5612,6 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -5817,15 +5803,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -6645,7 +6629,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6706,7 +6689,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7663,7 +7645,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -7979,7 +7960,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -8264,7 +8244,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -9192,7 +9171,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -10009,7 +9987,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -10127,7 +10104,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10237,7 +10213,6 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -10269,7 +10244,6 @@
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
       "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^10.0.0",
@@ -10472,7 +10446,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10773,8 +10746,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-addon": {
       "version": "1.2.0",
@@ -10925,7 +10897,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11802,7 +11773,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12167,7 +12137,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12333,7 +12302,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -12553,7 +12521,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12854,7 +12821,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -12924,7 +12890,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13148,7 +13113,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/nftopia-backend/src/graphql/graphql.module.ts
+++ b/nftopia-backend/src/graphql/graphql.module.ts
@@ -8,6 +8,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtStrategy } from '../auth/jwt.strategy';
 import { GqlAuthGuard } from '../common/guards/gql-auth.guard';
 import { CollectionModule } from '../modules/collection/collection.module';
+import { ListingModule } from '../modules/listing/listing.module';
 import { NftModule } from '../modules/nft/nft.module';
 import { SearchModule } from '../search/search.module';
 import { GraphqlContextFactory } from './context/context.factory';
@@ -48,6 +49,7 @@ const jwtAccessExpiresInSeconds = parseInt(
       },
     }),
     CollectionModule,
+    ListingModule,
     NftModule,
     SearchModule,
   ],

--- a/nftopia-backend/src/graphql/inputs/listing.inputs.ts
+++ b/nftopia-backend/src/graphql/inputs/listing.inputs.ts
@@ -1,0 +1,52 @@
+import { Field, Float, ID, InputType } from '@nestjs/graphql';
+import { Type } from 'class-transformer';
+import {
+  IsDateString,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { ListingStatus } from '../types/listing.types';
+
+@InputType()
+export class ListingFilterInput {
+  @Field(() => ListingStatus, { nullable: true })
+  @IsOptional()
+  @IsEnum(ListingStatus)
+  status?: ListingStatus;
+
+  @Field(() => ID, { nullable: true })
+  @IsOptional()
+  @IsString()
+  nftId?: string;
+
+  @Field(() => ID, { nullable: true })
+  @IsOptional()
+  @IsString()
+  sellerId?: string;
+}
+
+@InputType()
+export class CreateListingInput {
+  @Field(() => ID)
+  @IsString()
+  nftId: string;
+
+  @Field(() => Float)
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 7 })
+  @Min(0.0000001)
+  price: number;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string;
+}

--- a/nftopia-backend/src/graphql/resolvers/index.ts
+++ b/nftopia-backend/src/graphql/resolvers/index.ts
@@ -1,5 +1,6 @@
 import { BaseResolver } from './base.resolver';
 import { CollectionResolver } from './collection.resolver';
+import { ListingResolver } from './listing.resolver';
 import { NftResolver } from './nft.resolver';
 import { JsonScalar } from '../types/nft.types';
 
@@ -7,11 +8,13 @@ export const graphqlResolvers = [
   BaseResolver,
   NftResolver,
   CollectionResolver,
+  ListingResolver,
 ] as const;
 
 export const graphqlScalarClasses = [JsonScalar] as const;
 
 export { BaseResolver };
 export { CollectionResolver };
+export { ListingResolver };
 export { NftResolver };
 export { JsonScalar };

--- a/nftopia-backend/src/graphql/resolvers/listing.resolver.spec.ts
+++ b/nftopia-backend/src/graphql/resolvers/listing.resolver.spec.ts
@@ -1,0 +1,214 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ListingResolver } from './listing.resolver';
+import { ListingService } from '../../modules/listing/listing.service';
+import { ListingStatus } from '../../modules/listing/interfaces/listing.interface';
+
+const mockListingService = {
+  findOne: jest.fn(),
+  findConnection: jest.fn(),
+  create: jest.fn(),
+  cancel: jest.fn(),
+  buy: jest.fn(),
+};
+
+describe('ListingResolver', () => {
+  let resolver: ListingResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ListingResolver,
+        { provide: ListingService, useValue: mockListingService },
+      ],
+    }).compile();
+
+    resolver = module.get<ListingResolver>(ListingResolver);
+    jest.clearAllMocks();
+  });
+
+  it('returns a single listing mapped to GraphQL shape', async () => {
+    mockListingService.findOne.mockResolvedValue({
+      id: 'listing-1',
+      nftContractId: 'C'.repeat(56),
+      nftTokenId: 'token-1',
+      sellerId: 'seller-1',
+      price: '10.2500000',
+      currency: 'XLM',
+      status: ListingStatus.ACTIVE,
+      createdAt: new Date('2026-03-25T10:00:00.000Z'),
+      expiresAt: null,
+    });
+
+    const result = await resolver.listing('listing-1');
+
+    expect(mockListingService.findOne).toHaveBeenCalledWith('listing-1');
+    expect(result.id).toBe('listing-1');
+    expect(result.nftId).toBe(`${'C'.repeat(56)}:token-1`);
+    expect(result.status).toBe(ListingStatus.ACTIVE);
+  });
+
+  it('builds a listing connection with pagination and filters', async () => {
+    const createdAt = new Date('2026-03-25T10:00:00.000Z');
+    mockListingService.findConnection.mockResolvedValue({
+      data: [
+        {
+          id: 'listing-1',
+          nftContractId: 'C'.repeat(56),
+          nftTokenId: 'token-1',
+          sellerId: 'seller-1',
+          price: 2.5,
+          currency: 'XLM',
+          status: ListingStatus.ACTIVE,
+          createdAt,
+          expiresAt: null,
+        },
+      ],
+      total: 1,
+      hasNextPage: false,
+    });
+
+    const result = await resolver.listings(
+      { first: 10 },
+      {
+        status: ListingStatus.ACTIVE,
+        nftId: `${'C'.repeat(56)}:token-1`,
+        sellerId: 'seller-1',
+      },
+    );
+
+    expect(mockListingService.findConnection).toHaveBeenCalledWith({
+      first: 10,
+      after: undefined,
+      status: ListingStatus.ACTIVE,
+      sellerId: 'seller-1',
+      nftContractId: 'C'.repeat(56),
+      nftTokenId: 'token-1',
+    });
+    expect(result.totalCount).toBe(1);
+    expect(result.pageInfo.hasNextPage).toBe(false);
+    expect(result.edges[0]?.cursor).toEqual(expect.any(String));
+  });
+
+  it('passes decoded cursor into listing connection query', async () => {
+    const cursor = Buffer.from(
+      JSON.stringify({
+        createdAt: '2026-03-25T10:00:00.000Z',
+        id: 'listing-1',
+      }),
+      'utf8',
+    ).toString('base64url');
+
+    mockListingService.findConnection.mockResolvedValue({
+      data: [],
+      total: 0,
+      hasNextPage: false,
+    });
+
+    await resolver.listings({ first: 5, after: cursor });
+
+    expect(mockListingService.findConnection).toHaveBeenCalledWith({
+      first: 5,
+      after: {
+        createdAt: '2026-03-25T10:00:00.000Z',
+        id: 'listing-1',
+      },
+      status: undefined,
+      sellerId: undefined,
+      nftContractId: undefined,
+      nftTokenId: undefined,
+    });
+  });
+
+  it('creates a listing for an authenticated user', async () => {
+    mockListingService.create.mockResolvedValue({
+      id: 'listing-1',
+      nftContractId: 'C'.repeat(56),
+      nftTokenId: 'token-1',
+      sellerId: 'seller-1',
+      price: 1,
+      currency: 'XLM',
+      status: ListingStatus.ACTIVE,
+      createdAt: new Date('2026-03-25T10:00:00.000Z'),
+      expiresAt: null,
+    });
+
+    await resolver.createListing(
+      {
+        nftId: `${'C'.repeat(56)}:token-1`,
+        price: 1,
+        currency: 'XLM',
+      },
+      {
+        req: {} as never,
+        res: {} as never,
+        user: { userId: 'seller-1' },
+      },
+    );
+
+    expect(mockListingService.create).toHaveBeenCalledWith(
+      {
+        nftContractId: 'C'.repeat(56),
+        nftTokenId: 'token-1',
+        price: 1,
+        currency: 'XLM',
+        expiresAt: undefined,
+      },
+      'seller-1',
+    );
+  });
+
+  it('cancels listing and returns true for authenticated caller', async () => {
+    mockListingService.cancel.mockResolvedValue({
+      id: 'listing-1',
+      status: ListingStatus.CANCELLED,
+    });
+
+    const result = await resolver.cancelListing('listing-1', {
+      req: {} as never,
+      res: {} as never,
+      user: { userId: 'seller-1' },
+    });
+
+    expect(result).toBe(true);
+    expect(mockListingService.cancel).toHaveBeenCalledWith(
+      'listing-1',
+      'seller-1',
+    );
+  });
+
+  it('buys NFT and maps transaction result', async () => {
+    mockListingService.buy.mockResolvedValue({
+      success: true,
+      listingId: 'listing-1',
+      buyer: 'buyer-1',
+    });
+
+    const result = await resolver.buyNFT('listing-1', {
+      req: {} as never,
+      res: {} as never,
+      user: { userId: 'buyer-1' },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      listingId: 'listing-1',
+      buyerId: 'buyer-1',
+    });
+  });
+
+  it('rejects unauthenticated listing mutation requests', async () => {
+    await expect(
+      resolver.createListing(
+        {
+          nftId: `${'C'.repeat(56)}:token-1`,
+          price: 1,
+        },
+        {
+          req: {} as never,
+          res: {} as never,
+        },
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+});

--- a/nftopia-backend/src/graphql/resolvers/listing.resolver.ts
+++ b/nftopia-backend/src/graphql/resolvers/listing.resolver.ts
@@ -1,0 +1,236 @@
+import { Args, Context, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import {
+  BadRequestException,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
+import type { GraphqlContext } from '../context/context.interface';
+import { PaginationInput } from '../inputs/nft.inputs';
+import {
+  CreateListingInput,
+  ListingFilterInput,
+} from '../inputs/listing.inputs';
+import {
+  GraphqlListing,
+  ListingConnection,
+  TransactionResult,
+} from '../types/listing.types';
+import { ListingService } from '../../modules/listing/listing.service';
+import type { Listing } from '../../modules/listing/entities/listing.entity';
+import { ListingStatus } from '../../modules/listing/interfaces/listing.interface';
+
+type CursorPayload = {
+  createdAt: string;
+  id: string;
+};
+
+@Resolver(() => GraphqlListing)
+export class ListingResolver {
+  constructor(private readonly listingService: ListingService) {}
+
+  @Query(() => GraphqlListing, {
+    name: 'listing',
+    description: 'Fetch a single listing by ID',
+  })
+  async listing(
+    @Args('id', { type: () => ID }) id: string,
+  ): Promise<GraphqlListing> {
+    const listing = await this.listingService.findOne(id);
+    return this.toGraphqlListing(listing);
+  }
+
+  @Query(() => ListingConnection, {
+    name: 'listings',
+    description: 'Fetch listings with cursor pagination and optional filters',
+  })
+  async listings(
+    @Args('pagination', { type: () => PaginationInput, nullable: true })
+    pagination?: PaginationInput,
+    @Args('filter', { type: () => ListingFilterInput, nullable: true })
+    filter?: ListingFilterInput,
+  ): Promise<ListingConnection> {
+    const first = pagination?.first ?? 20;
+    const after = pagination?.after
+      ? this.decodeCursor(pagination.after)
+      : undefined;
+
+    const nftParts = filter?.nftId ? this.parseNftId(filter.nftId) : undefined;
+
+    const result = await this.listingService.findConnection({
+      first,
+      after,
+      status: filter?.status as ListingStatus | undefined,
+      sellerId: filter?.sellerId,
+      nftContractId: nftParts?.contractId,
+      nftTokenId: nftParts?.tokenId,
+    });
+
+    return this.toConnection(result.data, result.total, result.hasNextPage);
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => GraphqlListing, {
+    name: 'createListing',
+    description: 'Create a new marketplace listing',
+  })
+  async createListing(
+    @Args('input', { type: () => CreateListingInput })
+    input: CreateListingInput,
+    @Context() context: GraphqlContext,
+  ): Promise<GraphqlListing> {
+    const callerId = this.getAuthenticatedUserId(context);
+    const nft = this.parseNftId(input.nftId);
+
+    const listing = await this.listingService.create(
+      {
+        nftContractId: nft.contractId,
+        nftTokenId: nft.tokenId,
+        price: input.price,
+        currency: input.currency,
+        expiresAt: input.expiresAt,
+      },
+      callerId,
+    );
+
+    return this.toGraphqlListing(listing);
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => Boolean, {
+    name: 'cancelListing',
+    description: 'Cancel an existing listing owned by the caller',
+  })
+  async cancelListing(
+    @Args('id', { type: () => ID }) id: string,
+    @Context() context: GraphqlContext,
+  ): Promise<boolean> {
+    const callerId = this.getAuthenticatedUserId(context);
+    await this.listingService.cancel(id, callerId);
+    return true;
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => TransactionResult, {
+    name: 'buyNFT',
+    description: 'Execute NFT purchase against an active listing',
+  })
+  async buyNFT(
+    @Args('listingId', { type: () => ID }) listingId: string,
+    @Context() context: GraphqlContext,
+  ): Promise<TransactionResult> {
+    const buyerId = this.getAuthenticatedUserId(context);
+    const result = await this.listingService.buy(listingId, buyerId);
+
+    return {
+      success: Boolean(result.success),
+      listingId: result.listingId,
+      buyerId: result.buyer,
+    };
+  }
+
+  private getAuthenticatedUserId(context: GraphqlContext): string {
+    const userId = context.user?.userId;
+    if (!userId) {
+      throw new UnauthorizedException('Authentication is required');
+    }
+
+    return userId;
+  }
+
+  private toConnection(
+    listings: Listing[],
+    totalCount: number,
+    hasNextPage: boolean,
+  ): ListingConnection {
+    const edges = listings.map((listing) => ({
+      node: this.toGraphqlListing(listing),
+      cursor: this.encodeCursor(listing),
+    }));
+
+    return {
+      edges,
+      pageInfo: {
+        hasNextPage,
+        startCursor: edges[0]?.cursor,
+        endCursor: edges.at(-1)?.cursor,
+      },
+      totalCount,
+    };
+  }
+
+  private toGraphqlListing(listing: Listing): GraphqlListing {
+    return {
+      id: listing.id,
+      nftId: this.composeNftId(listing.nftContractId, listing.nftTokenId),
+      sellerId: listing.sellerId,
+      price: this.toDecimalString(listing.price),
+      currency: listing.currency,
+      status: listing.status as ListingStatus,
+      createdAt: listing.createdAt,
+      expiresAt: listing.expiresAt ?? null,
+    };
+  }
+
+  private parseNftId(nftId: string): { contractId: string; tokenId: string } {
+    const [contractId, tokenId] = nftId.split(':');
+
+    if (!contractId || !tokenId) {
+      throw new BadRequestException(
+        'nftId must be in format <contractId>:<tokenId>',
+      );
+    }
+
+    return { contractId, tokenId };
+  }
+
+  private composeNftId(contractId: string, tokenId: string): string {
+    return `${contractId}:${tokenId}`;
+  }
+
+  private toDecimalString(value: string | number | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '0.0000000';
+    }
+
+    const parsed = Number(value);
+    if (Number.isNaN(parsed)) {
+      return '0.0000000';
+    }
+
+    return parsed.toFixed(7);
+  }
+
+  private encodeCursor(listing: Pick<Listing, 'createdAt' | 'id'>): string {
+    return Buffer.from(
+      JSON.stringify({
+        createdAt: listing.createdAt.toISOString(),
+        id: listing.id,
+      } satisfies CursorPayload),
+      'utf8',
+    ).toString('base64url');
+  }
+
+  private decodeCursor(cursor: string): CursorPayload {
+    try {
+      const payload = JSON.parse(
+        Buffer.from(cursor, 'base64url').toString('utf8'),
+      ) as Partial<CursorPayload>;
+
+      if (!payload.createdAt || !payload.id) {
+        throw new Error('Cursor is missing fields');
+      }
+
+      if (Number.isNaN(Date.parse(payload.createdAt))) {
+        throw new Error('Cursor contains invalid createdAt');
+      }
+
+      return {
+        createdAt: payload.createdAt,
+        id: payload.id,
+      };
+    } catch {
+      throw new BadRequestException('Invalid pagination cursor');
+    }
+  }
+}

--- a/nftopia-backend/src/graphql/types/listing.types.ts
+++ b/nftopia-backend/src/graphql/types/listing.types.ts
@@ -1,0 +1,82 @@
+import {
+  Field,
+  GraphQLISODateTime,
+  ID,
+  Int,
+  ObjectType,
+  registerEnumType,
+} from '@nestjs/graphql';
+import { ListingStatus as ListingStatusValue } from '../../modules/listing/interfaces/listing.interface';
+import { PageInfo } from './nft.types';
+
+export enum ListingStatus {
+  ACTIVE = ListingStatusValue.ACTIVE,
+  SOLD = ListingStatusValue.SOLD,
+  CANCELLED = ListingStatusValue.CANCELLED,
+  EXPIRED = ListingStatusValue.EXPIRED,
+}
+
+registerEnumType(ListingStatus, {
+  name: 'ListingStatus',
+  description: 'Current state of a marketplace listing',
+});
+
+@ObjectType('Listing')
+export class GraphqlListing {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID)
+  nftId: string;
+
+  @Field(() => ID)
+  sellerId: string;
+
+  @Field(() => String)
+  price: string;
+
+  @Field(() => String)
+  currency: string;
+
+  @Field(() => ListingStatus)
+  status: ListingStatus;
+
+  @Field(() => GraphQLISODateTime)
+  createdAt: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  expiresAt?: Date | null;
+}
+
+@ObjectType()
+export class ListingEdge {
+  @Field(() => GraphqlListing)
+  node: GraphqlListing;
+
+  @Field()
+  cursor: string;
+}
+
+@ObjectType()
+export class ListingConnection {
+  @Field(() => [ListingEdge])
+  edges: ListingEdge[];
+
+  @Field(() => PageInfo)
+  pageInfo: PageInfo;
+
+  @Field(() => Int)
+  totalCount: number;
+}
+
+@ObjectType()
+export class TransactionResult {
+  @Field(() => Boolean)
+  success: boolean;
+
+  @Field(() => ID)
+  listingId: string;
+
+  @Field(() => ID, { nullable: true })
+  buyerId?: string;
+}

--- a/nftopia-backend/src/modules/bid/bid.gateway.spec.ts
+++ b/nftopia-backend/src/modules/bid/bid.gateway.spec.ts
@@ -9,8 +9,10 @@ type RoomLike = ReturnType<Server['to']>;
 
 const makeMockRoom = () => ({ emit: jest.fn() });
 
-const makeMockServer = (room: ReturnType<typeof makeMockRoom>): jest.Mocked<Server> =>
-  ({ to: jest.fn().mockReturnValue(room) } as unknown as jest.Mocked<Server>);
+const makeMockServer = (
+  room: ReturnType<typeof makeMockRoom>,
+): jest.Mocked<Server> =>
+  ({ to: jest.fn().mockReturnValue(room) }) as unknown as jest.Mocked<Server>;
 
 const makeMockClient = (id = 'client-abc'): jest.Mocked<Socket> =>
   ({
@@ -18,9 +20,11 @@ const makeMockClient = (id = 'client-abc'): jest.Mocked<Socket> =>
     join: jest.fn().mockResolvedValue(undefined),
     leave: jest.fn().mockResolvedValue(undefined),
     emit: jest.fn(),
-  } as unknown as jest.Mocked<Socket>);
+  }) as unknown as jest.Mocked<Socket>;
 
-const makeBidPayload = (override: Partial<BidPlacedEvent> = {}): BidPlacedEvent => ({
+const makeBidPayload = (
+  override: Partial<BidPlacedEvent> = {},
+): BidPlacedEvent => ({
   auctionId: 'auction-123',
   bidderId: 'user-456',
   stellarPublicKey: 'GABC1234567890EXAMPLESTELLARKEY0000000000000000000000000',
@@ -67,7 +71,9 @@ describe('BidGateway', () => {
     it('logs server initialisation', () => {
       const logSpy = jest.spyOn(Logger.prototype, 'log');
       gateway.afterInit();
-      expect(logSpy).toHaveBeenCalledWith('BidGateway WebSocket server initialised');
+      expect(logSpy).toHaveBeenCalledWith(
+        'BidGateway WebSocket server initialised',
+      );
     });
   });
 
@@ -75,12 +81,20 @@ describe('BidGateway', () => {
     it('logs the connected client id', () => {
       const debugSpy = jest.spyOn(Logger.prototype, 'debug');
       gateway.handleConnection(mockClient);
-      expect(debugSpy).toHaveBeenCalledWith(`Client connected: ${mockClient.id}`);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `Client connected: ${mockClient.id}`,
+      );
     });
 
     it('handles clients with different ids without throwing', () => {
-      const clients = [makeMockClient('c-1'), makeMockClient('c-2'), makeMockClient('c-3')];
-      clients.forEach((c) => expect(() => gateway.handleConnection(c)).not.toThrow());
+      const clients = [
+        makeMockClient('c-1'),
+        makeMockClient('c-2'),
+        makeMockClient('c-3'),
+      ];
+      clients.forEach((c) =>
+        expect(() => gateway.handleConnection(c)).not.toThrow(),
+      );
     });
   });
 
@@ -88,12 +102,16 @@ describe('BidGateway', () => {
     it('logs the disconnected client id', () => {
       const debugSpy = jest.spyOn(Logger.prototype, 'debug');
       gateway.handleDisconnect(mockClient);
-      expect(debugSpy).toHaveBeenCalledWith(`Client disconnected: ${mockClient.id}`);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `Client disconnected: ${mockClient.id}`,
+      );
     });
 
     it('handles multiple disconnecting clients without throwing', () => {
       const clients = [makeMockClient('d-1'), makeMockClient('d-2')];
-      clients.forEach((c) => expect(() => gateway.handleDisconnect(c)).not.toThrow());
+      clients.forEach((c) =>
+        expect(() => gateway.handleDisconnect(c)).not.toThrow(),
+      );
     });
   });
 
@@ -106,8 +124,14 @@ describe('BidGateway', () => {
     });
 
     it('returns joined event with the auctionId', () => {
-      const result = gateway.handleJoinAuction({ auctionId: 'auction-123' }, mockClient);
-      expect(result).toEqual({ event: 'joined', data: { auctionId: 'auction-123' } });
+      const result = gateway.handleJoinAuction(
+        { auctionId: 'auction-123' },
+        mockClient,
+      );
+      expect(result).toEqual({
+        event: 'joined',
+        data: { auctionId: 'auction-123' },
+      });
     });
 
     it('logs the join with client id and room', () => {
@@ -149,8 +173,14 @@ describe('BidGateway', () => {
     });
 
     it('returns left event with the auctionId', () => {
-      const result = gateway.handleLeaveAuction({ auctionId: 'auction-123' }, mockClient);
-      expect(result).toEqual({ event: 'left', data: { auctionId: 'auction-123' } });
+      const result = gateway.handleLeaveAuction(
+        { auctionId: 'auction-123' },
+        mockClient,
+      );
+      expect(result).toEqual({
+        event: 'left',
+        data: { auctionId: 'auction-123' },
+      });
     });
 
     it('logs the leave with client id and room', () => {
@@ -163,7 +193,10 @@ describe('BidGateway', () => {
 
     it('works with UUID-formatted auction ids', () => {
       const uuid = '550e8400-e29b-41d4-a716-446655440000';
-      const result = gateway.handleLeaveAuction({ auctionId: uuid }, mockClient);
+      const result = gateway.handleLeaveAuction(
+        { auctionId: uuid },
+        mockClient,
+      );
       expect(mockClient.leave).toHaveBeenCalledWith(`auction:${uuid}`);
       expect(result).toEqual({ event: 'left', data: { auctionId: uuid } });
     });
@@ -194,7 +227,10 @@ describe('BidGateway', () => {
       const payload = makeBidPayload({ auctionId: 'auction-abc' });
       gateway.handleBidPlacedEvent(payload);
       expect(mockServer.to).toHaveBeenCalledWith('auction:auction-abc');
-      expect(mockRoom.emit).toHaveBeenCalledWith('bid-placed', expect.any(Object));
+      expect(mockRoom.emit).toHaveBeenCalledWith(
+        'bid-placed',
+        expect.any(Object),
+      );
     });
 
     it('broadcasts all required bid fields', () => {
@@ -215,7 +251,10 @@ describe('BidGateway', () => {
     it('does not expose stellarPublicKey in the broadcast payload', () => {
       const payload = makeBidPayload();
       gateway.handleBidPlacedEvent(payload);
-      const callArgs = mockRoom.emit.mock.calls[0] as unknown as [string, Record<string, unknown>];
+      const callArgs = mockRoom.emit.mock.calls[0] as unknown as [
+        string,
+        Record<string, unknown>,
+      ];
       const broadcasted = callArgs[1];
       expect(broadcasted).not.toHaveProperty('stellarPublicKey');
     });
@@ -245,7 +284,9 @@ describe('BidGateway', () => {
     });
 
     it('handles PENDING soroban status', () => {
-      const payload = makeBidPayload({ sorobanStatus: BidSorobanStatus.PENDING });
+      const payload = makeBidPayload({
+        sorobanStatus: BidSorobanStatus.PENDING,
+      });
       gateway.handleBidPlacedEvent(payload);
       expect(mockRoom.emit).toHaveBeenCalledWith(
         'bid-placed',
@@ -254,7 +295,9 @@ describe('BidGateway', () => {
     });
 
     it('handles FAILED soroban status', () => {
-      const payload = makeBidPayload({ sorobanStatus: BidSorobanStatus.FAILED });
+      const payload = makeBidPayload({
+        sorobanStatus: BidSorobanStatus.FAILED,
+      });
       gateway.handleBidPlacedEvent(payload);
       expect(mockRoom.emit).toHaveBeenCalledWith(
         'bid-placed',
@@ -263,7 +306,9 @@ describe('BidGateway', () => {
     });
 
     it('handles SKIPPED soroban status', () => {
-      const payload = makeBidPayload({ sorobanStatus: BidSorobanStatus.SKIPPED });
+      const payload = makeBidPayload({
+        sorobanStatus: BidSorobanStatus.SKIPPED,
+      });
       gateway.handleBidPlacedEvent(payload);
       expect(mockRoom.emit).toHaveBeenCalledWith(
         'bid-placed',
@@ -272,11 +317,17 @@ describe('BidGateway', () => {
     });
 
     it('handles payload without optional txHash and ledgerSequence', () => {
-      const payload = makeBidPayload({ txHash: undefined, ledgerSequence: undefined });
+      const payload = makeBidPayload({
+        txHash: undefined,
+        ledgerSequence: undefined,
+      });
       expect(() => gateway.handleBidPlacedEvent(payload)).not.toThrow();
       expect(mockRoom.emit).toHaveBeenCalledWith(
         'bid-placed',
-        expect.objectContaining({ txHash: undefined, ledgerSequence: undefined }),
+        expect.objectContaining({
+          txHash: undefined,
+          ledgerSequence: undefined,
+        }),
       );
     });
 

--- a/nftopia-backend/src/modules/bid/bid.service.spec.ts
+++ b/nftopia-backend/src/modules/bid/bid.service.spec.ts
@@ -14,7 +14,8 @@ import { Keypair } from 'stellar-sdk';
 // Prevent real Horizon HTTP calls — verifyBalance falls back to testnet URL even
 // when STELLAR_HORIZON_URL is undefined, so we stub the server at module level.
 jest.mock('stellar-sdk', () => {
-  const actual = jest.requireActual<typeof import('stellar-sdk')>('stellar-sdk');
+  const actual =
+    jest.requireActual<typeof import('stellar-sdk')>('stellar-sdk');
   return {
     ...actual,
     Horizon: {

--- a/nftopia-backend/src/modules/listing/listing.module.ts
+++ b/nftopia-backend/src/modules/listing/listing.module.ts
@@ -10,5 +10,6 @@ import { NftMetadata } from '../../nft/entities/nft-metadata.entity';
   imports: [TypeOrmModule.forFeature([Listing, StellarNft, NftMetadata])],
   providers: [ListingService],
   controllers: [ListingController],
+  exports: [ListingService],
 })
 export class ListingModule {}

--- a/nftopia-backend/src/modules/listing/listing.service.ts
+++ b/nftopia-backend/src/modules/listing/listing.service.ts
@@ -13,6 +13,11 @@ import { ListingStatus } from './interfaces/listing.interface';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { StellarNft } from '../../nft/entities/stellar-nft.entity';
 
+type ListingCursorPayload = {
+  createdAt: string;
+  id: string;
+};
+
 @Injectable()
 export class ListingService {
   private readonly logger = new Logger(ListingService.name);
@@ -90,6 +95,84 @@ export class ListingService {
     qb.skip((page - 1) * limit).take(limit);
 
     return qb.getMany();
+  }
+
+  async findConnection(query: {
+    first: number;
+    after?: ListingCursorPayload;
+    status?: ListingStatus;
+    sellerId?: string;
+    nftContractId?: string;
+    nftTokenId?: string;
+  }): Promise<{
+    data: Listing[];
+    total: number;
+    hasNextPage: boolean;
+  }> {
+    const qb = this.listingRepo
+      .createQueryBuilder('l')
+      .orderBy('l.createdAt', 'DESC')
+      .addOrderBy('l.id', 'DESC');
+
+    this.applyFilters(qb, query);
+
+    if (query.after) {
+      qb.andWhere(
+        '(l.createdAt < :afterCreatedAt OR (l.createdAt = :afterCreatedAt AND l.id < :afterId))',
+        {
+          afterCreatedAt: query.after.createdAt,
+          afterId: query.after.id,
+        },
+      );
+    }
+
+    const totalQb = this.listingRepo.createQueryBuilder('l');
+    this.applyFilters(totalQb, query);
+
+    const [rows, total] = await Promise.all([
+      qb.take(query.first + 1).getMany(),
+      totalQb.getCount(),
+    ]);
+
+    return {
+      data: rows.slice(0, query.first),
+      total,
+      hasNextPage: rows.length > query.first,
+    };
+  }
+
+  private applyFilters(
+    qb: ReturnType<Repository<Listing>['createQueryBuilder']>,
+    query: {
+      status?: ListingStatus;
+      sellerId?: string;
+      nftContractId?: string;
+      nftTokenId?: string;
+    },
+  ) {
+    if (query.status) {
+      qb.andWhere('l.status = :status', { status: query.status });
+    }
+    if (query.sellerId) {
+      qb.andWhere('l.sellerId = :sellerId', { sellerId: query.sellerId });
+    }
+    if (query.nftContractId) {
+      qb.andWhere('l.nftContractId = :nftContractId', {
+        nftContractId: query.nftContractId,
+      });
+    }
+    if (query.nftTokenId) {
+      qb.andWhere('l.nftTokenId = :nftTokenId', {
+        nftTokenId: query.nftTokenId,
+      });
+    }
+
+    const status = query.status;
+    if (status === ListingStatus.ACTIVE || status == null) {
+      qb.andWhere('(l.expiresAt IS NULL OR l.expiresAt > :now)', {
+        now: new Date(),
+      });
+    }
   }
 
   async findOne(id: string) {


### PR DESCRIPTION
## Implement GraphQL resolvers for Listing entity (marketplace listings)

This PR adds complete GraphQL support for marketplace listings, enabling queries and mutations through the GraphQL gateway alongside existing REST endpoints.

**Changes include:**
- GraphQL types: `ListingStatus`, `Listing`, `ListingConnection`, `TransactionResult`
- Input types for filtering and listing creation
- Queries: `listing(id)` and paginated `listings(filter, pagination)`
- Mutations: `createListing`, `cancelListing`, `buyNFT` (all authenticated)
- Cursor-based pagination support in Listing service
- Unit tests for all resolver queries and mutations

**Breaking changes:** None. Existing REST endpoints remain fully functional.

Closes #106