### PR TITLE
feat(frontend): accessible buttons, unified dropdown, and standardized data components

### DIFF
--- a/nftopia-frontend/__tests__/ui-components.test.tsx
+++ b/nftopia-frontend/__tests__/ui-components.test.tsx
@@ -1,0 +1,224 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Button } from "../components/ui/button";
+import { Dropdown, DropdownTrigger, DropdownMenu, DropdownItem } from "../components/ui/dropdown";
+import { EmptyState } from "../components/ui/empty-state";
+import { DataTable } from "../components/ui/data-table";
+import { DataGrid } from "../components/ui/data-grid";
+import { DataList } from "../components/ui/data-list";
+
+// ---------------------------------------------------------------------------
+// Button
+// ---------------------------------------------------------------------------
+describe("Button", () => {
+  it("renders children", () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole("button", { name: /click me/i })).toBeInTheDocument();
+  });
+
+  it("sets aria-disabled and disabled when disabled prop is true", () => {
+    render(<Button disabled>Disabled</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("sets aria-pressed when pressed prop is provided", () => {
+    render(<Button pressed={true}>Toggle</Button>);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows loading state with sr-only text and aria-busy", () => {
+    render(<Button loading>Save</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Loading")).toBeInTheDocument();
+  });
+
+  it("passes aria-label through", () => {
+    render(<Button aria-label="Close dialog">X</Button>);
+    expect(screen.getByRole("button", { name: "Close dialog" })).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dropdown
+// ---------------------------------------------------------------------------
+describe("Dropdown", () => {
+  function TestDropdown({ onSelect }: { onSelect?: () => void }) {
+    return (
+      <Dropdown>
+        <DropdownTrigger>Open</DropdownTrigger>
+        <DropdownMenu>
+          <DropdownItem onClick={onSelect}>Item 1</DropdownItem>
+          <DropdownItem>Item 2</DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+    );
+  }
+
+  it("menu is hidden initially", () => {
+    render(<TestDropdown />);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("opens menu on trigger click", () => {
+    render(<TestDropdown />);
+    fireEvent.click(screen.getByRole("button", { name: /open/i }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("trigger has aria-expanded=true when open", () => {
+    render(<TestDropdown />);
+    const trigger = screen.getByRole("button", { name: /open/i });
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("closes menu on Escape key", () => {
+    render(<TestDropdown />);
+    fireEvent.click(screen.getByRole("button", { name: /open/i }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("closes menu when item is selected", () => {
+    const onSelect = jest.fn();
+    render(<TestDropdown onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole("button", { name: /open/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /item 1/i }));
+    expect(onSelect).toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EmptyState
+// ---------------------------------------------------------------------------
+describe("EmptyState", () => {
+  it("renders title and description", () => {
+    render(<EmptyState title="No results" description="Try a different search." />);
+    expect(screen.getByText("No results")).toBeInTheDocument();
+    expect(screen.getByText("Try a different search.")).toBeInTheDocument();
+  });
+
+  it("renders action button and calls handler", () => {
+    const onAction = jest.fn();
+    render(<EmptyState title="Empty" actionLabel="Refresh" onAction={onAction} />);
+    fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+    expect(onAction).toHaveBeenCalled();
+  });
+
+  it("has role=status for screen readers", () => {
+    render(<EmptyState title="No data" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataTable
+// ---------------------------------------------------------------------------
+describe("DataTable", () => {
+  type Row = { name: string; value: string };
+  const columns: import("../components/ui/data-table").DataTableColumn<Row>[] = [
+    { key: "name", header: "Name" },
+    { key: "value", header: "Value" },
+  ];
+  const data: Row[] = [
+    { name: "Alice", value: "100" },
+    { name: "Bob", value: "200" },
+  ];
+
+  it("renders column headers and rows", () => {
+    render(<DataTable<Row> columns={columns} data={data} rowKey={(r) => r.name} />);
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is empty", () => {
+    render(
+      <DataTable<Row>
+        columns={columns}
+        data={[]}
+        rowKey={(r) => r.name}
+        emptyState={{ title: "No rows" }}
+      />
+    );
+    expect(screen.getByText("No rows")).toBeInTheDocument();
+  });
+
+  it("shows skeleton rows when loading", () => {
+    const { container } = render(
+      <DataTable<Row> columns={columns} data={[]} rowKey={(r) => r.name} loading />
+    );
+    expect(container.querySelector("table")).toHaveAttribute("aria-busy", "true");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataGrid
+// ---------------------------------------------------------------------------
+describe("DataGrid", () => {
+  type Card = { id: string; label: string };
+  const items: Card[] = [{ id: "1", label: "Card A" }, { id: "2", label: "Card B" }];
+
+  it("renders items", () => {
+    render(
+      <DataGrid<Card>
+        data={items}
+        rowKey={(i) => i.id}
+        renderItem={(i) => <div>{i.label}</div>}
+      />
+    );
+    expect(screen.getByText("Card A")).toBeInTheDocument();
+    expect(screen.getByText("Card B")).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is empty", () => {
+    render(
+      <DataGrid<Card>
+        data={[]}
+        rowKey={(i) => i.id}
+        renderItem={(i) => <div>{i.label}</div>}
+        emptyState={{ title: "No cards" }}
+      />
+    );
+    expect(screen.getByText("No cards")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DataList
+// ---------------------------------------------------------------------------
+describe("DataList", () => {
+  type ListItem = { id: string; text: string };
+  const items: ListItem[] = [{ id: "1", text: "Item A" }, { id: "2", text: "Item B" }];
+
+  it("renders list items", () => {
+    render(
+      <DataList<ListItem>
+        data={items}
+        rowKey={(i) => i.id}
+        renderItem={(i) => <span>{i.text}</span>}
+        aria-label="Test list"
+      />
+    );
+    expect(screen.getByRole("list", { name: "Test list" })).toBeInTheDocument();
+    expect(screen.getByText("Item A")).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is empty", () => {
+    render(
+      <DataList<ListItem>
+        data={[]}
+        rowKey={(i) => i.id}
+        renderItem={(i) => <span>{i.text}</span>}
+        emptyState={{ title: "No items found" }}
+      />
+    );
+    expect(screen.getByText("No items found")).toBeInTheDocument();
+  });
+});

--- a/nftopia-frontend/__tests__/walletconnector.test.tsx
+++ b/nftopia-frontend/__tests__/walletconnector.test.tsx
@@ -88,15 +88,17 @@ describe("WalletConnector", () => {
 
     expect(screen.getByText("GABC...0XYZ")).toBeInTheDocument();
 
+    // Open the dropdown via the trigger button
     fireEvent.click(screen.getByRole("button"));
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy Address" }));
+    // Items are now role="menuitem"
+    fireEvent.click(screen.getByRole("menuitem", { name: /copy address/i }));
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(address);
       expect(mockShowSuccess).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /disconnect/i }));
     expect(mockDisconnect).toHaveBeenCalled();
   });
 });

--- a/nftopia-frontend/components/LanguageSwitcher.tsx
+++ b/nftopia-frontend/components/LanguageSwitcher.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
 import { ChevronDown, Globe, Check } from "lucide-react";
 import { useTranslation, Locale } from "@/hooks/useTranslation";
 import { Button } from "@/components/ui/button";
+import { Dropdown, DropdownTrigger, DropdownMenu, DropdownItem } from "@/components/ui/dropdown";
 
 interface LanguageOption {
   code: Locale;
@@ -24,79 +24,41 @@ const languages: LanguageOption[] = [
 // -------------------------
 export function LanguageSwitcher() {
   const { locale, changeLocale } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  const currentLanguage =
-    languages.find((lang) => lang.code === locale) || languages[0];
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  // Close dropdown when pressing Escape
-  useEffect(() => {
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setIsOpen(false);
-    };
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, []);
-
-  const handleLanguageChange = (languageCode: Locale) => {
-    changeLocale(languageCode);
-    setIsOpen(false);
-  };
+  const currentLanguage = languages.find((l) => l.code === locale) ?? languages[0];
 
   return (
-    <div className="relative" ref={dropdownRef}>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-white border-purple-500/30 bg-transparent hover:text-purple-400 hover:bg-purple-500/10 hover:border-purple-400/50 transition-colors rounded-lg"
+    <Dropdown>
+      <DropdownTrigger
+        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-white border border-purple-500/30 bg-transparent hover:text-purple-400 hover:bg-purple-500/10 hover:border-purple-400/50 transition-colors rounded-lg"
         aria-label="Select language"
-        aria-expanded={isOpen}
-        aria-haspopup="listbox"
       >
-        <Globe className="h-4 w-4" />
-        <span className="hidden sm:inline">{currentLanguage.flag}</span>
+        <Globe className="h-4 w-4" aria-hidden="true" />
+        <span className="hidden sm:inline" aria-hidden="true">{currentLanguage.flag}</span>
         <span className="hidden md:inline">{currentLanguage.nativeName}</span>
-        <ChevronDown className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`} />
-      </Button>
+        <ChevronDown className="h-4 w-4" aria-hidden="true" />
+      </DropdownTrigger>
 
-      {isOpen && (
-        <div className="absolute right-0 mt-2 w-48 bg-[#181359]/95 backdrop-blur-md border border-purple-500/20 rounded-lg shadow-lg z-50">
-          <div className="py-1" role="listbox">
-            {languages.map((language) => (
-              <button
-                key={language.code}
-                onClick={() => handleLanguageChange(language.code)}
-                className={`w-full flex items-center gap-3 px-4 py-2 text-sm hover:bg-purple-500/10 transition-colors rounded-md ${
-                  locale === language.code ? "text-purple-400 bg-purple-500/10" : "text-white"
-                }`}
-                role="option"
-                aria-selected={locale === language.code}
-              >
-                <span className="text-lg">{language.flag}</span>
-                <div className="flex flex-col items-start">
-                  <span className="font-medium">{language.nativeName}</span>
-                  <span className="text-xs text-gray-400">{language.name}</span>
-                </div>
-                {locale === language.code && <Check className="h-4 w-4 ml-auto text-purple-400" />}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+      <DropdownMenu className="w-48" align="right">
+        {languages.map((language) => (
+          <DropdownItem
+            key={language.code}
+            onClick={() => changeLocale(language.code)}
+            role="option"
+            aria-selected={locale === language.code}
+            className={locale === language.code ? "text-purple-400 bg-purple-500/10" : "text-white"}
+          >
+            <span className="text-lg" aria-hidden="true">{language.flag}</span>
+            <div className="flex flex-col items-start">
+              <span className="font-medium">{language.nativeName}</span>
+              <span className="text-xs text-gray-400">{language.name}</span>
+            </div>
+            {locale === language.code && (
+              <Check className="h-4 w-4 ml-auto text-purple-400" aria-hidden="true" />
+            )}
+          </DropdownItem>
+        ))}
+      </DropdownMenu>
+    </Dropdown>
   );
 }
 
@@ -105,49 +67,36 @@ export function LanguageSwitcher() {
 // -------------------------
 export function MobileLanguageSwitcher() {
   const { locale, changeLocale } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
-
-  const currentLanguage =
-    languages.find((lang) => lang.code === locale) || languages[0];
-
-  const handleLanguageChange = (languageCode: Locale) => {
-    changeLocale(languageCode);
-    setIsOpen(false);
-  };
+  const currentLanguage = languages.find((l) => l.code === locale) ?? languages[0];
 
   return (
-    <div className="relative">
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-white border-purple-500/30 bg-transparent hover:text-purple-400 hover:bg-purple-500/10 hover:border-purple-400/50 transition-colors rounded-lg"
+    <Dropdown>
+      <DropdownTrigger
+        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-white border border-purple-500/30 bg-transparent hover:text-purple-400 hover:bg-purple-500/10 hover:border-purple-400/50 transition-colors rounded-lg"
         aria-label="Select language"
       >
-        <Globe className="h-4 w-4" />
-        <span>{currentLanguage.flag}</span>
-        <ChevronDown className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`} />
-      </Button>
+        <Globe className="h-4 w-4" aria-hidden="true" />
+        <span aria-hidden="true">{currentLanguage.flag}</span>
+        <ChevronDown className="h-4 w-4" aria-hidden="true" />
+      </DropdownTrigger>
 
-      {isOpen && (
-        <div className="absolute right-0 mt-2 w-40 bg-[#181359]/95 backdrop-blur-md border border-purple-500/20 rounded-lg shadow-lg z-50">
-          <div className="py-1">
-            {languages.map((language) => (
-              <button
-                key={language.code}
-                onClick={() => handleLanguageChange(language.code)}
-                className={`w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-purple-500/10 transition-colors rounded-md ${
-                  locale === language.code ? "text-purple-400 bg-purple-500/10" : "text-white"
-                }`}
-              >
-                <span className="text-base">{language.flag}</span>
-                <span>{language.nativeName}</span>
-                {locale === language.code && <Check className="h-4 w-4 ml-auto text-purple-400" />}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+      <DropdownMenu className="w-40" align="right">
+        {languages.map((language) => (
+          <DropdownItem
+            key={language.code}
+            onClick={() => changeLocale(language.code)}
+            role="option"
+            aria-selected={locale === language.code}
+            className={locale === language.code ? "text-purple-400 bg-purple-500/10" : "text-white"}
+          >
+            <span className="text-base" aria-hidden="true">{language.flag}</span>
+            <span>{language.nativeName}</span>
+            {locale === language.code && (
+              <Check className="h-4 w-4 ml-auto text-purple-400" aria-hidden="true" />
+            )}
+          </DropdownItem>
+        ))}
+      </DropdownMenu>
+    </Dropdown>
   );
 }

--- a/nftopia-frontend/components/ui/button.tsx
+++ b/nftopia-frontend/components/ui/button.tsx
@@ -57,6 +57,8 @@ export interface ButtonProps
     ButtonLoadingState {
   asChild?: boolean;
   children?: React.ReactNode;
+  /** Indicates a toggle button's pressed state */
+  pressed?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -69,20 +71,30 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       loading = false,
       loadingText,
       children,
+      pressed,
+      disabled,
+      "aria-label": ariaLabel,
       ...props
     },
     ref
   ) => {
     const Comp = asChild ? Slot : "button";
+    const isDisabled = loading || disabled;
+
     return (
       <Comp
         className={cn(
           buttonVariants({ variant, size, className }),
-          loading && "cursor-wait opacity-80"
+          loading && "cursor-wait opacity-80",
+          // Explicit disabled visual state (covers aria-disabled usage too)
+          isDisabled && "opacity-50 pointer-events-none"
         )}
         ref={ref}
-        disabled={loading || props.disabled}
-        aria-busy={loading}
+        disabled={isDisabled}
+        aria-busy={loading || undefined}
+        aria-disabled={isDisabled || undefined}
+        aria-pressed={pressed}
+        aria-label={ariaLabel}
         {...props}
       >
         {loading ? (
@@ -92,6 +104,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <circle
                 className="opacity-25"
@@ -107,6 +120,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
               />
             </svg>
+            <span className="sr-only">Loading</span>
             {loadingText || children}
           </>
         ) : (

--- a/nftopia-frontend/components/ui/data-grid.tsx
+++ b/nftopia-frontend/components/ui/data-grid.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+import { EmptyState, EmptyStateProps } from "./empty-state";
+
+export interface DataGridProps<T> {
+  data: T[];
+  /** Render a single card */
+  renderItem: (item: T, index: number) => React.ReactNode;
+  rowKey: (item: T, index: number) => string | number;
+  /** Responsive column counts */
+  cols?: {
+    default?: number;
+    sm?: number;
+    md?: number;
+    lg?: number;
+    xl?: number;
+  };
+  gap?: "sm" | "md" | "lg";
+  emptyState?: Omit<EmptyStateProps, "className"> & { className?: string };
+  className?: string;
+  loading?: boolean;
+  /** Skeleton card count shown while loading */
+  skeletonCount?: number;
+  /** Render a skeleton card */
+  renderSkeleton?: (index: number) => React.ReactNode;
+}
+
+const gapClass = { sm: "gap-3", md: "gap-6", lg: "gap-8" };
+
+const colsClass = (cols: DataGridProps<unknown>["cols"] = {}) => {
+  const { default: d = 1, sm, md, lg, xl } = cols;
+  return [
+    `grid-cols-${d}`,
+    sm && `sm:grid-cols-${sm}`,
+    md && `md:grid-cols-${md}`,
+    lg && `lg:grid-cols-${lg}`,
+    xl && `xl:grid-cols-${xl}`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+};
+
+/**
+ * Standardized responsive grid with empty-state and loading skeleton support.
+ */
+export function DataGrid<T>({
+  data,
+  renderItem,
+  rowKey,
+  cols = { default: 1, sm: 2, md: 3, lg: 4 },
+  gap = "md",
+  emptyState,
+  className,
+  loading,
+  skeletonCount = 8,
+  renderSkeleton,
+}: DataGridProps<T>) {
+  if (!loading && data.length === 0) {
+    return (
+      <EmptyState
+        title={emptyState?.title ?? "Nothing here yet"}
+        description={emptyState?.description}
+        icon={emptyState?.icon}
+        actionLabel={emptyState?.actionLabel}
+        onAction={emptyState?.onAction}
+        secondaryActionLabel={emptyState?.secondaryActionLabel}
+        onSecondaryAction={emptyState?.onSecondaryAction}
+        className={emptyState?.className}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn("grid", colsClass(cols), gapClass[gap], className)}
+      aria-busy={loading}
+    >
+      {loading
+        ? Array.from({ length: skeletonCount }).map((_, i) =>
+            renderSkeleton ? (
+              renderSkeleton(i)
+            ) : (
+              <div
+                key={i}
+                aria-hidden="true"
+                className="rounded-2xl bg-purple-500/10 animate-pulse h-64"
+              />
+            )
+          )
+        : data.map((item, i) => (
+            <React.Fragment key={rowKey(item, i)}>
+              {renderItem(item, i)}
+            </React.Fragment>
+          ))}
+    </div>
+  );
+}

--- a/nftopia-frontend/components/ui/data-list.tsx
+++ b/nftopia-frontend/components/ui/data-list.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+import { EmptyState, EmptyStateProps } from "./empty-state";
+
+export interface DataListProps<T> {
+  data: T[];
+  renderItem: (item: T, index: number) => React.ReactNode;
+  rowKey: (item: T, index: number) => string | number;
+  emptyState?: Omit<EmptyStateProps, "className"> & { className?: string };
+  className?: string;
+  /** Extra className for each list item wrapper */
+  itemClassName?: string;
+  loading?: boolean;
+  skeletonCount?: number;
+  /** Render a skeleton row */
+  renderSkeleton?: (index: number) => React.ReactNode;
+  /** Accessible label for the list */
+  "aria-label"?: string;
+}
+
+/**
+ * Standardized accessible list with empty-state and loading skeleton support.
+ */
+export function DataList<T>({
+  data,
+  renderItem,
+  rowKey,
+  emptyState,
+  className,
+  itemClassName,
+  loading,
+  skeletonCount = 5,
+  renderSkeleton,
+  "aria-label": ariaLabel,
+}: DataListProps<T>) {
+  if (!loading && data.length === 0) {
+    return (
+      <EmptyState
+        title={emptyState?.title ?? "No items"}
+        description={emptyState?.description}
+        icon={emptyState?.icon}
+        actionLabel={emptyState?.actionLabel}
+        onAction={emptyState?.onAction}
+        secondaryActionLabel={emptyState?.secondaryActionLabel}
+        onSecondaryAction={emptyState?.onSecondaryAction}
+        className={emptyState?.className}
+      />
+    );
+  }
+
+  return (
+    <ul
+      role="list"
+      aria-label={ariaLabel}
+      aria-busy={loading}
+      className={cn("divide-y divide-purple-500/10", className)}
+    >
+      {loading
+        ? Array.from({ length: skeletonCount }).map((_, i) =>
+            renderSkeleton ? (
+              <li key={i} aria-hidden="true">{renderSkeleton(i)}</li>
+            ) : (
+              <li key={i} aria-hidden="true" className="py-3 px-4">
+                <div className="h-4 bg-purple-500/10 rounded animate-pulse w-3/4" />
+              </li>
+            )
+          )
+        : data.map((item, i) => (
+            <li key={rowKey(item, i)} className={cn("py-1", itemClassName)}>
+              {renderItem(item, i)}
+            </li>
+          ))}
+    </ul>
+  );
+}

--- a/nftopia-frontend/components/ui/data-table.tsx
+++ b/nftopia-frontend/components/ui/data-table.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+import { EmptyState, EmptyStateProps } from "./empty-state";
+
+// ---------------------------------------------------------------------------
+// Column definition
+// ---------------------------------------------------------------------------
+export interface DataTableColumn<T> {
+  key: string;
+  header: React.ReactNode;
+  /** Render cell content. Defaults to `String(row[key])`. */
+  render?: (row: T, index: number) => React.ReactNode;
+  /** Optional cell className */
+  className?: string;
+  /** Optional header className */
+  headerClassName?: string;
+  align?: "left" | "center" | "right";
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+export interface DataTableProps<T> {
+  columns: DataTableColumn<T>[];
+  data: T[];
+  /** Key extractor for rows */
+  rowKey: (row: T, index: number) => string | number;
+  /** Props forwarded to EmptyState when data is empty */
+  emptyState?: Omit<EmptyStateProps, "className"> & { className?: string };
+  caption?: string;
+  className?: string;
+  /** Extra className applied to each <tr> */
+  rowClassName?: string | ((row: T, index: number) => string);
+  loading?: boolean;
+}
+
+const alignClass = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+};
+
+/**
+ * Standardized accessible data table with built-in empty-state handling.
+ */
+export function DataTable<T>({
+  columns,
+  data,
+  rowKey,
+  emptyState,
+  caption,
+  className,
+  rowClassName,
+  loading,
+}: DataTableProps<T>) {
+  if (!loading && data.length === 0) {
+    return (
+      <EmptyState
+        title={emptyState?.title ?? "No data"}
+        description={emptyState?.description}
+        icon={emptyState?.icon}
+        actionLabel={emptyState?.actionLabel}
+        onAction={emptyState?.onAction}
+        secondaryActionLabel={emptyState?.secondaryActionLabel}
+        onSecondaryAction={emptyState?.onSecondaryAction}
+        className={emptyState?.className}
+      />
+    );
+  }
+
+  return (
+    <div className={cn("w-full overflow-x-auto rounded-xl border border-purple-500/20", className)}>
+      <table className="w-full text-sm text-left text-gray-300" aria-busy={loading}>
+        {caption && (
+          <caption className="sr-only">{caption}</caption>
+        )}
+        <thead className="text-xs uppercase text-gray-400 bg-purple-900/20 border-b border-purple-500/20">
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                scope="col"
+                className={cn(
+                  "px-4 py-3 font-medium",
+                  alignClass[col.align ?? "left"],
+                  col.headerClassName
+                )}
+              >
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-purple-500/10">
+          {loading
+            ? Array.from({ length: 3 }).map((_, i) => (
+                <tr key={i} aria-hidden="true">
+                  {columns.map((col) => (
+                    <td key={col.key} className="px-4 py-3">
+                      <div className="h-4 bg-purple-500/10 rounded animate-pulse" />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            : data.map((row, i) => {
+                const trClass =
+                  typeof rowClassName === "function"
+                    ? rowClassName(row, i)
+                    : rowClassName;
+                return (
+                  <tr
+                    key={rowKey(row, i)}
+                    className={cn(
+                      "hover:bg-purple-500/5 transition-colors",
+                      trClass
+                    )}
+                  >
+                    {columns.map((col) => (
+                      <td
+                        key={col.key}
+                        className={cn(
+                          "px-4 py-3",
+                          alignClass[col.align ?? "left"],
+                          col.className
+                        )}
+                      >
+                        {col.render
+                          ? col.render(row, i)
+                          : String((row as Record<string, unknown>)[col.key] ?? "")}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/nftopia-frontend/components/ui/dropdown.tsx
+++ b/nftopia-frontend/components/ui/dropdown.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  KeyboardEvent,
+} from "react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+interface DropdownContextValue {
+  open: boolean;
+  setOpen: (v: boolean) => void;
+  triggerId: string;
+  menuId: string;
+}
+
+const DropdownContext = createContext<DropdownContextValue | null>(null);
+
+function useDropdown() {
+  const ctx = useContext(DropdownContext);
+  if (!ctx) throw new Error("Dropdown compound components must be used inside <Dropdown>");
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+interface DropdownProps {
+  children: React.ReactNode;
+  className?: string;
+  /** Controlled open state */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+let uid = 0;
+
+export function Dropdown({ children, className, open: controlledOpen, onOpenChange }: DropdownProps) {
+  const id = useRef(`dropdown-${++uid}`);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+
+  const setOpen = useCallback(
+    (v: boolean) => {
+      if (!isControlled) setInternalOpen(v);
+      onOpenChange?.(v);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open, setOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, setOpen]);
+
+  return (
+    <DropdownContext.Provider
+      value={{
+        open,
+        setOpen,
+        triggerId: `${id.current}-trigger`,
+        menuId: `${id.current}-menu`,
+      }}
+    >
+      <div ref={containerRef} className={cn("relative", className)}>
+        {children}
+      </div>
+    </DropdownContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Trigger
+// ---------------------------------------------------------------------------
+interface DropdownTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+export function DropdownTrigger({ children, className, ...props }: DropdownTriggerProps) {
+  const { open, setOpen, triggerId, menuId } = useDropdown();
+
+  return (
+    <button
+      id={triggerId}
+      type="button"
+      aria-haspopup="menu"
+      aria-expanded={open}
+      aria-controls={menuId}
+      onClick={() => setOpen(!open)}
+      className={cn(
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Menu
+// ---------------------------------------------------------------------------
+interface DropdownMenuProps {
+  children: React.ReactNode;
+  className?: string;
+  align?: "left" | "right";
+}
+
+export function DropdownMenu({ children, className, align = "right" }: DropdownMenuProps) {
+  const { open, menuId, triggerId } = useDropdown();
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Arrow-key navigation between menu items
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])') ?? []
+    );
+    if (!items.length) return;
+    const idx = items.indexOf(document.activeElement as HTMLElement);
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      items[(idx + 1) % items.length]?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      items[(idx - 1 + items.length) % items.length]?.focus();
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      items[0]?.focus();
+    } else if (e.key === "End") {
+      e.preventDefault();
+      items[items.length - 1]?.focus();
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      id={menuId}
+      ref={menuRef}
+      role="menu"
+      aria-labelledby={triggerId}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "absolute top-full mt-2 z-50 min-w-[10rem] rounded-lg border border-purple-500/20 bg-[#181359]/95 backdrop-blur-md shadow-xl overflow-hidden",
+        align === "right" ? "right-0" : "left-0",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Item
+// ---------------------------------------------------------------------------
+interface DropdownItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  /** Close the dropdown when this item is activated */
+  closeOnSelect?: boolean;
+}
+
+export function DropdownItem({
+  children,
+  className,
+  onClick,
+  closeOnSelect = true,
+  disabled,
+  ...props
+}: DropdownItemProps) {
+  const { setOpen } = useDropdown();
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    if (closeOnSelect) setOpen(false);
+  };
+
+  return (
+    <button
+      role="menuitem"
+      type="button"
+      disabled={disabled}
+      aria-disabled={disabled}
+      onClick={handleClick}
+      className={cn(
+        "w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors",
+        "hover:bg-purple-500/10 focus-visible:bg-purple-500/10 focus-visible:outline-none",
+        "disabled:opacity-50 disabled:pointer-events-none",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Separator
+// ---------------------------------------------------------------------------
+export function DropdownSeparator({ className }: { className?: string }) {
+  return <div role="separator" className={cn("my-1 border-t border-purple-500/20", className)} />;
+}

--- a/nftopia-frontend/components/ui/empty-state.tsx
+++ b/nftopia-frontend/components/ui/empty-state.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+export interface EmptyStateProps {
+  /** Icon or illustration to display */
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  /** Primary action button label */
+  actionLabel?: string;
+  onAction?: () => void;
+  /** Secondary action button label */
+  secondaryActionLabel?: string;
+  onSecondaryAction?: () => void;
+  className?: string;
+}
+
+/**
+ * Reusable empty-state component.
+ * Renders a centred message with optional icon and action buttons.
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  secondaryActionLabel,
+  onSecondaryAction,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      aria-label={title}
+      className={cn(
+        "flex flex-col items-center justify-center gap-4 py-16 px-6 text-center",
+        className
+      )}
+    >
+      {icon && (
+        <div className="text-purple-400/60 mb-2" aria-hidden="true">
+          {icon}
+        </div>
+      )}
+
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+
+      {description && (
+        <p className="text-sm text-gray-400 max-w-sm">{description}</p>
+      )}
+
+      {(actionLabel || secondaryActionLabel) && (
+        <div className="flex flex-wrap gap-3 mt-2 justify-center">
+          {actionLabel && onAction && (
+            <Button onClick={onAction} size="sm">
+              {actionLabel}
+            </Button>
+          )}
+          {secondaryActionLabel && onSecondaryAction && (
+            <Button variant="outline" size="sm" onClick={onSecondaryAction}>
+              {secondaryActionLabel}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/nftopia-frontend/components/ui/styled-button.tsx
+++ b/nftopia-frontend/components/ui/styled-button.tsx
@@ -3,10 +3,10 @@
 import React from "react";
 import { LucideIcon } from "lucide-react";
 
-interface StyledButtonProps {
+interface StyledButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   className?: string;
-  onClick?: () => void;
   icon?: LucideIcon;
   iconPosition?: "left" | "right";
 }
@@ -14,18 +14,23 @@ interface StyledButtonProps {
 export const StyledButton = ({
   children,
   className,
-  onClick,
   icon: Icon,
   iconPosition = "left",
+  disabled,
+  "aria-label": ariaLabel,
+  ...props
 }: StyledButtonProps) => {
   return (
-    <div className={`relative ${className}`}>
+    <div className={`relative ${className ?? ""}`}>
       <button
-        onClick={onClick}
-        className="relative cursor-pointer rounded-full bg-black/75 shadow-[-0.15em_-0.15em_0.15em_-0.075em_rgba(5,5,5,0.25),0.0375em_0.0375em_0.0675em_0_rgba(5,5,5,0.1)] group"
+        disabled={disabled}
+        aria-disabled={disabled}
+        aria-label={ariaLabel}
+        className="relative cursor-pointer rounded-full bg-black/75 shadow-[-0.15em_-0.15em_0.15em_-0.075em_rgba(5,5,5,0.25),0.0375em_0.0375em_0.0675em_0_rgba(5,5,5,0.1)] group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none"
+        {...props}
       >
         {/* After element simulation */}
-        <div className="absolute z-0 w-[calc(100%+0.3em)] h-[calc(100%+0.3em)] -top-[0.15em] -left-[0.15em] rounded-full bg-gradient-to-tr from-[rgba(5,5,5,0.5)] via-transparent to-transparent blur-[0.0125em] opacity-25 mix-blend-multiply"></div>
+        <div className="absolute z-0 w-[calc(100%+0.3em)] h-[calc(100%+0.3em)] -top-[0.15em] -left-[0.15em] rounded-full bg-gradient-to-tr from-[rgba(5,5,5,0.5)] via-transparent to-transparent blur-[0.0125em] opacity-25 mix-blend-multiply" aria-hidden="true" />
 
         {/* Button outer */}
         <div className="relative z-1 rounded-full transition-shadow duration-300 shadow-[0_0.05em_0.05em_-0.01em_rgba(5,5,5,1),0_0.01em_0.01em_-0.01em_rgba(5,5,5,0.5),0.15em_0.3em_0.1em_-0.01em_rgba(5,5,5,0.25)] group-hover:shadow-none">
@@ -34,16 +39,15 @@ export const StyledButton = ({
             className="relative z-1 rounded-full p-4 bg-gradient-to-br from-[rgba(230,230,230,1)] to-[rgba(180,180,180,1)] transition-all duration-300 overflow-clip 
             shadow-[0_0_0_0_inset_rgba(5,5,5,0.1),-0.05em_-0.05em_0.05em_0_inset_rgba(5,5,5,0.25),0_0_0_0_inset_rgba(5,5,5,0.1),0_0_0.05em_0.2em_inset_rgba(255,255,255,0.25),0.025em_0.05em_0.1em_0_inset_rgba(255,255,255,1),0.12em_0.12em_0.12em_inset_rgba(255,255,255,0.25),-0.075em_-0.25em_0.25em_0.1em_inset_rgba(5,5,5,0.25)]
             group-hover:shadow-[0.1em_0.15em_0.05em_0_inset_rgba(5,5,5,0.75),-0.025em_-0.03em_0.05em_0.025em_inset_rgba(5,5,5,0.5),0.25em_0.25em_0.2em_0_inset_rgba(5,5,5,0.5),0_0_0.05em_0.5em_inset_rgba(255,255,255,0.15),0_0_0_0_inset_rgba(255,255,255,1),0.12em_0.12em_0.12em_inset_rgba(255,255,255,0.25),-0.075em_-0.12em_0.2em_0.1em_inset_rgba(5,5,5,0.25)]
-            group-hover:clip-path-inset-[1px_1px_1px_1px_round_100em] group-active:transform group-active:scale-[0.975]"
+            group-active:scale-[0.975]"
           >
-            {/* Text span with icon */}
-            <span className="relative z-[4] font-inter text-transparent bg-gradient-to-br from-[rgba(25,25,25,1)] to-[rgba(75,75,75,1)] bg-clip-text tracking-tight font-medium transition-transform duration-250 flex items-center gap-2 select-none shadow-[rgba(0,0,0,0.1)_0_0_0.1em] group-hover:scale-[0.975]">
+            <span className="relative z-[4] font-inter text-transparent bg-gradient-to-br from-[rgba(25,25,25,1)] to-[rgba(75,75,75,1)] bg-clip-text tracking-tight font-medium transition-transform duration-250 flex items-center gap-2 select-none group-hover:scale-[0.975]">
               {iconPosition === "left" && Icon && (
-                <Icon className="w-4 h-4 text-black" />
+                <Icon className="w-4 h-4 text-black" aria-hidden="true" />
               )}
               {children}
               {iconPosition === "right" && Icon && (
-                <Icon className="w-4 h-4 text-black" />
+                <Icon className="w-4 h-4 text-black" aria-hidden="true" />
               )}
             </span>
           </div>

--- a/nftopia-frontend/components/user-dropdown.tsx
+++ b/nftopia-frontend/components/user-dropdown.tsx
@@ -5,138 +5,109 @@ import { ChevronDown, User, LogOut, Settings } from "lucide-react";
 import { useAuth } from "@/lib/stores/auth-store";
 import { useToast } from "@/lib/stores";
 import Link from "next/link";
-import { useTranslation } from "@/hooks/useTranslation";
+import { Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, DropdownSeparator } from "@/components/ui/dropdown";
 
 export function UserDropdown() {
   const { user, logout, isAuthenticated } = useAuth();
   const { showSuccess, showError } = useToast();
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [logoutLoading, setLogoutLoading] = useState(false);
 
-  if (!isAuthenticated || !user) {
-    return null;
-  }
-
-  const { t, locale } = useTranslation();
+  if (!isAuthenticated || !user) return null;
 
   const handleLogout = async () => {
     const confirmed = window.confirm(
-      'Are you sure you want to log out? This will disconnect your wallet and clear your session.'
+      "Are you sure you want to log out? This will disconnect your wallet and clear your session."
     );
-    
     if (!confirmed) return;
 
     try {
       setLogoutLoading(true);
-      
-      // Clear localStorage
-      localStorage.removeItem('auth-user');
-      
-      // Call logout API
+      localStorage.removeItem("auth-user");
       await logout();
-      
-      showSuccess('Successfully logged out');
-      setDropdownOpen(false);
+      showSuccess("Successfully logged out");
     } catch (error) {
-      console.error('Logout failed:', error);
-      showError('Logout failed. Please try again.');
+      console.error("Logout failed:", error);
+      showError("Logout failed. Please try again.");
     } finally {
       setLogoutLoading(false);
     }
   };
 
-  const formatAddress = (address: string) => {
-    return `${address.slice(0, 6)}...${address.slice(-4)}`;
-  };
+  const formatAddress = (address: string) =>
+    `${address.slice(0, 6)}...${address.slice(-4)}`;
 
   return (
-    <div className="relative">
-      <button
-        onClick={() => setDropdownOpen(!dropdownOpen)}
+    <Dropdown>
+      <DropdownTrigger
         className="flex items-center gap-2 px-3 py-2 rounded-lg bg-purple-600/20 border border-purple-500/30 hover:bg-purple-600/30 transition-colors"
+        aria-label={`User menu for ${user.username || "User"}`}
       >
-        <div className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center">
+        <div className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center" aria-hidden="true">
           <User className="w-4 h-4 text-white" />
         </div>
         <div className="hidden md:block text-left">
-          <div className="text-sm font-medium text-white">
-            {user.username || 'User'}
-          </div>
-          <div className="text-xs text-white/60">
-            {formatAddress(user.walletAddress)}
+          <div className="text-sm font-medium text-white">{user.username || "User"}</div>
+          <div className="text-xs text-white/60">{formatAddress(user.walletAddress)}</div>
+        </div>
+        <ChevronDown className="w-4 h-4 text-white/60" aria-hidden="true" />
+      </DropdownTrigger>
+
+      <DropdownMenu className="w-64 bg-[#181359]">
+        {/* Header */}
+        <div className="p-4 border-b border-purple-500/20" role="presentation">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center" aria-hidden="true">
+              <User className="w-5 h-5 text-white" />
+            </div>
+            <div>
+              <div className="text-sm font-medium text-white">{user.username || "User"}</div>
+              <div className="text-xs text-white/60">{formatAddress(user.walletAddress)}</div>
+            </div>
           </div>
         </div>
-        <ChevronDown className={`w-4 h-4 text-white/60 transition-transform ${dropdownOpen ? 'rotate-180' : ''}`} />
-      </button>
 
-      {dropdownOpen && (
-        <>
-          {/* Backdrop */}
-          <div 
-            className="fixed inset-0 z-40"
-            onClick={() => setDropdownOpen(false)}
-          />
-          
-          {/* Dropdown Menu */}
-          <div className="absolute right-0 top-full mt-2 w-64 bg-[#181359] border border-purple-500/20 rounded-lg shadow-xl z-50">
-            <div className="p-4 border-b border-purple-500/20">
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center">
-                  <User className="w-5 h-5 text-white" />
-                </div>
-                <div>
-                  <div className="text-sm font-medium text-white">
-                    {user.username || 'User'}
-                  </div>
-                  <div className="text-xs text-white/60">
-                    {formatAddress(user.walletAddress)}
-                  </div>
-                </div>
-              </div>
-            </div>
+        <div className="py-1">
+          {/* Link items use role="menuitem" directly */}
+          <Link
+            href="/creator-dashboard"
+            role="menuitem"
+            className="flex items-center gap-3 px-4 py-2 text-sm text-white hover:bg-purple-600/20 transition-colors focus-visible:outline-none focus-visible:bg-purple-600/20"
+          >
+            <User className="w-4 h-4" aria-hidden="true" />
+            Dashboard
+          </Link>
 
-            <div className="py-2">
-              <Link
-                href="/creator-dashboard"
-                className="flex items-center gap-3 px-4 py-2 text-sm text-white hover:bg-purple-600/20 transition-colors"
-                onClick={() => setDropdownOpen(false)}
-              >
-                <User className="w-4 h-4" />
-                Dashboard
-              </Link>
-              
-              <Link
-                href="/creator-dashboard/settings"
-                className="flex items-center gap-3 px-4 py-2 text-sm text-white hover:bg-purple-600/20 transition-colors"
-                onClick={() => setDropdownOpen(false)}
-              >
-                <Settings className="w-4 h-4" />
-                Settings
-              </Link>
+          <Link
+            href="/creator-dashboard/settings"
+            role="menuitem"
+            className="flex items-center gap-3 px-4 py-2 text-sm text-white hover:bg-purple-600/20 transition-colors focus-visible:outline-none focus-visible:bg-purple-600/20"
+          >
+            <Settings className="w-4 h-4" aria-hidden="true" />
+            Settings
+          </Link>
 
-              <div className="border-t border-purple-500/20 mt-2 pt-2">
-                <button 
-                  className="flex items-center gap-3 px-4 py-2 text-sm text-red-400 hover:bg-red-500/20 transition-colors w-full text-left disabled:opacity-50"
-                  onClick={handleLogout}
-                  disabled={logoutLoading}
-                >
-                  {logoutLoading ? (
-                    <>
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-red-400"></div>
-                      Logging out...
-                    </>
-                  ) : (
-                    <>
-                      <LogOut className="w-4 h-4" />
-                      Logout
-                    </>
-                  )}
-                </button>
-              </div>
-            </div>
-          </div>
-        </>
-      )}
-    </div>
+          <DropdownSeparator />
+
+          <DropdownItem
+            onClick={handleLogout}
+            disabled={logoutLoading}
+            className="text-red-400 hover:bg-red-500/20"
+          >
+            {logoutLoading ? (
+              <>
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-red-400" aria-hidden="true" />
+                <span className="sr-only">Logging out</span>
+                Logging out...
+              </>
+            ) : (
+              <>
+                <LogOut className="w-4 h-4" aria-hidden="true" />
+                Logout
+              </>
+            )}
+          </DropdownItem>
+        </div>
+      </DropdownMenu>
+    </Dropdown>
   );
-} 
+}

--- a/nftopia-frontend/components/wallet/WalletConnector.tsx
+++ b/nftopia-frontend/components/wallet/WalletConnector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Wallet, ChevronDown, LogOut, Copy, ExternalLink, CheckCircle2 } from "lucide-react";
 import { useWalletStore } from "@/stores/walletStore";
 import { useStellarWallet } from "./hooks/useStellarWallet";
@@ -9,6 +9,7 @@ import { WalletNetworkStatus } from "./WalletNetworkStatus";
 import { useTranslation } from "@/hooks/useTranslation";
 import { getExplorerUrl } from "@/lib/stellar/network";
 import { useToast } from "@/lib/stores";
+import { Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, DropdownSeparator } from "@/components/ui/dropdown";
 
 interface WalletConnectorProps {
   forceVisible?: boolean;
@@ -21,15 +22,7 @@ export function WalletConnector({ forceVisible = false, fullWidth = false }: Wal
   const { disconnect } = useStellarWallet();
   const { showSuccess, showError } = useToast();
   const [modalOpen, setModalOpen] = useState(false);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [copied, setCopied] = useState(false);
-
-  // Close dropdown on outside click
-  useEffect(() => {
-    const handler = () => setDropdownOpen(false);
-    if (dropdownOpen) document.addEventListener("click", handler);
-    return () => document.removeEventListener("click", handler);
-  }, [dropdownOpen]);
 
   const copyAddress = async () => {
     if (!address) return;
@@ -48,19 +41,20 @@ export function WalletConnector({ forceVisible = false, fullWidth = false }: Wal
     : "";
 
   if (!connected) {
-    const connectButtonClass = forceVisible
-      ? "flex w-full justify-center"
-      : "hidden xl:flex";
+    const connectButtonClass = forceVisible ? "flex w-full justify-center" : "hidden xl:flex";
 
     return (
       <>
         <button
           onClick={() => setModalOpen(true)}
-          className={`${connectButtonClass} items-center gap-2 rounded-full px-6 py-2 bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white hover:opacity-90 transition-opacity font-medium text-sm`}
+          className={`${connectButtonClass} items-center gap-2 rounded-full px-6 py-2 bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white hover:opacity-90 transition-opacity font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
           disabled={connecting}
+          aria-busy={connecting}
         >
-          <Wallet className="h-4 w-4" />
-          {connecting ? t("connectWallet.connecting") || "Connecting..." : t("connectWallet.connect")}
+          <Wallet className="h-4 w-4" aria-hidden="true" />
+          {connecting
+            ? t("connectWallet.connecting") || "Connecting..."
+            : t("connectWallet.connect")}
         </button>
         <WalletModal open={modalOpen} onClose={() => setModalOpen(false)} />
       </>
@@ -68,65 +62,57 @@ export function WalletConnector({ forceVisible = false, fullWidth = false }: Wal
   }
 
   return (
-    <div className="relative" onClick={(e) => e.stopPropagation()}>
-      <button
-        onClick={() => setDropdownOpen((v) => !v)}
+    <Dropdown className={fullWidth ? "w-full" : undefined}>
+      <DropdownTrigger
         className={`flex items-center gap-2 rounded-full pl-3 pr-4 py-2 bg-[#4e3bff]/20 border border-[#4e3bff]/40 text-white hover:bg-[#4e3bff]/30 transition-colors text-sm ${fullWidth ? "w-full justify-between" : ""}`}
+        aria-label={`Wallet menu for ${truncatedAddress}`}
       >
-        <div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+        <div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" aria-hidden="true" />
         <span className="font-mono font-medium hidden sm:inline">{truncatedAddress}</span>
         <span className="font-mono font-medium sm:hidden">{address ? `${address.slice(0, 4)}...` : ""}</span>
-        <ChevronDown className={`h-3.5 w-3.5 text-purple-300 transition-transform ${dropdownOpen ? "rotate-180" : ""}`} />
-      </button>
+        <ChevronDown className="h-3.5 w-3.5 text-purple-300" aria-hidden="true" />
+      </DropdownTrigger>
 
-      {dropdownOpen && (
-        <div className="absolute right-0 top-full mt-2 w-60 rounded-xl border border-purple-500/20 bg-gray-900/95 backdrop-blur-md shadow-2xl z-50 overflow-hidden">
-          <div className="px-4 py-3 border-b border-purple-500/10">
-            <div className="flex items-center justify-between mb-1">
-              <span className="text-xs text-purple-300 uppercase tracking-wider">
-                {provider}
-              </span>
-              <WalletNetworkStatus network={network} />
-            </div>
-            <p className="text-xs font-mono text-gray-300 truncate">{address}</p>
+      <DropdownMenu className="w-60 rounded-xl bg-gray-900/95">
+        <div className="px-4 py-3 border-b border-purple-500/10" role="presentation">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-purple-300 uppercase tracking-wider">{provider}</span>
+            <WalletNetworkStatus network={network} />
           </div>
-
-          <div className="py-1">
-            <button
-              onClick={copyAddress}
-              className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-200 hover:bg-purple-500/10 transition-colors"
-            >
-              {copied ? (
-                <CheckCircle2 className="h-4 w-4 text-green-400" />
-              ) : (
-                <Copy className="h-4 w-4 text-purple-400" />
-              )}
-              {copied ? "Copied!" : t("connectWallet.copyAddress") || "Copy Address"}
-            </button>
-
-            <a
-              href={getExplorerUrl(network, undefined, address!)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-200 hover:bg-purple-500/10 transition-colors"
-            >
-              <ExternalLink className="h-4 w-4 text-purple-400" />
-              {t("connectWallet.viewExplorer") || "View on Explorer"}
-            </a>
-
-            <div className="border-t border-purple-500/10 mt-1 pt-1">
-              <button
-                onClick={() => { disconnect(); setDropdownOpen(false); }}
-                className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-red-400 hover:bg-red-500/10 transition-colors"
-              >
-                <LogOut className="h-4 w-4" />
-                {t("connectWallet.disconnect")}
-              </button>
-            </div>
-          </div>
+          <p className="text-xs font-mono text-gray-300 truncate">{address}</p>
         </div>
-      )}
-    </div>
+
+        <DropdownItem onClick={copyAddress} closeOnSelect={false} className="text-gray-200">
+          {copied ? (
+            <CheckCircle2 className="h-4 w-4 text-green-400" aria-hidden="true" />
+          ) : (
+            <Copy className="h-4 w-4 text-purple-400" aria-hidden="true" />
+          )}
+          {copied ? "Copied!" : t("connectWallet.copyAddress") || "Copy Address"}
+        </DropdownItem>
+
+        <a
+          href={getExplorerUrl(network, undefined, address!)}
+          target="_blank"
+          rel="noopener noreferrer"
+          role="menuitem"
+          className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-200 hover:bg-purple-500/10 transition-colors focus-visible:outline-none focus-visible:bg-purple-500/10"
+        >
+          <ExternalLink className="h-4 w-4 text-purple-400" aria-hidden="true" />
+          {t("connectWallet.viewExplorer") || "View on Explorer"}
+        </a>
+
+        <DropdownSeparator />
+
+        <DropdownItem
+          onClick={() => disconnect()}
+          className="text-red-400 hover:bg-red-500/10"
+        >
+          <LogOut className="h-4 w-4" aria-hidden="true" />
+          {t("connectWallet.disconnect")}
+        </DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
   );
 }
 


### PR DESCRIPTION
## Summary

Resolves #200, #201, and #202.

### Issue #200 — Accessible Buttons
- `button.tsx`: added `pressed` prop (`aria-pressed`), explicit `aria-disabled`, `aria-label` passthrough, `sr-only` loading text, `aria-hidden` on spinner SVG
- `styled-button.tsx`: extends `ButtonHTMLAttributes` for full a11y passthrough, `focus-visible` ring, `disabled` states

### Issue #201 — Standardized Dropdown
- New `components/ui/dropdown.tsx`: `Dropdown`, `DropdownTrigger`, `DropdownMenu`, `DropdownItem`, `DropdownSeparator` with `aria-haspopup`, `aria-expanded`, `aria-controls`, `role=menu/menuitem`, keyboard nav (ArrowUp/Down/Home/End/Escape), outside-click close
- Refactored `UserDropdown`, `WalletConnector`, and `LanguageSwitcher` to use it

### Issue #202 — Standardized Data Presentations
- `components/ui/empty-state.tsx`: reusable `EmptyState` with `role=status`, icon, title, description, action buttons
- `components/ui/data-table.tsx`: accessible `DataTable` with loading skeletons, empty state, `aria-busy`, `scope=col` headers
- `components/ui/data-grid.tsx`: responsive `DataGrid` with configurable columns, loading skeletons, empty state
- `components/ui/data-list.tsx`: `DataList` with `role=list`, `aria-label`, loading skeletons, empty state

### Tests
- 20 new tests in `__tests__/ui-components.test.tsx`
- Updated `walletconnector.test.tsx` to match new `role=menuitem` structure
- All 21 test suites pass, `tsc --noEmit` clean, `next build` succeeds

Closes #200
Closes #201
Closes #202
Closes #203