### PR TITLE
feat: replace Starknet with Stellar in frontend i18n (#167)

### DIFF
--- a/nftopia-frontend/README.md
+++ b/nftopia-frontend/README.md
@@ -168,5 +168,5 @@ Useful companion docs in this workspace:
 
 ## 📌 Repository Notes
 
-- Some translation copy and older implementation artifacts still mention Starknet. The active wallet, network, and backend integration code is now aligned around Stellar and Soroban.
+- All translation copy and implementation code is aligned with Stellar and Soroban. Legacy Starknet references have been removed.
 - The project supports four locale folders: EN, FR, ES, and DE.

--- a/nftopia-frontend/components/main-hero.tsx
+++ b/nftopia-frontend/components/main-hero.tsx
@@ -106,7 +106,7 @@ export function MainHero() {
               <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm0-15v5l4.5 2.5"></path>
             </svg>
             <div className="text-xl sm:text-2xl font-bold text-white mb-1 truncate">
-              {t("homepage.features.starknet")}
+              {t("homepage.features.stellar")}
             </div>
             <div className="text-xs sm:text-sm text-purple-400 font-medium">
               {t("homepage.features.ecosystem")}

--- a/nftopia-frontend/i18n-README.md
+++ b/nftopia-frontend/i18n-README.md
@@ -157,7 +157,7 @@ t('items', { count: 5 }) // "5 items"
   "homepage": {
     "hero": {
       "title": "Discover, Collect & Trade Unique Digital Art",
-      "subtitle": "The premier NFT marketplace on Starknet"
+      "subtitle": "The premier NFT marketplace on Stellar"
     }
   },
   "common": {
@@ -180,7 +180,7 @@ t('items', { count: 5 }) // "5 items"
   "homepage": {
     "hero": {
       "title": "Découvrez, Collectez et Échangez de l'Art Numérique Unique",
-      "subtitle": "Le marché NFT principal sur Starknet"
+      "subtitle": "Le marché NFT principal sur Stellar"
     }
   },
   "common": {

--- a/nftopia-frontend/lib/stores/auth-store.ts
+++ b/nftopia-frontend/lib/stores/auth-store.ts
@@ -375,13 +375,7 @@ export const useAuthStore = create<AuthStore>()(
           });
 
           // Step 1: Disconnect wallet first (before API call)
-          try {
-            if (typeof window !== 'undefined' && (window as any).starknet) {
-              await (window as any).starknet.disable();
-            }
-          } catch (walletError) {
-            console.warn('Wallet disconnect failed:', walletError);
-          }
+          // Note: Legacy Starknet wallet disconnect removed; Stellar wallet cleanup handled by wallet provider
 
           // Step 2: Clear localStorage immediately
           if (typeof window !== 'undefined') {

--- a/nftopia-frontend/locales/de/common.json
+++ b/nftopia-frontend/locales/de/common.json
@@ -31,7 +31,7 @@
         "titlePart1": "Dezentrales",
         "titlePart2": "NFT-Speicher",
         "titlePart3": "Management",
-        "subtitle": "Sichere Aufbewahrung, Verwaltung und Präsentation Ihrer digitalen Assets auf der Starknet-Blockchain mit unübertroffener Sicherheit und echtem Eigentum.",
+        "subtitle": "Sichere Aufbewahrung, Verwaltung und Präsentation Ihrer digitalen Assets auf der Stellar-Blockchain mit unübertroffener Sicherheit und echtem Eigentum.",
         "cta": "Jetzt erstellen",
         "learnMore": "NFTs entdecken"
       },
@@ -42,13 +42,13 @@
       "features": {
         "title": "Warum NFTopia?",
         "secure": "Sicher",
-        "secureDesc": "Auf Starknet für maximale Sicherheit",
+        "secureDesc": "Auf Stellar für maximale Sicherheit",
         "fast": "Schnell",
         "fastDesc": "Blitzschnelle Transaktionen",
         "affordable": "Erschwinglich",
         "affordableDesc": "Niedrige Gas-Gebühren und Kosten",
         "onChain": "On-Chain",
-        "starknet": "Starknet",
+        "stellar": "Stellar",
         "ecosystem": "Ökosystem",
         "storage": "Speicher"
       }
@@ -151,8 +151,8 @@
     },
     "seo": {
       "title": "NFTopia - Entdecken, Sammeln und Handeln mit einzigartiger digitaler Kunst",
-      "description": "Der führende NFT-Marktplatz auf Starknet. Entdecken, sammeln und handeln Sie mit einzigartiger digitaler Kunst mit sicheren, schnellen und kostengünstigen Transaktionen.",
-      "keywords": "NFT, digitale Kunst, Blockchain, Starknet, Marktplatz, Sammlerstücke"
+      "description": "Der führende NFT-Marktplatz auf Stellar. Entdecken, sammeln und handeln Sie mit einzigartiger digitaler Kunst mit sicheren, schnellen und kostengünstigen Transaktionen.",
+      "keywords": "NFT, digitale Kunst, Blockchain, Stellar, Marktplatz, Sammlerstücke"
     },
     "footer": {
       "description": "Entdecken, sammeln und handeln Sie einzigartige digitale Assets auf dem fortschrittlichsten NFT-Marktplatz.",
@@ -226,7 +226,7 @@
       "userName": "Benutzername (optional)",
       "alreadyHave": "Haben Sie bereits ein Konto?",
       "signIn": "Anmelden",
-      "starknetSecure": "100% Starknet-sicher",
+      "stellarSecure": "100% Stellar-sicher",
       "inputPlaceholderOne": "Verbinden Sie Ihre Wallet, um die Adresse zu sehen",
       "inputPlaceholderTwo": "coolersammler123",
       "connecting": "Wird verbunden...",
@@ -237,10 +237,10 @@
     },
     "login": {
       "walletAddress": "Wallet-Adresse",
-      "connectWallet": "Starknet-Wallet verbinden",
+      "connectWallet": "Stellar-Wallet verbinden",
       "getNonce": "Nonce abrufen",
       "dontHave": "Noch kein Konto?",
-      "registerWith": "Mit Starknet registrieren",
+      "registerWith": "Mit Stellar registrieren",
       "signingIn": "Anmeldung läuft...",
       "signAndLogin": "Signieren & anmelden",
       "inputPlaceholder": "Verbinden Sie Ihre Wallet, um die Adresse anzuzeigen"

--- a/nftopia-frontend/locales/en/common.json
+++ b/nftopia-frontend/locales/en/common.json
@@ -31,7 +31,7 @@
       "titlePart1": "Decentralized",
       "titlePart2": "NFT Storage",
       "titlePart3": "Management",
-      "subtitle": "Securely store, manage, and showcase your unique digital assets on Starknet blockchain with unparalleled security and true ownership.",
+      "subtitle": "Securely store, manage, and showcase your unique digital assets on Stellar blockchain with unparalleled security and true ownership.",
       "cta": "Start Creating",
       "learnMore": "Explore NFTs"
     },
@@ -42,13 +42,13 @@
     "features": {
       "title": "Why Choose NFTopia",
       "secure": "Secure",
-      "secureDesc": "Built on Starknet for maximum security",
+      "secureDesc": "Built on Stellar for maximum security",
       "fast": "Fast",
       "fastDesc": "Lightning-fast transactions",
       "affordable": "Affordable",
       "affordableDesc": "Low gas fees and costs",
       "onChain": "On-Chain",
-      "starknet": "Starknet",
+      "stellar": "Stellar",
       "ecosystem": "Ecosystem",
       "storage": "Storage"
     }
@@ -151,8 +151,8 @@
   },
   "seo": {
     "title": "NFTopia - Discover, Collect & Trade Unique Digital Art",
-    "description": "The premier NFT marketplace on Starknet. Discover, collect, and trade unique digital art with secure, fast, and affordable transactions.",
-    "keywords": "NFT, digital art, blockchain, Starknet, marketplace, collectibles"
+    "description": "The premier NFT marketplace on Stellar. Discover, collect, and trade unique digital art with secure, fast, and affordable transactions.",
+    "keywords": "NFT, digital art, blockchain, Stellar, marketplace, collectibles"
   },
   "footer": {
     "description": "Discover, collect, and trade unique digital assets on the most advanced NFT marketplace.",
@@ -226,7 +226,7 @@
     "userName": "Username (optional)",
     "alreadyHave": "Already have an account?",
     "signIn": "Sign in",
-    "starknetSecure": "100% Starknet Secure",
+    "stellarSecure": "100% Stellar Secure",
     "inputPlaceholderOne": "Connect your wallet to see address",
     "inputPlaceholderTwo": "coolcollector123",
     "connecting": "Connecting...",
@@ -237,10 +237,10 @@
   },
   "login": {
     "walletAddress": "Wallet Address",
-    "connectWallet": "Connect Starknet Wallet",
+    "connectWallet": "Connect Stellar Wallet",
     "getNonce": "Get Nonce",
     "dontHave": "Don't have an account?",
-    "registerWith": "Register with Starknet",
+    "registerWith": "Register with Stellar",
     "signingIn": "Signing in...",
     "signAndLogin": "Sign & Login",
     "inputPlaceholder": "Connect your wallet to display address"

--- a/nftopia-frontend/locales/es/common.json
+++ b/nftopia-frontend/locales/es/common.json
@@ -31,7 +31,7 @@
         "titlePart1": "Descentralizado",
         "titlePart2": "Almacenamiento NFT",
         "titlePart3": "Gestión",
-        "subtitle": "Almacena, gestiona y muestra tus activos digitales únicos en la blockchain Starknet con seguridad incomparable y propiedad real.",
+        "subtitle": "Almacena, gestiona y muestra tus activos digitales únicos en la blockchain Stellar con seguridad incomparable y propiedad real.",
         "cta": "Comenzar a crear",
         "learnMore": "Explorar NFTs"
       },
@@ -42,13 +42,13 @@
       "features": {
         "title": "Por qué elegir NFTopia",
         "secure": "Seguro",
-        "secureDesc": "Construido en Starknet para máxima seguridad",
+        "secureDesc": "Construido en Stellar para máxima seguridad",
         "fast": "Rápido",
         "fastDesc": "Transacciones ultrarrápidas",
         "affordable": "Económico",
         "affordableDesc": "Bajas tarifas de gas y costos",
         "onChain": "On-Chain",
-        "starknet": "Starknet",
+        "stellar": "Stellar",
         "ecosystem": "Ecosistema",
         "storage": "Almacenamiento"
       }
@@ -151,8 +151,8 @@
     },
     "seo": {
       "title": "NFTopia - Descubre, colecciona y comercia arte digital único",
-      "description": "El principal mercado NFT en Starknet. Descubre, colecciona y comercia arte digital único con transacciones seguras, rápidas y económicas.",
-      "keywords": "NFT, arte digital, blockchain, Starknet, mercado, coleccionables"
+      "description": "El principal mercado NFT en Stellar. Descubre, colecciona y comercia arte digital único con transacciones seguras, rápidas y económicas.",
+      "keywords": "NFT, arte digital, blockchain, Stellar, mercado, coleccionables"
     },
     "footer": {
       "description": "Descubre, colecciona y comercia activos digitales únicos en el mercado NFT más avanzado.",
@@ -226,7 +226,7 @@
       "userName": "Nombre de usuario (opcional)",
       "alreadyHave": "¿Ya tienes una cuenta?",
       "signIn": "Iniciar sesión",
-      "starknetSecure": "100% seguro con Starknet",
+      "stellarSecure": "100% seguro con Stellar",
       "inputPlaceholderOne": "Conecta tu billetera para ver la dirección",
       "inputPlaceholderTwo": "coleccionistagenial123",
       "connecting": "Conectando...",
@@ -237,10 +237,10 @@
     },
     "login": {
       "walletAddress": "Dirección de la billetera",
-      "connectWallet": "Conectar billetera Starknet",
+      "connectWallet": "Conectar billetera Stellar",
       "getNonce": "Obtener nonce",
       "dontHave": "¿No tienes una cuenta?",
-      "registerWith": "Registrarse con Starknet",
+      "registerWith": "Registrarse con Stellar",
       "signingIn": "Iniciando sesión...",
       "signAndLogin": "Firmar e iniciar sesión",
       "inputPlaceholder": "Conecta tu billetera para mostrar la dirección"

--- a/nftopia-frontend/locales/fr/common.json
+++ b/nftopia-frontend/locales/fr/common.json
@@ -31,7 +31,7 @@
       "titlePart1": "Décentralisé",
       "titlePart2": "Stockage NFT",
       "titlePart3": "Gestion",
-      "subtitle": "Stockez, gérez et présentez en toute sécurité vos actifs numériques uniques sur la blockchain Starknet avec une sécurité inégalée et une véritable propriété.",
+      "subtitle": "Stockez, gérez et présentez en toute sécurité vos actifs numériques uniques sur la blockchain Stellar avec une sécurité inégalée et une véritable propriété.",
       "cta": "Commencer à créer",
       "learnMore": "Explorer les NFTs"
     },
@@ -42,13 +42,13 @@
     "features": {
       "title": "Pourquoi choisir NFTopia",
       "secure": "Sécurisé",
-      "secureDesc": "Construit sur Starknet pour une sécurité maximale",
+      "secureDesc": "Construit sur Stellar pour une sécurité maximale",
       "fast": "Rapide",
       "fastDesc": "Transactions ultra-rapides",
       "affordable": "Abordable",
       "affordableDesc": "Frais de gaz et coûts réduits",
       "onChain": "Sur la chaîne",
-      "starknet": "Starknet",
+      "stellar": "Stellar",
       "ecosystem": "Écosystème",
       "storage": "Stockage"
     }
@@ -151,8 +151,8 @@
   },
   "seo": {
     "title": "NFTopia - Découvrez, Collectez et Échangez de l'Art Numérique Unique",
-    "description": "Le marché NFT principal sur Starknet. Découvrez, collectez et échangez de l'art numérique unique avec des transactions sécurisées, rapides et abordables.",
-    "keywords": "NFT, art numérique, blockchain, Starknet, marché, collections"
+    "description": "Le marché NFT principal sur Stellar. Découvrez, collectez et échangez de l'art numérique unique avec des transactions sécurisées, rapides et abordables.",
+    "keywords": "NFT, art numérique, blockchain, Stellar, marché, collections"
   },
   "footer": {
     "description": "Découvrez, collectez et échangez des actifs numériques uniques sur le marché NFT le plus avancé.",
@@ -226,7 +226,7 @@
       "userName": "Nom d'utilisateur (optionnel)",
       "alreadyHave": "Vous avez déjà un compte ?",
       "signIn": "Se connecter",
-      "starknetSecure": "100% sécurisé par Starknet",
+      "stellarSecure": "100% sécurisé par Stellar",
       "inputPlaceholderOne": "Connectez votre portefeuille pour voir l'adresse",
       "inputPlaceholderTwo": "collectionneurcool123",
       "connecting": "Connexion en cours...",
@@ -237,10 +237,10 @@
     },
     "login": {
       "walletAddress": "Adresse du portefeuille",
-      "connectWallet": "Connecter le portefeuille Starknet",
+      "connectWallet": "Connecter le portefeuille Stellar",
       "getNonce": "Obtenir un nonce",
       "dontHave": "Vous n'avez pas de compte ?",
-      "registerWith": "S'inscrire avec Starknet",
+      "registerWith": "S'inscrire avec Stellar",
       "signingIn": "Connexion en cours...",
       "signAndLogin": "Signer et se connecter",
       "inputPlaceholder": "Connectez votre portefeuille pour afficher l'adresse"


### PR DESCRIPTION
## Summary

Closes #167

Replaces all user-facing Starknet references with Stellar across the frontend i18n layer.

## Changes

**Locale files (en, es, fr, de):**
- `homepage.hero.subtitle` — blockchain name updated to Stellar
- `homepage.features.secureDesc` — "Built on Starknet" → "Built on Stellar"
- `homepage.features.starknet` key renamed to `homepage.features.stellar` (value: "Stellar")
- `seo.description` and `seo.keywords` — Starknet → Stellar
- `login.connectWallet` — "Connect Starknet Wallet" → "Connect Stellar Wallet"
- `login.registerWith` — "Register with Starknet" → "Register with Stellar"
- `register.starknetSecure` key renamed to `register.stellarSecure`

**Components:**
- `components/main-hero.tsx` — updated translation key reference to `homepage.features.stellar`

**Code / docs:**
- `lib/stores/auth-store.ts` — removed legacy `(window as any).starknet.disable()` block; replaced with explanatory comment
- `i18n-README.md` — updated example snippets
- `nftopia-frontend/README.md` — updated repository notes

## Testing

- ✅ 22 test suites, 77 tests passed (7 skipped)
- ✅ Translation validation: 243 keys across all locales, 0 missing, 0 inconsistencies