### PR TITLE
feat: unified client validation and server error mapping for auth forms

### DIFF
--- a/nftopia-frontend/__tests__/server-error-mapping.test.ts
+++ b/nftopia-frontend/__tests__/server-error-mapping.test.ts
@@ -1,0 +1,33 @@
+import { mapServerError } from "@/lib/errors/serverErrorMapper";
+
+describe("mapServerError", () => {
+  it("maps known field errors shape", () => {
+    const { fieldErrors, formError } = mapServerError({
+      errors: { email: "Email already taken", password: ["Too weak"] },
+    });
+    expect(fieldErrors.email).toBe("Email already taken");
+    expect(fieldErrors.password).toBe("Too weak");
+    expect(formError).toBe("");
+  });
+
+  it("maps single message string", () => {
+    const { fieldErrors, formError } = mapServerError({ message: "Invalid credentials" });
+    expect(formError).toBe("Invalid credentials");
+    expect(fieldErrors).toEqual({});
+  });
+
+  it("maps error string fallback", () => {
+    const { formError } = mapServerError({ error: "Server error" });
+    expect(formError).toBe("Server error");
+  });
+
+  it("returns generic message for unknown payload", () => {
+    const { formError } = mapServerError(null);
+    expect(formError).toBe("Something went wrong. Please try again.");
+  });
+
+  it("returns generic message for empty object", () => {
+    const { formError } = mapServerError({});
+    expect(formError).toBe("Something went wrong. Please try again.");
+  });
+});

--- a/nftopia-frontend/__tests__/validation-rules-auth.test.ts
+++ b/nftopia-frontend/__tests__/validation-rules-auth.test.ts
@@ -1,0 +1,45 @@
+import { loginSchema, registerSchema } from "@/lib/validation/auth";
+
+describe("loginSchema", () => {
+  it("passes with valid email and password", () => {
+    const result = loginSchema.safeParse({ email: "user@example.com", password: "secret" });
+    expect(result.success).toBe(true);
+  });
+
+  it("fails with invalid email", () => {
+    const result = loginSchema.safeParse({ email: "not-an-email", password: "secret" });
+    expect(result.success).toBe(false);
+  });
+
+  it("fails with empty password", () => {
+    const result = loginSchema.safeParse({ email: "user@example.com", password: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("registerSchema", () => {
+  const valid = {
+    email: "user@example.com",
+    password: "password123",
+    confirmPassword: "password123",
+  };
+
+  it("passes with valid data", () => {
+    expect(registerSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("fails when passwords do not match", () => {
+    const result = registerSchema.safeParse({ ...valid, confirmPassword: "different" });
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when password is under 8 characters", () => {
+    const result = registerSchema.safeParse({ ...valid, password: "short", confirmPassword: "short" });
+    expect(result.success).toBe(false);
+  });
+
+  it("passes with optional username", () => {
+    const result = registerSchema.safeParse({ ...valid, username: "temy" });
+    expect(result.success).toBe(true);
+  });
+});

--- a/nftopia-frontend/app/[locale]/auth/login/page.tsx
+++ b/nftopia-frontend/app/[locale]/auth/login/page.tsx
@@ -4,21 +4,19 @@ import { CircuitBackground } from "@/components/circuit-background";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/lib/stores/auth-store";
+import { useAuthStore } from "@/lib/stores/auth-store";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useStellarWallet } from "@/components/wallet/hooks/useStellarWallet";
 import { useStellarAuth } from "@/components/wallet/hooks/useStellarAuth";
 import { WalletModal } from "@/components/wallet/WalletModal";
 import { WalletNetworkStatus } from "@/components/wallet/WalletNetworkStatus";
 import { defaultNetwork } from "@/lib/stellar/client";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema, LoginFormData } from "@/lib/validation/auth";
+import { mapServerError } from "@/lib/errors/serverErrorMapper";
 import {
-  KeyRound,
-  LogIn,
-  Wallet,
-  Mail,
-  Lock,
-  Eye,
-  EyeOff,
-  ChevronRight,
+  LogIn, Wallet, Mail, Lock, Eye, EyeOff, ChevronRight,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -28,42 +26,33 @@ type AuthMode = "wallet" | "email";
 
 export default function LoginPage() {
   const { t, locale } = useTranslation();
+  const { loading: emailLoading, error: emailError, clearError: clearEmailError } = useAuth();
+  const { emailLogin } = useAuthStore();
 
   const {
-    loading: emailLoading,
-    error: emailError,
-    clearError: clearEmailError,
-  } = useAuth();
-
-  // Stellar wallet state
-  const {
-    connected,
-    address,
-    provider,
-    connecting,
-    error: walletError,
-    connect,
-    disconnect,
-    clearError: clearWalletError,
+    connected, address, provider, connecting,
+    error: walletError, connect, disconnect, clearError: clearWalletError,
   } = useStellarWallet();
 
   const {
-    loading: authLoading,
-    error: authError,
-    authenticateWithWallet,
-    clearError: clearAuthError,
+    loading: authLoading, error: authError,
+    authenticateWithWallet, clearError: clearAuthError,
   } = useStellarAuth();
 
-  // UI state
   const [mode, setMode] = useState<AuthMode>("wallet");
   const [walletModalOpen, setWalletModalOpen] = useState(false);
   const [challengeRequested, setChallengeRequested] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [localError, setLocalError] = useState("");
 
-  const loading = emailLoading || connecting || authLoading;
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormData>({ resolver: zodResolver(loginSchema) });
+
+  const loading = emailLoading || connecting || authLoading || isSubmitting;
 
   const clearAllErrors = () => {
     clearEmailError();
@@ -78,7 +67,6 @@ export default function LoginPage() {
     setMode(m);
   };
 
-  /* ── Wallet auth flow ── */
   const handleWalletAuth = async () => {
     if (!address || !provider) {
       setLocalError("Please connect your wallet first");
@@ -86,22 +74,26 @@ export default function LoginPage() {
     }
     clearAllErrors();
     try {
-      await authenticateWithWallet(address, provider, () => {
-        // Redirect on success — auth store handles navigation
-      });
+      await authenticateWithWallet(address, provider, () => {});
     } catch {
       // error already set in hook
     }
   };
 
-  // Email auth flow 
-  const handleEmailLogin = async () => {
-    if (!email || !password) {
-      setLocalError("Please enter your email and password");
-      return;
-    }
+  const onEmailSubmit = async (data: LoginFormData) => {
     clearAllErrors();
-    setLocalError("Email login: wire to useAuth().loginWithEmail()");
+    try {
+      await emailLogin(data.email, data.password);
+    } catch (err: unknown) {
+      const { fieldErrors, formError } = mapServerError(err);
+      if (Object.keys(fieldErrors).length > 0) {
+        for (const [field, msg] of Object.entries(fieldErrors)) {
+          setError(field as keyof LoginFormData, { message: msg });
+        }
+      } else {
+        setLocalError(formError);
+      }
+    }
   };
 
   const displayError = localError || walletError || authError || emailError;
@@ -109,19 +101,12 @@ export default function LoginPage() {
   return (
     <div className="min-h-[500px] text-white">
       <CircuitBackground />
-
       <div className="relative z-10 pb-16 px-4">
         <div className="max-w-md mx-auto">
           <div className="border border-purple-500/20 rounded-xl p-8 bg-glass backdrop-blur-md shadow-lg">
 
             <div className="flex justify-center mb-8">
-              <Image
-                src="/nftopia-04.svg"
-                alt="NFTopia Logo"
-                width={200}
-                height={60}
-                className="h-auto"
-              />
+              <Image src="/nftopia-04.svg" alt="NFTopia Logo" width={200} height={60} className="h-auto" />
             </div>
 
             {displayError && (
@@ -130,14 +115,11 @@ export default function LoginPage() {
               </div>
             )}
 
-        
             <div className="flex rounded-lg bg-gray-800/50 p-1 mb-6 gap-1">
               <button
                 onClick={() => switchMode("wallet")}
                 className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${
-                  mode === "wallet"
-                    ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow"
-                    : "text-gray-400 hover:text-white"
+                  mode === "wallet" ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow" : "text-gray-400 hover:text-white"
                 }`}
               >
                 <Wallet className="h-4 w-4" />
@@ -146,9 +128,7 @@ export default function LoginPage() {
               <button
                 onClick={() => switchMode("email")}
                 className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${
-                  mode === "email"
-                    ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow"
-                    : "text-gray-400 hover:text-white"
+                  mode === "email" ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow" : "text-gray-400 hover:text-white"
                 }`}
               >
                 <Mail className="h-4 w-4" />
@@ -156,14 +136,13 @@ export default function LoginPage() {
               </button>
             </div>
 
-            {/*WALLET MODE  */}
+            {/* WALLET MODE */}
             {mode === "wallet" && (
               <div className="space-y-5">
                 <div>
                   <label className="block text-sm font-medium mb-2 text-purple-300">
                     {t("login.walletAddress") || "Wallet Address"}
                   </label>
-
                   {connected && address ? (
                     <div className="flex items-center justify-between w-full bg-gray-800/50 border border-purple-500/20 rounded-lg px-4 py-3">
                       <div className="flex items-center gap-2 min-w-0">
@@ -184,15 +163,12 @@ export default function LoginPage() {
                     </div>
                   ) : (
                     <Input
-                      type="text"
-                      value=""
-                      readOnly
+                      type="text" value="" readOnly
                       placeholder={t("login.inputPlaceholder") || "Connect wallet to populate"}
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg px-4 py-3 text-sm"
                     />
                   )}
                 </div>
-
                 <div className="space-y-3">
                   {!connected ? (
                     <Button
@@ -210,23 +186,19 @@ export default function LoginPage() {
                       disabled={loading}
                     >
                       <LogIn className="mr-2 h-5 w-5" />
-                      {loading
-                        ? t("login.signingIn") || "Signing in…"
-                        : t("login.signAndLogin") || "Sign & Login"}
+                      {loading ? t("login.signingIn") || "Signing in…" : t("login.signAndLogin") || "Sign & Login"}
                     </Button>
                   )}
                 </div>
-
                 <p className="text-xs text-gray-500 text-center leading-relaxed">
-                  {t("login.walletAuthNote") ||
-                    "You will be asked to sign a message to verify ownership of your Stellar wallet. No transaction will be submitted."}
+                  {t("login.walletAuthNote") || "You will be asked to sign a message to verify ownership of your Stellar wallet. No transaction will be submitted."}
                 </p>
               </div>
             )}
 
             {/* EMAIL MODE */}
             {mode === "email" && (
-              <div className="space-y-5">
+              <form onSubmit={handleSubmit(onEmailSubmit)} className="space-y-5" noValidate>
                 <div>
                   <label className="block text-sm font-medium mb-2 text-gray-300">
                     {t("login.email") || "Email"}
@@ -235,12 +207,14 @@ export default function LoginPage() {
                     <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
                       placeholder="you@example.com"
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      {...register("email")}
                     />
                   </div>
+                  {errors.email && (
+                    <p className="mt-1 text-xs text-red-400">{errors.email.message}</p>
+                  )}
                 </div>
 
                 <div>
@@ -251,10 +225,9 @@ export default function LoginPage() {
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type={showPassword ? "text" : "password"}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
                       placeholder="••••••••"
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-10 py-3 text-sm"
+                      {...register("password")}
                     />
                     <button
                       type="button"
@@ -264,20 +237,22 @@ export default function LoginPage() {
                       {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                     </button>
                   </div>
+                  {errors.password && (
+                    <p className="mt-1 text-xs text-red-400">{errors.password.message}</p>
+                  )}
                 </div>
 
                 <Button
-                  onClick={handleEmailLogin}
+                  type="submit"
                   className="w-full bg-gradient-to-r from-[#4e3bff] to-[#9747ff] hover:opacity-90 text-white font-medium py-2 px-4 rounded-lg flex items-center justify-center"
                   disabled={loading}
                 >
                   <LogIn className="mr-2 h-5 w-5" />
-                  {loading ? t("login.signingIn") || "Signing in…" : t("login.signIn") || "Sign In"}
+                  {isSubmitting ? t("login.signingIn") || "Signing in…" : t("login.signIn") || "Sign In"}
                 </Button>
-              </div>
+              </form>
             )}
 
-            {/*Register link */}
             <div className="text-center text-sm text-gray-400 mt-6">
               {t("login.dontHave") || "Don't have an account?"}{" "}
               <Link
@@ -292,11 +267,7 @@ export default function LoginPage() {
         </div>
       </div>
 
-      {/* Wallet selection modal */}
-      <WalletModal
-        open={walletModalOpen}
-        onClose={() => setWalletModalOpen(false)}
-      />
+      <WalletModal open={walletModalOpen} onClose={() => setWalletModalOpen(false)} />
     </div>
   );
 }

--- a/nftopia-frontend/app/[locale]/auth/register/page.tsx
+++ b/nftopia-frontend/app/[locale]/auth/register/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { API_CONFIG } from "@/lib/config";
 import { Button } from "@/components/ui/button";
@@ -11,17 +10,15 @@ import { useStellarWallet } from "@/components/wallet/hooks/useStellarWallet";
 import { WalletModal } from "@/components/wallet/WalletModal";
 import { WalletNetworkStatus } from "@/components/wallet/WalletNetworkStatus";
 import { defaultNetwork } from "@/lib/stellar/client";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { registerSchema, RegisterFormData } from "@/lib/validation/auth";
+import { mapServerError } from "@/lib/errors/serverErrorMapper";
 import {
-  Wallet,
-  Mail,
-  Lock,
-  User,
-  Eye,
-  EyeOff,
-  CheckCircle2,
-  ChevronRight,
-  AlertCircle,
+  Wallet, Mail, Lock, User, Eye, EyeOff,
+  CheckCircle2, ChevronRight, AlertCircle,
 } from "lucide-react";
+import { useState } from "react";
 
 type RegisterMode = "wallet" | "email";
 
@@ -29,31 +26,28 @@ export default function RegisterPage() {
   const router = useRouter();
   const { t, locale } = useTranslation();
 
-  // Stellar wallet
   const {
-    connected,
-    address,
-    provider,
-    connecting,
-    error: walletError,
-    disconnect,
-    clearError: clearWalletError,
+    connected, address, provider, connecting,
+    error: walletError, disconnect, clearError: clearWalletError,
   } = useStellarWallet();
 
-  // Form state
   const [mode, setMode] = useState<RegisterMode>("wallet");
   const [walletModalOpen, setWalletModalOpen] = useState(false);
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
+  const [walletUsername, setWalletUsername] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+  const [walletLoading, setWalletLoading] = useState(false);
+  const [walletError2, setWalletError2] = useState("");
   const [success, setSuccess] = useState("");
 
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterFormData>({ resolver: zodResolver(registerSchema) });
+
   const clearAllErrors = () => {
-    setError("");
+    setWalletError2("");
     clearWalletError();
   };
 
@@ -65,32 +59,25 @@ export default function RegisterPage() {
   /* ── Wallet registration ── */
   const handleWalletRegister = async () => {
     if (!address) {
-      setError("Please connect your Stellar wallet first");
+      setWalletError2("Please connect your Stellar wallet first");
       return;
     }
     clearAllErrors();
-    setLoading(true);
-
+    setWalletLoading(true);
     try {
-      // Fetch CSRF token
-      const csrfRes = await fetch(`${API_CONFIG.baseUrl}/auth/csrf-token`, {
-        credentials: "include",
-      });
+      const csrfRes = await fetch(`${API_CONFIG.baseUrl}/auth/csrf-token`, { credentials: "include" });
       if (!csrfRes.ok) throw new Error("Failed to fetch CSRF token");
       const { csrfToken } = await csrfRes.json();
 
       const body: Record<string, string> = { walletAddress: address };
-      if (username.trim()) body.username = username.trim();
+      if (walletUsername.trim()) body.username = walletUsername.trim();
       if (provider) body.walletProvider = provider;
       body.network = defaultNetwork;
 
       const response = await fetch(`${API_CONFIG.baseUrl}/users`, {
         method: "POST",
         credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CSRF-Token": csrfToken,
-        },
+        headers: { "Content-Type": "application/json", "X-CSRF-Token": csrfToken },
         body: JSON.stringify(body),
       });
 
@@ -102,41 +89,22 @@ export default function RegisterPage() {
       setSuccess(t("register.success") || "Account created! Redirecting to login…");
       setTimeout(() => router.push(`/${locale}/auth/login`), 2500);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Registration failed. Please try again."
-      );
+      setWalletError2(err instanceof Error ? err.message : "Registration failed. Please try again.");
     } finally {
-      setLoading(false);
+      setWalletLoading(false);
     }
   };
 
   /* ── Email registration ── */
-  const handleEmailRegister = async () => {
-    if (!email || !password) {
-      setError("Please fill in all required fields");
-      return;
-    }
-    if (password !== confirmPassword) {
-      setError("Passwords do not match");
-      return;
-    }
-    if (password.length < 8) {
-      setError("Password must be at least 8 characters");
-      return;
-    }
+  const onEmailSubmit = async (data: RegisterFormData) => {
     clearAllErrors();
-    setLoading(true);
-
     try {
-      const csrfRes = await fetch(`${API_CONFIG.baseUrl}/auth/csrf-token`, {
-        credentials: "include",
-      });
+      const csrfRes = await fetch(`${API_CONFIG.baseUrl}/auth/csrf-token`, { credentials: "include" });
       if (!csrfRes.ok) throw new Error("Failed to fetch CSRF token");
       const { csrfToken } = await csrfRes.json();
 
-      const body: Record<string, string> = { email, password };
-      if (username.trim()) body.username = username.trim();
-      // Optionally link wallet if already connected
+      const body: Record<string, string> = { email: data.email, password: data.password };
+      if (data.username?.trim()) body.username = data.username.trim();
       if (connected && address) {
         body.walletAddress = address;
         if (provider) body.walletProvider = provider;
@@ -145,33 +113,35 @@ export default function RegisterPage() {
       const response = await fetch(`${API_CONFIG.baseUrl}/auth/register`, {
         method: "POST",
         credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CSRF-Token": csrfToken,
-        },
+        headers: { "Content-Type": "application/json", "X-CSRF-Token": csrfToken },
         body: JSON.stringify(body),
       });
 
       if (!response.ok) {
         const errData = await response.json().catch(() => ({}));
-        throw new Error(errData.message || "Registration failed");
+        const { fieldErrors, formError } = mapServerError(errData);
+        if (Object.keys(fieldErrors).length > 0) {
+          for (const [field, msg] of Object.entries(fieldErrors)) {
+            setError(field as keyof RegisterFormData, { message: msg });
+          }
+        } else {
+          setError("root", { message: formError });
+        }
+        return;
       }
 
       setSuccess(t("register.success") || "Account created! Redirecting to login…");
       setTimeout(() => router.push(`/${locale}/auth/login`), 2500);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Registration failed.");
-    } finally {
-      setLoading(false);
+      setError("root", { message: err instanceof Error ? err.message : "Registration failed." });
     }
   };
 
-  const displayError = error || walletError;
+  const displayWalletError = walletError2 || walletError;
 
   return (
     <div className="min-h-[500px] text-white">
       <CircuitBackground />
-
       <div className="relative z-10 pb-16 px-4">
         <div className="max-w-md mx-auto">
           <div className="border border-purple-500/20 rounded-xl p-8 bg-glass backdrop-blur-md shadow-lg">
@@ -179,13 +149,6 @@ export default function RegisterPage() {
             <h2 className="text-3xl font-bold mb-6 text-center bg-clip-text text-transparent bg-gradient-to-r from-white to-purple-200">
               {t("register.title") || "Create Account"}
             </h2>
-
-            {displayError && (
-              <div className="mb-4 flex items-start gap-2 p-3 bg-red-900/50 text-red-300 rounded-lg border border-red-500/30 text-sm">
-                <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                {displayError}
-              </div>
-            )}
 
             {success && (
               <div className="mb-4 flex items-center gap-2 p-3 bg-green-900/50 text-green-300 rounded-lg border border-green-500/30 text-sm">
@@ -199,9 +162,7 @@ export default function RegisterPage() {
               <button
                 onClick={() => switchMode("wallet")}
                 className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${
-                  mode === "wallet"
-                    ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow"
-                    : "text-gray-400 hover:text-white"
+                  mode === "wallet" ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow" : "text-gray-400 hover:text-white"
                 }`}
               >
                 <Wallet className="h-4 w-4" />
@@ -210,9 +171,7 @@ export default function RegisterPage() {
               <button
                 onClick={() => switchMode("email")}
                 className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${
-                  mode === "email"
-                    ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow"
-                    : "text-gray-400 hover:text-white"
+                  mode === "email" ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow" : "text-gray-400 hover:text-white"
                 }`}
               >
                 <Mail className="h-4 w-4" />
@@ -220,33 +179,36 @@ export default function RegisterPage() {
               </button>
             </div>
 
-            {/* Shared: username field */}
-            <div className="mb-5">
-              <label className="block text-sm font-medium mb-2 text-gray-300">
-                {t("register.userName") || "Username"}{" "}
-                <span className="text-gray-500 font-normal">(optional)</span>
-              </label>
-              <div className="relative">
-                <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
-                <Input
-                  type="text"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  placeholder={t("register.inputPlaceholderTwo") || "Choose a username"}
-                  className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
-                  maxLength={50}
-                />
-              </div>
-            </div>
-
-            {/* ── WALLET MODE ── */}
+            {/* WALLET MODE */}
             {mode === "wallet" && (
               <div className="space-y-5">
+                {displayWalletError && (
+                  <div className="flex items-start gap-2 p-3 bg-red-900/50 text-red-300 rounded-lg border border-red-500/30 text-sm">
+                    <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                    {displayWalletError}
+                  </div>
+                )}
+                <div className="mb-5">
+                  <label className="block text-sm font-medium mb-2 text-gray-300">
+                    {t("register.userName") || "Username"}{" "}
+                    <span className="text-gray-500 font-normal">(optional)</span>
+                  </label>
+                  <div className="relative">
+                    <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                    <Input
+                      type="text"
+                      value={walletUsername}
+                      onChange={(e) => setWalletUsername(e.target.value)}
+                      placeholder={t("register.inputPlaceholderTwo") || "Choose a username"}
+                      className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      maxLength={50}
+                    />
+                  </div>
+                </div>
                 <div>
                   <label className="block text-sm font-medium mb-2 text-gray-300">
                     {t("register.walletAddress") || "Stellar Wallet Address"}
                   </label>
-
                   {connected && address ? (
                     <div className="flex items-center justify-between w-full bg-gray-800/50 border border-green-500/30 rounded-lg px-4 py-3">
                       <div className="flex items-center gap-2 min-w-0">
@@ -257,50 +219,63 @@ export default function RegisterPage() {
                       </div>
                       <div className="flex items-center gap-2 ml-2 flex-shrink-0">
                         <WalletNetworkStatus network={defaultNetwork} />
-                        <button
-                          onClick={disconnect}
-                          className="text-xs text-red-400 hover:text-red-300 transition-colors"
-                        >
+                        <button onClick={disconnect} className="text-xs text-red-400 hover:text-red-300 transition-colors">
                           Change
                         </button>
                       </div>
                     </div>
                   ) : (
                     <Input
-                      type="text"
-                      value=""
-                      readOnly
+                      type="text" value="" readOnly
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg px-4 py-3 text-sm"
                       placeholder={t("register.inputPlaceholderOne") || "Connect wallet to populate"}
                     />
                   )}
                 </div>
-
                 <Button
                   onClick={connected ? handleWalletRegister : () => setWalletModalOpen(true)}
-                  disabled={loading || connecting}
+                  disabled={walletLoading || connecting}
                   className="w-full py-3 px-4 rounded-lg font-medium transition bg-gradient-to-r from-[#4e3bff] to-[#9747ff] hover:opacity-90 flex items-center justify-center gap-2"
                 >
                   <Wallet className="h-4 w-4" />
-                  {loading
-                    ? t("register.creatingAccount") || "Creating account…"
-                    : connecting
-                    ? t("register.connecting") || "Connecting…"
-                    : connected
-                    ? t("register.completeRegistration") || "Complete Registration"
+                  {walletLoading ? t("register.creatingAccount") || "Creating account…"
+                    : connecting ? t("register.connecting") || "Connecting…"
+                    : connected ? t("register.completeRegistration") || "Complete Registration"
                     : t("register.connectWallet") || "Connect Wallet"}
                 </Button>
-
                 <p className="text-xs text-gray-500 text-center">
-                  {t("register.stellarSecure") ||
-                    "Your Stellar public key is used as your account identifier. Your private key never leaves your wallet."}
+                  {t("register.stellarSecure") || "Your Stellar public key is used as your account identifier. Your private key never leaves your wallet."}
                 </p>
               </div>
             )}
 
-            {/* ── EMAIL MODE ── */}
+            {/* EMAIL MODE */}
             {mode === "email" && (
-              <div className="space-y-4">
+              <form onSubmit={handleSubmit(onEmailSubmit)} className="space-y-4" noValidate>
+                {errors.root && (
+                  <div className="flex items-start gap-2 p-3 bg-red-900/50 text-red-300 rounded-lg border border-red-500/30 text-sm">
+                    <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                    {errors.root.message}
+                  </div>
+                )}
+
+                <div>
+                  <label className="block text-sm font-medium mb-2 text-gray-300">
+                    {t("register.userName") || "Username"}{" "}
+                    <span className="text-gray-500 font-normal">(optional)</span>
+                  </label>
+                  <div className="relative">
+                    <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                    <Input
+                      type="text"
+                      placeholder={t("register.inputPlaceholderTwo") || "Choose a username"}
+                      className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      maxLength={50}
+                      {...register("username")}
+                    />
+                  </div>
+                </div>
+
                 <div>
                   <label className="block text-sm font-medium mb-2 text-gray-300">
                     {t("register.email") || "Email"}
@@ -309,12 +284,12 @@ export default function RegisterPage() {
                     <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
                       placeholder="you@example.com"
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      {...register("email")}
                     />
                   </div>
+                  {errors.email && <p className="mt-1 text-xs text-red-400">{errors.email.message}</p>}
                 </div>
 
                 <div>
@@ -325,10 +300,9 @@ export default function RegisterPage() {
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type={showPassword ? "text" : "password"}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
                       placeholder="Min. 8 characters"
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-10 py-3 text-sm"
+                      {...register("password")}
                     />
                     <button
                       type="button"
@@ -338,6 +312,7 @@ export default function RegisterPage() {
                       {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                     </button>
                   </div>
+                  {errors.password && <p className="mt-1 text-xs text-red-400">{errors.password.message}</p>}
                 </div>
 
                 <div>
@@ -348,15 +323,14 @@ export default function RegisterPage() {
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type={showPassword ? "text" : "password"}
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
                       placeholder="Repeat password"
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      {...register("confirmPassword")}
                     />
                   </div>
+                  {errors.confirmPassword && <p className="mt-1 text-xs text-red-400">{errors.confirmPassword.message}</p>}
                 </div>
 
-                {/* Optional wallet link for email users */}
                 {connected && address && (
                   <div className="flex items-center gap-2 p-3 rounded-lg bg-purple-500/10 border border-purple-500/20 text-sm text-purple-300">
                     <CheckCircle2 className="h-4 w-4 flex-shrink-0 text-green-400" />
@@ -366,6 +340,7 @@ export default function RegisterPage() {
 
                 {!connected && (
                   <button
+                    type="button"
                     onClick={() => setWalletModalOpen(true)}
                     className="w-full text-sm text-purple-400 hover:text-purple-300 flex items-center justify-center gap-1 py-2 transition-colors"
                   >
@@ -376,23 +351,20 @@ export default function RegisterPage() {
                 )}
 
                 <Button
-                  onClick={handleEmailRegister}
-                  disabled={loading}
+                  type="submit"
+                  disabled={isSubmitting}
                   className="w-full py-3 px-4 rounded-lg font-medium transition bg-gradient-to-r from-[#4e3bff] to-[#9747ff] hover:opacity-90"
                 >
-                  {loading
+                  {isSubmitting
                     ? t("register.creatingAccount") || "Creating account…"
                     : t("register.completeRegistration") || "Complete Registration"}
                 </Button>
-              </div>
+              </form>
             )}
 
             <div className="mt-6 text-center text-sm text-gray-400">
               {t("register.alreadyHave") || "Already have an account?"}{" "}
-              <a
-                href={`/${locale}/auth/login`}
-                className="text-purple-400 hover:text-purple-300"
-              >
+              <a href={`/${locale}/auth/login`} className="text-purple-400 hover:text-purple-300">
                 {t("register.signIn") || "Sign in"}
               </a>
             </div>
@@ -400,10 +372,7 @@ export default function RegisterPage() {
         </div>
       </div>
 
-      <WalletModal
-        open={walletModalOpen}
-        onClose={() => setWalletModalOpen(false)}
-      />
+      <WalletModal open={walletModalOpen} onClose={() => setWalletModalOpen(false)} />
     </div>
   );
 }

--- a/nftopia-frontend/features/auth/store/authStore.ts
+++ b/nftopia-frontend/features/auth/store/authStore.ts
@@ -58,6 +58,29 @@ export const useAuthStore = create<AuthStore>()(
           ) => {
             throw new Error("Not implemented");
           },
+          register: async (_email: string, _password: string, _username?: string) => {
+            throw new Error("Not implemented");
+          },
+          emailLogin: async (_email: string, _password: string) => {
+            throw new Error("Not implemented");
+          },
+          getWalletChallenge: async (_walletAddress: string, _walletProvider?: string) => {
+            throw new Error("Not implemented");
+          },
+          verifyWalletSignature: async (_walletAddress: string, _nonce: string, _signature: string, _walletProvider?: string) => {
+            throw new Error("Not implemented");
+          },
+          linkWallet: async (_walletAddress: string, _nonce: string, _signature: string, _walletProvider?: string) => {
+            throw new Error("Not implemented");
+          },
+          unlinkWallet: async (_walletAddress: string) => {
+            throw new Error("Not implemented");
+          },
+          listWallets: async () => {
+            throw new Error("Not implemented");
+          },
+          isAccessTokenExpired: () => true,
+          getCurrentUser: () => null,
           logout: async () => {
             throw new Error("Not implemented");
           },

--- a/nftopia-frontend/lib/context/AuthContext.tsx
+++ b/nftopia-frontend/lib/context/AuthContext.tsx
@@ -39,7 +39,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   // Load wallets on user change
   useEffect(() => {
     if (auth.user) {
-      auth.listWallets().then(setWallets).catch(() => setWallets([]));
+      auth.listWallets().then((w) => setWallets(w as UserWallet[])).catch(() => setWallets([]));
     } else {
       setWallets([]);
     }
@@ -78,7 +78,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const unlinkWallet = async (address: string) => {
     await auth.unlinkWallet(address);
-    setWallets(await auth.listWallets() || []);
+    setWallets((await auth.listWallets() as UserWallet[]) || []);
   };
 
   const value: AuthContextType = {

--- a/nftopia-frontend/lib/errors/serverErrorMapper.ts
+++ b/nftopia-frontend/lib/errors/serverErrorMapper.ts
@@ -1,0 +1,38 @@
+type FieldErrors = Record<string, string>;
+
+interface MappedError {
+  fieldErrors: FieldErrors;
+  formError: string;
+}
+
+interface ServerErrorPayload {
+  errors?: Record<string, string | string[]>;
+  message?: string;
+  error?: string;
+}
+
+export function mapServerError(err: unknown): MappedError {
+  const fieldErrors: FieldErrors = {};
+  let formError = "Something went wrong. Please try again.";
+
+  if (!err || typeof err !== "object") return { fieldErrors, formError };
+
+  const payload = err as ServerErrorPayload;
+
+  // Known shape: { errors: { fieldName: "message" | ["message"] } }
+  if (payload.errors && typeof payload.errors === "object") {
+    for (const [field, msg] of Object.entries(payload.errors)) {
+      fieldErrors[field] = Array.isArray(msg) ? msg[0] : msg;
+    }
+    return { fieldErrors, formError: "" };
+  }
+
+  // Single string message
+  if (typeof payload.message === "string") {
+    formError = payload.message;
+  } else if (typeof payload.error === "string") {
+    formError = payload.error;
+  }
+
+  return { fieldErrors, formError };
+}

--- a/nftopia-frontend/lib/stores/types.ts
+++ b/nftopia-frontend/lib/stores/types.ts
@@ -37,20 +37,40 @@ export type AuthStore = {
   error: string | null;
   accessToken: string | null;
   refreshTokenValue: string | null;
+
+  // Setters
   setUser: (user: User | null) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   clearError: () => void;
+
+  // Email auth
+  register: (email: string, password: string, username?: string) => Promise<void>;
+  emailLogin: (email: string, password: string) => Promise<void>;
+
+  // Wallet auth
+  getWalletChallenge: (walletAddress: string, walletProvider?: string) => Promise<unknown>;
+  verifyWalletSignature: (walletAddress: string, nonce: string, signature: string, walletProvider?: string) => Promise<void>;
+  linkWallet: (walletAddress: string, nonce: string, signature: string, walletProvider?: string) => Promise<unknown>;
+  unlinkWallet: (walletAddress: string) => Promise<unknown>;
+  listWallets: () => Promise<unknown>;
+
+  // Legacy Starknet methods (kept for backward compat)
   requestNonce: (walletAddress: string) => Promise<string>;
   verifySignature: (
     walletAddress: string,
-    signature: [string, string], // Changed from string to [string, string]
+    signature: [string, string],
     nonce: string,
     walletType: 'argentx' | 'braavos',
     locale: string
   ) => Promise<void>;
-  logout: () => Promise<void>;
+
+  // Token / session
   refreshToken: () => Promise<string>;
+  isAccessTokenExpired: () => boolean;
+  getCurrentUser: () => User | null;
+
+  logout: () => Promise<void>;
 };
 
 // Collection Store Types

--- a/nftopia-frontend/lib/validation/auth.ts
+++ b/nftopia-frontend/lib/validation/auth.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(1, "Password is required"),
+});
+
+export const registerSchema = z
+  .object({
+    username: z.string().optional(),
+    email: z.string().email("Invalid email address"),
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type LoginFormData = z.infer<typeof loginSchema>;
+export type RegisterFormData = z.infer<typeof registerSchema>;

--- a/nftopia-frontend/package-lock.json
+++ b/nftopia-frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@albedo-link/intent": "^0.13.0",
         "@apollo/client": "^3.14.0",
+        "@hookform/resolvers": "^5.4.0",
         "@lottiefiles/dotlottie-react": "^0.14.4",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.7",
@@ -40,14 +41,15 @@
         "postcss": "8.4.30",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-hook-form": "^7.76.1",
         "react-loading-skeleton": "^3.5.0",
         "shadcn-ui": "^0.9.5",
         "tailwind-merge": "^3.0.2",
         "tailwindcss": "3.3.3",
         "tailwindcss-animate": "^1.0.7",
         "use-sound": "^5.0.0",
-        "utf-8-validate": "5.0.10",
         "uuid": "^11.1.0",
+        "zod": "^4.4.3",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -4811,6 +4813,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -6757,6 +6771,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@stellar/freighter-api": {
       "version": "6.0.1",
@@ -10321,6 +10341,16 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/ci-info": {
@@ -19198,6 +19228,22 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.76.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.1.tgz",
+      "integrity": "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -22949,7 +22995,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -23108,10 +23154,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/nftopia-frontend/package.json
+++ b/nftopia-frontend/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@albedo-link/intent": "^0.13.0",
     "@apollo/client": "^3.14.0",
+    "@hookform/resolvers": "^5.4.0",
     "@lottiefiles/dotlottie-react": "^0.14.4",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.7",
@@ -49,6 +50,7 @@
     "postcss": "8.4.30",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.76.1",
     "react-loading-skeleton": "^3.5.0",
     "shadcn-ui": "^0.9.5",
     "tailwind-merge": "^3.0.2",
@@ -56,6 +58,7 @@
     "tailwindcss-animate": "^1.0.7",
     "use-sound": "^5.0.0",
     "uuid": "^11.1.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Closes #227

## Changes
- Added \`lib/validation/auth.ts\` — Zod schemas for login and register forms
- Added \`lib/errors/serverErrorMapper.ts\` — maps backend errors to field/form-level messages
- Refactored \`login/page.tsx\` — replaced raw useState with React Hook Form + Zod
- Refactored \`register/page.tsx\` — same treatment, wallet flow untouched
- Added 12 passing tests across validation and error mapping

## Out of scope
Creator dashboard forms (create-collection, mint-nft, settings) — separate PR" \
  --head feat/unified-form-validation \
  --repo NFTopia-Foundation/nftopia-stellar