### PR TITLE
test(collection): add comprehensive unit tests for service and controller (#162)

### DIFF
--- a/nftopia-backend/src/modules/collection/collection.controller.spec.ts
+++ b/nftopia-backend/src/modules/collection/collection.controller.spec.ts
@@ -1,10 +1,18 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { Test, TestingModule } from '@nestjs/testing';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { CollectionController } from './collection.controller';
 import { CollectionService } from './collection.service';
+import { CollectionQueryDto } from './dto/collection-query.dto';
+import { CreateCollectionDto } from './dto/create-collection.dto';
+import { UpdateCollectionDto } from './dto/update-collection.dto';
 
 describe('CollectionController', () => {
   let controller: CollectionController;
-  let service: CollectionService;
+  let service: jest.Mocked<CollectionService>;
 
   const mockCollectionService = {
     create: jest.fn(),
@@ -19,17 +27,19 @@ describe('CollectionController', () => {
 
   const mockCollection = {
     id: '123e4567-e89b-12d3-a456-426614174000',
-    contractAddress: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFGHIJKLMNOPQR',
+    contractAddress: 'C'.repeat(56),
     name: 'Test Collection',
     symbol: 'TEST',
     description: 'Test description',
+    imageUrl: 'https://example.com/image.png',
+    bannerImageUrl: null,
     creatorId: 'user-123',
     totalSupply: 100,
-    floorPrice: '10.5',
-    totalVolume: '1000.0',
+    floorPrice: '10.5000000',
+    totalVolume: '1000.0000000',
     isVerified: false,
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: new Date('2026-04-20T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-20T00:00:00.000Z'),
   };
 
   beforeEach(async () => {
@@ -44,7 +54,7 @@ describe('CollectionController', () => {
     }).compile();
 
     controller = module.get<CollectionController>(CollectionController);
-    service = module.get<CollectionService>(CollectionService);
+    service = module.get(CollectionService);
   });
 
   afterEach(() => {
@@ -56,25 +66,24 @@ describe('CollectionController', () => {
   });
 
   describe('findAll', () => {
-    it('should return paginated collections', async () => {
+    it('returns a paginated collection connection', async () => {
       const mockResult = {
         data: [mockCollection],
         total: 1,
-        page: 1,
-        limit: 20,
-      } as const;
-
+        hasNextPage: false,
+      };
       mockCollectionService.findAll.mockResolvedValue(mockResult);
 
-      const result = await controller.findAll({ page: 1, limit: 20 });
+      const query = { page: 1, limit: 20 } as CollectionQueryDto;
+      const result = await controller.findAll(query);
 
       expect(result).toEqual(mockResult);
-      expect(service.findAll).toHaveBeenCalledWith({ page: 1, limit: 20 });
+      expect(service.findAll).toHaveBeenCalledWith(query);
     });
   });
 
   describe('findOne', () => {
-    it('should return a collection by id', async () => {
+    it('returns a collection by id', async () => {
       mockCollectionService.findOne.mockResolvedValue(mockCollection);
 
       const result = await controller.findOne(mockCollection.id);
@@ -82,10 +91,20 @@ describe('CollectionController', () => {
       expect(result).toEqual(mockCollection);
       expect(service.findOne).toHaveBeenCalledWith(mockCollection.id);
     });
+
+    it('propagates NotFoundException (404) when the service throws', async () => {
+      mockCollectionService.findOne.mockRejectedValue(
+        new NotFoundException('Collection not found'),
+      );
+
+      await expect(controller.findOne(mockCollection.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 
   describe('findByContractAddress', () => {
-    it('should return a collection by contract address', async () => {
+    it('returns a collection by contract address', async () => {
       mockCollectionService.findByContractAddress.mockResolvedValue(
         mockCollection,
       );
@@ -99,18 +118,26 @@ describe('CollectionController', () => {
         mockCollection.contractAddress,
       );
     });
+
+    it('propagates NotFoundException (404) when address is unknown', async () => {
+      mockCollectionService.findByContractAddress.mockRejectedValue(
+        new NotFoundException(),
+      );
+
+      await expect(
+        controller.findByContractAddress('C'.repeat(56)),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('getStats', () => {
-    it('should return collection statistics', async () => {
+    it('returns collection statistics', async () => {
       const mockStats = {
+        totalVolume: '1000.0000000',
+        floorPrice: '10.5000000',
         totalSupply: 100,
-        floorPrice: '10.5',
-        totalVolume: '1000.0',
-        owners: 50,
-        listedCount: 20,
+        ownerCount: 50,
       };
-
       mockCollectionService.getStats.mockResolvedValue(mockStats);
 
       const result = await controller.getStats(mockCollection.id);
@@ -118,61 +145,101 @@ describe('CollectionController', () => {
       expect(result).toEqual(mockStats);
       expect(service.getStats).toHaveBeenCalledWith(mockCollection.id);
     });
+
+    it('propagates NotFoundException when stats are requested for a missing collection', async () => {
+      mockCollectionService.getStats.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.getStats(mockCollection.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 
   describe('getTopCollections', () => {
-    it('should return top collections', async () => {
-      const mockCollections = [mockCollection];
-      mockCollectionService.getTopCollections.mockResolvedValue(
-        mockCollections,
-      );
+    it('parses the limit query param and delegates to the service', async () => {
+      mockCollectionService.getTopCollections.mockResolvedValue([
+        mockCollection,
+      ]);
 
-      const result = await controller.getTopCollections('10');
+      const result = await controller.getTopCollections('5');
 
-      expect(result).toEqual(mockCollections);
+      expect(result).toEqual([mockCollection]);
+      expect(service.getTopCollections).toHaveBeenCalledWith(5);
+    });
+
+    it('defaults the limit to 10 when none is provided', async () => {
+      mockCollectionService.getTopCollections.mockResolvedValue([]);
+
+      await controller.getTopCollections();
+
       expect(service.getTopCollections).toHaveBeenCalledWith(10);
     });
   });
 
   describe('getNftsInCollection', () => {
-    it('should return NFTs in collection', async () => {
+    it('parses page and limit and returns NFTs for a collection', async () => {
       const mockResult = {
         data: [],
         total: 0,
-        page: 1,
-        limit: 20,
+        page: 2,
+        limit: 5,
       };
-
       mockCollectionService.getNftsInCollection.mockResolvedValue(mockResult);
 
       const result = await controller.getNftsInCollection(
         mockCollection.id,
-        '1',
-        '20',
+        '2',
+        '5',
       );
 
       expect(result).toEqual(mockResult);
+      expect(service.getNftsInCollection).toHaveBeenCalledWith(
+        mockCollection.id,
+        2,
+        5,
+      );
+    });
+
+    it('defaults page=1 and limit=20 when not provided', async () => {
+      mockCollectionService.getNftsInCollection.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+      });
+
+      await controller.getNftsInCollection(mockCollection.id);
+
       expect(service.getNftsInCollection).toHaveBeenCalledWith(
         mockCollection.id,
         1,
         20,
       );
     });
+
+    it('propagates NotFoundException when the collection is missing', async () => {
+      mockCollectionService.getNftsInCollection.mockRejectedValue(
+        new NotFoundException(),
+      );
+
+      await expect(
+        controller.getNftsInCollection(mockCollection.id),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('create', () => {
-    it('should create a new collection', async () => {
-      const createDto = {
-        contractAddress:
-          'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFGHIJKLMNOPQR',
-        name: 'Test Collection',
-        symbol: 'TEST',
-        description: 'Test description',
-        imageUrl: 'https://example.com/image.png',
-      };
+    const createDto: CreateCollectionDto = {
+      contractAddress: 'C'.repeat(56),
+      name: 'Test Collection',
+      symbol: 'TEST',
+      description: 'Test description',
+      imageUrl: 'https://example.com/image.png',
+    };
 
-      const mockRequest = { user: { userId: 'user-123' } };
+    const mockRequest = { user: { userId: 'user-123' } };
 
+    it('creates a new collection using the authenticated user id', async () => {
       mockCollectionService.create.mockResolvedValue(mockCollection);
 
       const result = await controller.create(createDto, mockRequest);
@@ -180,14 +247,34 @@ describe('CollectionController', () => {
       expect(result).toEqual(mockCollection);
       expect(service.create).toHaveBeenCalledWith(createDto, 'user-123');
     });
+
+    it('propagates BadRequestException (400) when creation fails validation in the service', async () => {
+      mockCollectionService.create.mockRejectedValue(
+        new BadRequestException('Collection contract address already exists'),
+      );
+
+      await expect(controller.create(createDto, mockRequest)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('guards the create endpoint with JwtAuthGuard (unauthenticated requests yield 401)', () => {
+      const guards = Reflect.getMetadata(
+        GUARDS_METADATA,
+        CollectionController.prototype.create,
+      ) as unknown[];
+
+      expect(guards).toBeDefined();
+      expect(guards).toContain(JwtAuthGuard);
+    });
   });
 
   describe('update', () => {
-    it('should update a collection', async () => {
-      const updateDto = { name: 'Updated Name' };
-      const mockRequest = { user: { userId: 'user-123' } };
-      const updatedCollection = { ...mockCollection, ...updateDto };
+    const updateDto: UpdateCollectionDto = { name: 'Updated Name' };
+    const mockRequest = { user: { userId: 'user-123' } };
 
+    it('updates a collection', async () => {
+      const updatedCollection = { ...mockCollection, ...updateDto };
       mockCollectionService.update.mockResolvedValue(updatedCollection);
 
       const result = await controller.update(
@@ -202,6 +289,131 @@ describe('CollectionController', () => {
         updateDto,
         'user-123',
       );
+    });
+
+    it('propagates BadRequestException (403-ish) when caller is not the creator', async () => {
+      mockCollectionService.update.mockRejectedValue(
+        new BadRequestException('Only the creator can update this collection'),
+      );
+
+      await expect(
+        controller.update(mockCollection.id, updateDto, mockRequest),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('propagates NotFoundException when collection does not exist', async () => {
+      mockCollectionService.update.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.update(mockCollection.id, updateDto, mockRequest),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('guards the update endpoint with JwtAuthGuard (unauthenticated requests yield 401)', () => {
+      const guards = Reflect.getMetadata(
+        GUARDS_METADATA,
+        CollectionController.prototype.update,
+      ) as unknown[];
+
+      expect(guards).toBeDefined();
+      expect(guards).toContain(JwtAuthGuard);
+    });
+  });
+
+  describe('DTO validation', () => {
+    it('accepts a fully-valid CreateCollectionDto', async () => {
+      const dto = plainToInstance(CreateCollectionDto, {
+        contractAddress: 'C'.repeat(56),
+        name: 'Genesis',
+        symbol: 'GEN',
+        description: 'desc',
+        imageUrl: 'https://example.com/image.png',
+      });
+
+      await expect(validate(dto)).resolves.toEqual([]);
+    });
+
+    it('rejects a CreateCollectionDto with a malformed contract address', async () => {
+      const dto = plainToInstance(CreateCollectionDto, {
+        contractAddress: 'not-a-valid-stellar-address',
+        name: 'Genesis',
+        symbol: 'GEN',
+        imageUrl: 'https://example.com/image.png',
+      });
+
+      const errors = await validate(dto);
+      const contractErr = errors.find((e) => e.property === 'contractAddress');
+      expect(contractErr).toBeDefined();
+      expect(Object.keys(contractErr!.constraints ?? {})).toEqual(
+        expect.arrayContaining(['isLength', 'matches']),
+      );
+    });
+
+    it('rejects a CreateCollectionDto missing required fields', async () => {
+      const dto = plainToInstance(CreateCollectionDto, {});
+
+      const errors = await validate(dto);
+      const properties = errors.map((e) => e.property);
+
+      expect(properties).toEqual(
+        expect.arrayContaining([
+          'contractAddress',
+          'name',
+          'symbol',
+          'imageUrl',
+        ]),
+      );
+    });
+
+    it('rejects a CreateCollectionDto with a non-URL imageUrl', async () => {
+      const dto = plainToInstance(CreateCollectionDto, {
+        contractAddress: 'C'.repeat(56),
+        name: 'Genesis',
+        symbol: 'GEN',
+        imageUrl: 'not a url',
+      });
+
+      const errors = await validate(dto);
+      const urlErr = errors.find((e) => e.property === 'imageUrl');
+      expect(urlErr?.constraints).toHaveProperty('isUrl');
+    });
+
+    it('accepts an empty UpdateCollectionDto (all fields optional)', async () => {
+      const dto = plainToInstance(UpdateCollectionDto, {});
+      await expect(validate(dto)).resolves.toEqual([]);
+    });
+
+    it('rejects UpdateCollectionDto with a name longer than 255 chars', async () => {
+      const dto = plainToInstance(UpdateCollectionDto, {
+        name: 'x'.repeat(256),
+      });
+      const errors = await validate(dto);
+      const nameErr = errors.find((e) => e.property === 'name');
+      expect(nameErr?.constraints).toHaveProperty('isLength');
+    });
+
+    it('coerces query params into numbers on CollectionQueryDto', async () => {
+      const dto = plainToInstance(CollectionQueryDto, {
+        page: '2',
+        limit: '50',
+      });
+      await expect(validate(dto)).resolves.toEqual([]);
+      expect(dto.page).toBe(2);
+      expect(dto.limit).toBe(50);
+    });
+
+    it('rejects CollectionQueryDto with limit above the max', async () => {
+      const dto = plainToInstance(CollectionQueryDto, { limit: 500 });
+      const errors = await validate(dto);
+      const limitErr = errors.find((e) => e.property === 'limit');
+      expect(limitErr?.constraints).toHaveProperty('max');
+    });
+
+    it('rejects CollectionQueryDto with an invalid sortBy', async () => {
+      const dto = plainToInstance(CollectionQueryDto, { sortBy: 'bogus' });
+      const errors = await validate(dto);
+      const sortErr = errors.find((e) => e.property === 'sortBy');
+      expect(sortErr?.constraints).toHaveProperty('isEnum');
     });
   });
 });

--- a/nftopia-backend/src/modules/collection/collection.service.spec.ts
+++ b/nftopia-backend/src/modules/collection/collection.service.spec.ts
@@ -53,6 +53,7 @@ describe('CollectionService', () => {
 
   const mockNftRepository = {
     createQueryBuilder: jest.fn(() => queryBuilder),
+    findAndCount: jest.fn(),
   };
 
   const mockUserRepository = {
@@ -83,136 +84,429 @@ describe('CollectionService', () => {
     service = module.get(CollectionService);
   });
 
-  it('finds a collection by id', async () => {
-    const collection = makeCollection();
-    mockCollectionRepository.findOne.mockResolvedValue(collection);
+  it('is defined', () => {
+    expect(service).toBeDefined();
+  });
 
-    await expect(service.findById('collection-1')).resolves.toEqual(collection);
-    expect(mockCollectionRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 'collection-1' },
+  describe('findById / findOne', () => {
+    it('finds a collection by id', async () => {
+      const collection = makeCollection();
+      mockCollectionRepository.findOne.mockResolvedValue(collection);
+
+      await expect(service.findById('collection-1')).resolves.toEqual(
+        collection,
+      );
+      expect(mockCollectionRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'collection-1' },
+      });
+    });
+
+    it('throws NotFoundException when a collection is missing', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findById('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('findOne delegates to findById and returns the collection', async () => {
+      const collection = makeCollection();
+      mockCollectionRepository.findOne.mockResolvedValue(collection);
+
+      await expect(service.findOne('collection-1')).resolves.toEqual(
+        collection,
+      );
+    });
+
+    it('findOne propagates NotFoundException from findById', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('missing')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
-  it('throws when a collection is missing', async () => {
-    mockCollectionRepository.findOne.mockResolvedValue(null);
+  describe('findByContractAddress', () => {
+    it('returns the collection matching the contract address', async () => {
+      const collection = makeCollection();
+      mockCollectionRepository.findOne.mockResolvedValue(collection);
 
-    await expect(service.findById('missing')).rejects.toThrow(
-      NotFoundException,
-    );
-  });
-
-  it('builds a paginated collection connection result', async () => {
-    const rows = [makeCollection(), makeCollection({ id: 'collection-2' })];
-    queryBuilder.getCount.mockResolvedValue(12);
-    queryBuilder.getMany.mockResolvedValue(rows);
-
-    const result = await service.findConnection({
-      first: 1,
-      search: 'genesis',
-      verifiedOnly: true,
+      await expect(
+        service.findByContractAddress('C'.repeat(56)),
+      ).resolves.toEqual(collection);
+      expect(mockCollectionRepository.findOne).toHaveBeenCalledWith({
+        where: { contractAddress: 'C'.repeat(56) },
+      });
     });
 
-    expect(result.total).toBe(12);
-    expect(result.data).toHaveLength(1);
-    expect(result.hasNextPage).toBe(true);
-    expect(mockCollectionRepository.createQueryBuilder).toHaveBeenCalledWith(
-      'collection',
-    );
-  });
+    it('throws NotFoundException when no collection has that address', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(null);
 
-  it('returns top collections ordered by volume', async () => {
-    const rows = [makeCollection()];
-    mockCollectionRepository.find.mockResolvedValue(rows);
-
-    await expect(service.findTopCollections(5)).resolves.toEqual(rows);
-    expect(mockCollectionRepository.find).toHaveBeenCalledWith({
-      order: {
-        totalVolume: 'DESC',
-        createdAt: 'DESC',
-      },
-      take: 5,
+      await expect(
+        service.findByContractAddress('C'.repeat(56)),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
-  it('computes collection stats from nft aggregates', async () => {
-    mockCollectionRepository.findOne.mockResolvedValue(makeCollection());
-    queryBuilder.getRawOne.mockResolvedValue({
-      nftCount: '9',
-      ownerCount: '4',
-      floorPrice: '1.7500000',
+  describe('findAll / findConnection', () => {
+    it('findAll delegates to findConnection', async () => {
+      queryBuilder.getCount.mockResolvedValue(0);
+      queryBuilder.getMany.mockResolvedValue([]);
+
+      const result = await service.findAll({ first: 5 });
+
+      expect(result).toEqual({ data: [], total: 0, hasNextPage: false });
     });
 
-    const result = await service.getStats('collection-1');
+    it('builds a paginated collection connection result with hasNextPage=true', async () => {
+      const rows = [makeCollection(), makeCollection({ id: 'collection-2' })];
+      queryBuilder.getCount.mockResolvedValue(12);
+      queryBuilder.getMany.mockResolvedValue(rows);
 
-    expect(result).toEqual({
-      totalVolume: '25.5000000',
-      floorPrice: '1.7500000',
-      totalSupply: 9,
-      ownerCount: 4,
+      const result = await service.findConnection({
+        first: 1,
+        search: 'genesis',
+        verifiedOnly: true,
+      });
+
+      expect(result.total).toBe(12);
+      expect(result.data).toHaveLength(1);
+      expect(result.hasNextPage).toBe(true);
+      expect(mockCollectionRepository.createQueryBuilder).toHaveBeenCalledWith(
+        'collection',
+      );
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'collection.isVerified = true',
+      );
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(collection.name)'),
+        { search: '%genesis%' },
+      );
     });
-  });
 
-  it('creates a collection for a valid creator', async () => {
-    const collection = makeCollection({
-      totalSupply: 0,
-      totalVolume: '0.0000000',
+    it('uses the default first=20 page size when not provided', async () => {
+      queryBuilder.getCount.mockResolvedValue(0);
+      queryBuilder.getMany.mockResolvedValue([]);
+
+      const result = await service.findConnection({});
+
+      expect(result.hasNextPage).toBe(false);
+      expect(queryBuilder.take).toHaveBeenCalledWith(21);
     });
-    mockUserRepository.exists.mockResolvedValue(true);
-    mockCollectionRepository.findOne.mockResolvedValue(null);
-    mockCollectionRepository.create.mockReturnValue(collection);
-    mockCollectionRepository.save.mockResolvedValue(collection);
 
-    const result = await service.create(
-      {
-        contractAddress: 'C'.repeat(56),
-        name: 'NFTopia Genesis',
-        symbol: 'NFTG',
-        description: 'Genesis drop',
-        imageUrl: 'https://example.com/collection.png',
-      },
-      'creator-1',
-    );
+    it('filters by creatorId and applies cursor after clause', async () => {
+      queryBuilder.getCount.mockResolvedValue(3);
+      queryBuilder.getMany.mockResolvedValue([makeCollection()]);
 
-    expect(result).toEqual(collection);
-    expect(mockCollectionRepository.create).toHaveBeenCalledWith(
-      expect.objectContaining({
+      await service.findConnection({
+        first: 2,
         creatorId: 'creator-1',
+        after: {
+          createdAt: '2026-03-24T00:00:00.000Z',
+          id: 'collection-0',
+        },
+      });
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'collection.creatorId = :creatorId',
+        { creatorId: 'creator-1' },
+      );
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('collection.createdAt < :cursorCreatedAt'),
+        expect.objectContaining({
+          cursorCreatedAt: new Date('2026-03-24T00:00:00.000Z'),
+          cursorId: 'collection-0',
+        }),
+      );
+      expect(queryBuilder.orderBy).toHaveBeenCalledWith(
+        'collection.createdAt',
+        'DESC',
+      );
+      expect(queryBuilder.addOrderBy).toHaveBeenCalledWith(
+        'collection.id',
+        'DESC',
+      );
+    });
+  });
+
+  describe('getTopCollections / findTopCollections', () => {
+    it('returns top collections ordered by volume', async () => {
+      const rows = [makeCollection()];
+      mockCollectionRepository.find.mockResolvedValue(rows);
+
+      await expect(service.findTopCollections(5)).resolves.toEqual(rows);
+      expect(mockCollectionRepository.find).toHaveBeenCalledWith({
+        order: {
+          totalVolume: 'DESC',
+          createdAt: 'DESC',
+        },
+        take: 5,
+      });
+    });
+
+    it('defaults the limit to 10', async () => {
+      mockCollectionRepository.find.mockResolvedValue([]);
+
+      await service.findTopCollections();
+
+      expect(mockCollectionRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 10 }),
+      );
+    });
+
+    it('getTopCollections delegates to findTopCollections with a custom limit', async () => {
+      mockCollectionRepository.find.mockResolvedValue([]);
+
+      await service.getTopCollections(3);
+
+      expect(mockCollectionRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 3 }),
+      );
+    });
+  });
+
+  describe('getNftsInCollection', () => {
+    it('returns paginated NFTs for an existing collection', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(makeCollection());
+      mockNftRepository.findAndCount.mockResolvedValue([
+        [{ id: 'nft-1' } as Nft, { id: 'nft-2' } as Nft],
+        2,
+      ]);
+
+      const result = await service.getNftsInCollection('collection-1', 2, 10);
+
+      expect(result).toEqual({
+        data: [{ id: 'nft-1' }, { id: 'nft-2' }],
+        total: 2,
+        page: 2,
+        limit: 10,
+      });
+      expect(mockNftRepository.findAndCount).toHaveBeenCalledWith({
+        where: { collectionId: 'collection-1', isBurned: false },
+        skip: 10,
+        take: 10,
+        order: { createdAt: 'DESC' },
+      });
+    });
+
+    it('uses default page=1 and limit=20 when omitted', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(makeCollection());
+      mockNftRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.getNftsInCollection('collection-1');
+
+      expect(result).toEqual({ data: [], total: 0, page: 1, limit: 20 });
+      expect(mockNftRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 20 }),
+      );
+    });
+
+    it('throws NotFoundException when the collection is missing', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getNftsInCollection('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockNftRepository.findAndCount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    it('updates a collection when the caller is the creator', async () => {
+      const collection = makeCollection();
+      const updated = { ...collection, name: 'Renamed' };
+      mockCollectionRepository.findOne.mockResolvedValue(collection);
+      mockCollectionRepository.save.mockResolvedValue(updated);
+
+      const result = await service.update(
+        'collection-1',
+        { name: 'Renamed' },
+        'creator-1',
+      );
+
+      expect(result).toEqual(updated);
+      expect(mockCollectionRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'collection-1', name: 'Renamed' }),
+      );
+    });
+
+    it('rejects update when the caller is not the creator', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(makeCollection());
+
+      await expect(
+        service.update('collection-1', { name: 'Hijack' }, 'someone-else'),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockCollectionRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('propagates NotFoundException when collection does not exist', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.update('missing', { name: 'Hijack' }, 'creator-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getStats', () => {
+    it('computes collection stats from nft aggregates', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(makeCollection());
+      queryBuilder.getRawOne.mockResolvedValue({
+        nftCount: '9',
+        ownerCount: '4',
+        floorPrice: '1.7500000',
+      });
+
+      const result = await service.getStats('collection-1');
+
+      expect(result).toEqual({
+        totalVolume: '25.5000000',
+        floorPrice: '1.7500000',
+        totalSupply: 9,
+        ownerCount: 4,
+      });
+    });
+
+    it('falls back to entity values when aggregates are empty', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(
+        makeCollection({ totalSupply: 7, floorPrice: null, totalVolume: '0' }),
+      );
+      queryBuilder.getRawOne.mockResolvedValue(null);
+
+      const result = await service.getStats('collection-1');
+
+      expect(result).toEqual({
+        totalVolume: '0.0000000',
+        floorPrice: '0.0000000',
+        totalSupply: 7,
+        ownerCount: 0,
+      });
+    });
+
+    it('normalizes non-numeric floor price to 0.0000000', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(
+        makeCollection({ totalVolume: 'not-a-number' }),
+      );
+      queryBuilder.getRawOne.mockResolvedValue({
+        nftCount: '3',
+        ownerCount: '2',
+        floorPrice: 'not-a-number',
+      });
+
+      const result = await service.getStats('collection-1');
+
+      expect(result).toEqual({
+        totalVolume: '0.0000000',
+        floorPrice: '0.0000000',
+        totalSupply: 3,
+        ownerCount: 2,
+      });
+    });
+
+    it('throws NotFoundException when collection is missing', async () => {
+      mockCollectionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getStats('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('creates a collection for a valid creator', async () => {
+      const collection = makeCollection({
         totalSupply: 0,
         totalVolume: '0.0000000',
-      }),
-    );
-  });
+      });
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockCollectionRepository.findOne.mockResolvedValue(null);
+      mockCollectionRepository.create.mockReturnValue(collection);
+      mockCollectionRepository.save.mockResolvedValue(collection);
 
-  it('rejects create when creator does not exist', async () => {
-    mockUserRepository.exists.mockResolvedValue(false);
+      const result = await service.create(
+        {
+          contractAddress: 'C'.repeat(56),
+          name: 'NFTopia Genesis',
+          symbol: 'NFTG',
+          description: 'Genesis drop',
+          imageUrl: 'https://example.com/collection.png',
+        },
+        'creator-1',
+      );
 
-    await expect(
-      service.create(
+      expect(result).toEqual(collection);
+      expect(mockCollectionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          creatorId: 'creator-1',
+          totalSupply: 0,
+          totalVolume: '0.0000000',
+        }),
+      );
+    });
+
+    it('prefers dto.creatorId over the authenticated creator when provided', async () => {
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockCollectionRepository.findOne.mockResolvedValue(null);
+      mockCollectionRepository.create.mockImplementation(
+        (obj: Partial<Collection>) => obj as Collection,
+      );
+      mockCollectionRepository.save.mockImplementation(
+        (obj: Partial<Collection>) => Promise.resolve(obj as Collection),
+      );
+
+      await service.create(
         {
           contractAddress: 'C'.repeat(56),
           name: 'NFTopia Genesis',
           symbol: 'NFTG',
           imageUrl: 'https://example.com/collection.png',
+          creatorId: 'override-creator',
         },
         'creator-1',
-      ),
-    ).rejects.toThrow(BadRequestException);
-  });
+      );
 
-  it('rejects create when contract address already exists', async () => {
-    mockUserRepository.exists.mockResolvedValue(true);
-    mockCollectionRepository.findOne.mockResolvedValue(makeCollection());
+      expect(mockUserRepository.exists).toHaveBeenCalledWith({
+        where: { id: 'override-creator' },
+      });
+      expect(mockCollectionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ creatorId: 'override-creator' }),
+      );
+    });
 
-    await expect(
-      service.create(
-        {
-          contractAddress: 'C'.repeat(56),
-          name: 'NFTopia Genesis',
-          symbol: 'NFTG',
-          imageUrl: 'https://example.com/collection.png',
-        },
-        'creator-1',
-      ),
-    ).rejects.toThrow(BadRequestException);
+    it('rejects create when creator does not exist', async () => {
+      mockUserRepository.exists.mockResolvedValue(false);
+
+      await expect(
+        service.create(
+          {
+            contractAddress: 'C'.repeat(56),
+            name: 'NFTopia Genesis',
+            symbol: 'NFTG',
+            imageUrl: 'https://example.com/collection.png',
+          },
+          'creator-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockCollectionRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects create when contract address already exists', async () => {
+      mockUserRepository.exists.mockResolvedValue(true);
+      mockCollectionRepository.findOne.mockResolvedValue(makeCollection());
+
+      await expect(
+        service.create(
+          {
+            contractAddress: 'C'.repeat(56),
+            name: 'NFTopia Genesis',
+            symbol: 'NFTG',
+            imageUrl: 'https://example.com/collection.png',
+          },
+          'creator-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockCollectionRepository.save).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #162.

Expands the unit test coverage for the Nest.js `CollectionService` and `CollectionController` so that every public method / endpoint is exercised in isolation with mocked dependencies (no database, no external services).

- **Service:** every public method is covered — `findById`/`findOne`, `findByContractAddress`, `findAll`/`findConnection` (including default page size, cursor `after`, `creatorId` filter, verified-only, search), `findTopCollections`/`getTopCollections` (including default limit), `getNftsInCollection` (including default paging and missing-collection), `update` (success, non-creator, missing collection), `getStats` (aggregate path, fallback path, non-numeric path, missing collection), and `create` (success, DTO-overridden `creatorId`, missing creator, duplicate contract address).
- **Controller:** every endpoint is covered, including 404 (`NotFoundException`) and 400 (`BadRequestException`) error propagation, default query-param handling, and reflected `JwtAuthGuard` metadata assertions for the authenticated `POST /` and `PUT /:id` routes (covers the 401 acceptance criterion at the unit-test layer).
- **DTOs:** `CreateCollectionDto`, `UpdateCollectionDto`, and `CollectionQueryDto` have explicit validation tests covering required fields, length/regex on the Stellar contract address, URL validation, numeric coercion, min/max bounds, and enum constraints.
- All TypeORM repositories (`Collection`, `Nft`, `User`) are mocked via `getRepositoryToken(...)`, and the `StorageService` / `StellarService` surface is not imported by the module under test. The JWT auth guard is asserted via `Reflect` metadata rather than executed, so tests run with no network, no auth, and no database.

## Checklist

- [x] Unit tests for every public method on `CollectionService`
- [x] Unit tests for every endpoint on `CollectionController`
- [x] All external dependencies mocked (TypeORM repositories, guard, request user)
- [x] DTO validation tests (create, update, query)
- [x] Error scenarios covered: 404 (NotFoundException), 400 (BadRequestException), 401 (guard metadata), 403-ish creator-mismatch path
- [x] ≥80% code coverage for the collection module
- [x] All tests run in isolation (no DB connection)

## How this was tested

- `pnpm test` (via `npx jest`): **28 suites, 192 tests, all passing.**
- `npx jest --testPathPatterns=collection --coverage --collectCoverageFrom='modules/collection/**/*.ts'`:

  | File | % Stmts | % Branch | % Funcs | % Lines |
  |---|---|---|---|---|
  | All files (collection module) | **93.12** | **85.86** | **92.85** | **93.91** |
  | `collection.controller.ts` | 100 | 80 | 100 | 100 |
  | `collection.service.ts` | 100 | 92 | 100 | 100 |
  | `create-collection.dto.ts` | 100 | 100 | 100 | 100 |
  | `update-collection.dto.ts` | 100 | 100 | 100 | 100 |
  | `collection-query.dto.ts` | 94.11 | 100 | 66.66 | 92.3 |

- `npx eslint 'src/modules/collection/**/*.ts'`: clean.
- `npx tsc --noEmit`: clean.

## Notes / follow-ups

- The `CollectionController` is not yet registered in `CollectionModule` (only the service is) — out of scope for this ticket (tests-only), but worth tracking if the HTTP surface is meant to be live.
- The `JwtAuthGuard` is asserted via reflected metadata rather than by executing the guard end-to-end; verifying the 401 response itself would belong in an E2E test, which the ticket explicitly excludes.
- `collection.module.ts` is intentionally not covered (it has no branches/logic worth testing in isolation).