### PR TITLE
Feature/247 contract level rate limiting

### DIFF
--- a/nftopia-stellar/contracts/marketplace_settlement/src/events.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/events.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Vec};
+use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Vec,Symbol};
 
 // Sale Events
 #[contracttype]
@@ -212,6 +212,16 @@ pub struct FrontRunningDetectedEvent {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitExceededEvent {
+    pub caller: Address,
+    pub function: Symbol,
+    pub window_seconds: u64,
+    pub limit: u32,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EmergencyWithdrawalEvent {
     pub transaction_id: u64,
     pub reason: Bytes,
@@ -355,6 +365,12 @@ pub fn emit_reentrancy_detected(env: &Env, event: ReentrancyDetectedEvent) {
 pub fn emit_front_running_detected(env: &Env, event: FrontRunningDetectedEvent) {
     env.events()
         .publish(("MarketplaceSettlement", symbol_short!("frontrun")), event);
+}
+
+#[allow(deprecated)]
+pub fn emit_rate_limit_exceeded(env: &Env, event: RateLimitExceededEvent) {
+    env.events()
+        .publish(("MarketplaceSettlement", symbol_short!("rt_limit")), event);
 }
 
 #[allow(deprecated)]

--- a/nftopia-stellar/contracts/marketplace_settlement/src/events.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/events.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Vec,Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Symbol, Vec};
 
 // Sale Events
 #[contracttype]

--- a/nftopia-stellar/contracts/marketplace_settlement/src/security/mod.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/security/mod.rs
@@ -1,2 +1,3 @@
 pub mod frontrun_protection;
+pub mod rate_limiter;
 pub mod reentrancy_guard;

--- a/nftopia-stellar/contracts/marketplace_settlement/src/security/rate_limiter.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/security/rate_limiter.rs
@@ -27,8 +27,9 @@ pub struct RateLimiter;
 impl RateLimiter {
     pub fn get_config(env: &Env, function: &Symbol) -> Option<RateLimitConfig> {
         let key = RateLimitStorageKey::Config(function.clone());
-        if let Some(config) = env.storage().instance().get(&key) {
-            Some(config)
+        
+        if env.storage().instance().has(&key) {
+            env.storage().instance().get(&key)
         } else {
             // Return defaults if not configured
             let place_bid_sym = Symbol::new(env, "place_bid");
@@ -82,17 +83,16 @@ impl RateLimiter {
         let key = RateLimitStorageKey::State(caller.clone(), function.clone());
         let current_time = env.ledger().timestamp();
 
-        let mut state = env
-            .storage()
-            .persistent()
-            .get::<_, RateLimitState>(&key)
-            .unwrap_or(RateLimitState {
+        let has_key = env.storage().persistent().has(&key);
+        
+        let mut state = if has_key {
+            env.storage().persistent().get::<_, RateLimitState>(&key).unwrap()
+        } else {
+            RateLimitState {
                 window_start: current_time,
                 count: 0,
-            });
-
-        // Extend TTL on read
-        env.storage().persistent().extend_ttl(&key, 1000, 5000);
+            }
+        };
 
         if current_time >= state.window_start + config.window_seconds {
             // Reset window
@@ -104,7 +104,6 @@ impl RateLimiter {
         } else {
             // Within same window
             if state.count >= config.limit {
-                // Emit rate limit exceeded event
                 let event = crate::events::RateLimitExceededEvent {
                     caller: caller.clone(),
                     function: function.clone(),

--- a/nftopia-stellar/contracts/marketplace_settlement/src/security/rate_limiter.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/security/rate_limiter.rs
@@ -1,0 +1,125 @@
+use crate::error::SettlementError;
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitConfig {
+    pub limit: u32,
+    pub window_seconds: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitState {
+    pub window_start: u64,
+    pub count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RateLimitStorageKey {
+    State(Address, Symbol),
+    Config(Symbol),
+}
+
+pub struct RateLimiter;
+
+impl RateLimiter {
+    pub fn get_config(env: &Env, function: &Symbol) -> Option<RateLimitConfig> {
+        let key = RateLimitStorageKey::Config(function.clone());
+        if let Some(config) = env.storage().instance().get(&key) {
+            Some(config)
+        } else {
+            // Return defaults if not configured
+            let place_bid_sym = Symbol::new(env, "place_bid");
+            let reveal_bid_sym = Symbol::new(env, "reveal_bid");
+            let create_auction_sym = Symbol::new(env, "create_auction");
+            let create_sale_sym = Symbol::new(env, "create_sale");
+            let create_trade_sym = Symbol::new(env, "create_trade");
+            let accept_trade_sym = Symbol::new(env, "accept_trade");
+            let execute_trade_sym = Symbol::new(env, "execute_trade");
+
+            if function == &place_bid_sym || function == &reveal_bid_sym {
+                Some(RateLimitConfig {
+                    limit: 5,
+                    window_seconds: 60,
+                })
+            } else if function == &create_auction_sym
+                || function == &create_sale_sym
+                || function == &create_trade_sym
+                || function == &accept_trade_sym
+                || function == &execute_trade_sym
+            {
+                Some(RateLimitConfig {
+                    limit: 10,
+                    window_seconds: 60,
+                })
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn set_config(env: &Env, function: &Symbol, limit: u32, window_seconds: u64) {
+        let key = RateLimitStorageKey::Config(function.clone());
+        let config = RateLimitConfig {
+            limit,
+            window_seconds,
+        };
+        env.storage().instance().set(&key, &config);
+    }
+
+    pub fn check_rate_limit(
+        env: &Env,
+        caller: &Address,
+        function: &Symbol,
+    ) -> Result<(), SettlementError> {
+        let config = match Self::get_config(env, function) {
+            Some(cfg) => cfg,
+            None => return Ok(()),
+        };
+
+        let key = RateLimitStorageKey::State(caller.clone(), function.clone());
+        let current_time = env.ledger().timestamp();
+
+        let mut state = env
+            .storage()
+            .persistent()
+            .get::<_, RateLimitState>(&key)
+            .unwrap_or(RateLimitState {
+                window_start: current_time,
+                count: 0,
+            });
+
+        // Extend TTL on read
+        env.storage().persistent().extend_ttl(&key, 1000, 5000);
+
+        if current_time >= state.window_start + config.window_seconds {
+            // Reset window
+            state.window_start = current_time;
+            state.count = 1;
+            env.storage().persistent().set(&key, &state);
+            env.storage().persistent().extend_ttl(&key, 1000, 5000);
+            Ok(())
+        } else {
+            // Within same window
+            if state.count >= config.limit {
+                // Emit rate limit exceeded event
+                let event = crate::events::RateLimitExceededEvent {
+                    caller: caller.clone(),
+                    function: function.clone(),
+                    window_seconds: config.window_seconds,
+                    limit: config.limit,
+                    timestamp: current_time,
+                };
+                crate::events::emit_rate_limit_exceeded(env, event);
+                Err(SettlementError::CooldownActive)
+            } else {
+                state.count += 1;
+                env.storage().persistent().set(&key, &state);
+                env.storage().persistent().extend_ttl(&key, 1000, 5000);
+                Ok(())
+            }
+        }
+    }
+}

--- a/nftopia-stellar/contracts/marketplace_settlement/src/security/rate_limiter.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/security/rate_limiter.rs
@@ -27,7 +27,7 @@ pub struct RateLimiter;
 impl RateLimiter {
     pub fn get_config(env: &Env, function: &Symbol) -> Option<RateLimitConfig> {
         let key = RateLimitStorageKey::Config(function.clone());
-        
+
         if env.storage().instance().has(&key) {
             env.storage().instance().get(&key)
         } else {
@@ -84,9 +84,12 @@ impl RateLimiter {
         let current_time = env.ledger().timestamp();
 
         let has_key = env.storage().persistent().has(&key);
-        
+
         let mut state = if has_key {
-            env.storage().persistent().get::<_, RateLimitState>(&key).unwrap()
+            env.storage()
+                .persistent()
+                .get::<_, RateLimitState>(&key)
+                .unwrap()
         } else {
             RateLimitState {
                 window_start: current_time,

--- a/nftopia-stellar/contracts/marketplace_settlement/src/settlement_core.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/settlement_core.rs
@@ -87,6 +87,12 @@ impl MarketplaceSettlement {
         duration_seconds: u64,
     ) -> Result<u64, SettlementError> {
         ReentrancyGuard::execute(&env, &seller, "create_sale", || {
+            crate::security::rate_limiter::RateLimiter::check_rate_limit(
+                &env,
+                &seller,
+                &Symbol::new(&env, "create_sale"),
+            )?;
+
             // Validate inputs
             asset_utils::validate_asset(&currency, &Vec::new(&env), &env)?;
             asset_utils::validate_nft_contract(&nft_address, &env)?;
@@ -217,6 +223,12 @@ impl MarketplaceSettlement {
         currency: Asset,
     ) -> Result<u64, SettlementError> {
         ReentrancyGuard::execute(&env, &seller, "create_auction", || {
+            crate::security::rate_limiter::RateLimiter::check_rate_limit(
+                &env,
+                &seller,
+                &Symbol::new(&env, "create_auction"),
+            )?;
+
             AuctionEngine::create_auction(
                 &env,
                 auction_type,
@@ -241,6 +253,12 @@ impl MarketplaceSettlement {
         commitment_hash: Option<Bytes>,
     ) -> Result<(), SettlementError> {
         ReentrancyGuard::execute(&env, &bidder, "place_bid", || {
+            crate::security::rate_limiter::RateLimiter::check_rate_limit(
+                &env,
+                &bidder,
+                &Symbol::new(&env, "place_bid"),
+            )?;
+
             AuctionEngine::place_bid(&env, auction_id, &bidder, bid_amount, commitment_hash)
         })
     }
@@ -254,6 +272,12 @@ impl MarketplaceSettlement {
         salt: Bytes,
     ) -> Result<(), SettlementError> {
         ReentrancyGuard::execute(&env, &bidder, "reveal_bid", || {
+            crate::security::rate_limiter::RateLimiter::check_rate_limit(
+                &env,
+                &bidder,
+                &Symbol::new(&env, "reveal_bid"),
+            )?;
+
             AuctionEngine::reveal_bid(&env, auction_id, &bidder, bid_amount, &salt)
         })
     }
@@ -275,6 +299,12 @@ impl MarketplaceSettlement {
         duration_seconds: u64,
     ) -> Result<u64, SettlementError> {
         ReentrancyGuard::execute(&env, &initiator, "create_trade", || {
+            crate::security::rate_limiter::RateLimiter::check_rate_limit(
+                &env,
+                &initiator,
+                &Symbol::new(&env, "create_trade"),
+            )?;
+
             // Validate trade parameters
             if initiator_nfts.is_empty() {
                 return Err(SettlementError::InvalidAmount);
@@ -302,6 +332,12 @@ impl MarketplaceSettlement {
     /// Accept a trade
     pub fn accept_trade(env: Env, trade_id: u64, acceptor: Address) -> Result<(), SettlementError> {
         ReentrancyGuard::execute(&env, &acceptor.clone(), "accept_trade", || {
+            crate::security::rate_limiter::RateLimiter::check_rate_limit(
+                &env,
+                &acceptor,
+                &Symbol::new(&env, "accept_trade"),
+            )?;
+
             let mut trade = TradeTransactionStore::get(&env, trade_id)?;
 
             if trade.state != crate::types::TransactionState::Pending {
@@ -327,6 +363,12 @@ impl MarketplaceSettlement {
         executor: Address,
     ) -> Result<(), SettlementError> {
         ReentrancyGuard::execute(&env, &executor, "execute_trade", || {
+            crate::security::rate_limiter::RateLimiter::check_rate_limit(
+                &env,
+                &executor,
+                &Symbol::new(&env, "execute_trade"),
+            )?;
+
             let mut trade = TradeTransactionStore::get(&env, trade_id)?;
 
             if trade.state != crate::types::TransactionState::Funded {
@@ -508,6 +550,37 @@ impl MarketplaceSettlement {
         }
 
         FeeManager::withdraw_platform_fees(&env, &asset, &recipient, &admin)
+    }
+
+    /// Update rate limit configuration for a specific function (admin only)
+    pub fn update_rate_limit(
+        env: Env,
+        function: Symbol,
+        limit: u32,
+        window_seconds: u64,
+        admin: Address,
+    ) -> Result<(), SettlementError> {
+        // Check admin permissions
+        let admin_config: AdminConfig = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin_cfg"))
+            .ok_or(SettlementError::Unauthorized)?;
+
+        if admin_config.admin != admin {
+            return Err(SettlementError::Unauthorized);
+        }
+
+        crate::security::rate_limiter::RateLimiter::set_config(&env, &function, limit, window_seconds);
+        Ok(())
+    }
+
+    /// Get rate limit configuration for a specific function
+    pub fn get_rate_limit_config(
+        env: Env,
+        function: Symbol,
+    ) -> Option<crate::security::rate_limiter::RateLimitConfig> {
+        crate::security::rate_limiter::RateLimiter::get_config(&env, &function)
     }
 
     /// Get transaction details

--- a/nftopia-stellar/contracts/marketplace_settlement/src/settlement_core.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/settlement_core.rs
@@ -571,7 +571,12 @@ impl MarketplaceSettlement {
             return Err(SettlementError::Unauthorized);
         }
 
-        crate::security::rate_limiter::RateLimiter::set_config(&env, &function, limit, window_seconds);
+        crate::security::rate_limiter::RateLimiter::set_config(
+            &env,
+            &function,
+            limit,
+            window_seconds,
+        );
         Ok(())
     }
 

--- a/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, Symbol};
-
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Bytes, Env, Symbol,
+};
 use crate::{
     error::SettlementError,
     royalty_distributor::RoyaltyDistributor,
@@ -267,7 +269,7 @@ fn test_get_nonexistent_auction_fails() {
 #[test]
 fn test_update_fee_config_by_admin() {
     use crate::types::FeeConfig;
-    let (env, _cid, client) = new_env();
+    let (env, _cid, _client) = new_env();
     let admin = Address::generate(&env);
     let cfg = FeeConfig {
         platform_fee_bps: 300,
@@ -475,4 +477,188 @@ fn test_reveal_wrong_salt_fails() {
 fn test_cleanup_expired_commitments() {
     let (_env, _cid, client) = new_env();
     client.cleanup_expired_commitments();
+}
+
+// ─── Rate Limiter ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_rate_limiter_defaults_and_cooldown_active() {
+    let (env, cid, client) = new_env();
+    let seller = Address::generate(&env);
+    let nft = Address::generate(&env);
+    let creator = Address::generate(&env);
+    reg(&env, &cid, &nft, &creator);
+
+    // Default rate limit for create_sale is 10 calls / 60s
+    // Make 10 calls successfully
+    for _ in 0..10 {
+        let _id = client.create_sale(
+            &seller,
+            &nft,
+            &1u64,
+            &1_000_000i128,
+            &mk_asset(&env),
+            &86400u64,
+        );
+    }
+
+    // The 11th call must fail with CooldownActive
+    let res = client.try_create_sale(
+        &seller,
+        &nft,
+        &1u64,
+        &1_000_000i128,
+        &mk_asset(&env),
+        &86400u64,
+    );
+    assert_eq!(res.unwrap().unwrap_err(), SettlementError::CooldownActive.into());
+}
+
+#[test]
+fn test_rate_limiter_independent_users_and_functions() {
+    let (env, cid, client) = new_env();
+    let seller_1 = Address::generate(&env);
+    let seller_2 = Address::generate(&env);
+    let nft = Address::generate(&env);
+    let creator = Address::generate(&env);
+    reg(&env, &cid, &nft, &creator);
+
+    // seller_1 spams create_sale until throttled (10 calls)
+    for _ in 0..10 {
+        let _id = client.create_sale(
+            &seller_1,
+            &nft,
+            &1u64,
+            &1_000_000i128,
+            &mk_asset(&env),
+            &86400u64,
+        );
+    }
+    // seller_1 is blocked
+    assert_eq!(
+        client.try_create_sale(&seller_1, &nft, &1u64, &1_000_000i128, &mk_asset(&env), &86400u64).unwrap().unwrap_err(),
+        SettlementError::CooldownActive.into()
+    );
+
+    // seller_2 should NOT be blocked (independent budgets)
+    let id_2 = client.create_sale(
+        &seller_2,
+        &nft,
+        &1u64,
+        &1_000_000i128,
+        &mk_asset(&env),
+        &86400u64,
+    );
+    assert_eq!(id_2, 11u64);
+
+    // seller_1 can still create_auction (independent functions)
+    let auc_id = client.create_auction(
+        &seller_1,
+        &nft,
+        &1u64,
+        &100_000i128,
+        &80_000i128,
+        &3600u64,
+        &1_000i128,
+        &AuctionType::English,
+        &mk_asset(&env),
+    );
+    assert_eq!(auc_id, 1u64);
+}
+
+#[test]
+fn test_rate_limiter_window_reset() {
+    let (env, cid, client) = new_env();
+    let seller = Address::generate(&env);
+    let nft = Address::generate(&env);
+    let creator = Address::generate(&env);
+    reg(&env, &cid, &nft, &creator);
+
+    // Spam create_sale (10 calls)
+    for _ in 0..10 {
+        let _id = client.create_sale(
+            &seller,
+            &nft,
+            &1u64,
+            &1_000_000i128,
+            &mk_asset(&env),
+            &86400u64,
+        );
+    }
+    // Blocked
+    assert_eq!(
+        client.try_create_sale(&seller, &nft, &1u64, &1_000_000i128, &mk_asset(&env), &86400u64).unwrap().unwrap_err(),
+        SettlementError::CooldownActive.into()
+    );
+
+    // Move ledger time forward by 60 seconds (window duration is 60s)
+    let new_timestamp = env.ledger().timestamp() + 60;
+    env.ledger().set_timestamp(new_timestamp);
+
+    // Now it should succeed again!
+    let id = client.create_sale(
+        &seller,
+        &nft,
+        &1u64,
+        &1_000_000i128,
+        &mk_asset(&env),
+        &86400u64,
+    );
+    assert!(id > 0);
+}
+
+#[test]
+fn test_rate_limiter_admin_update_config() {
+    let (env, _cid, _client) = new_env();
+    let admin = Address::generate(&env);
+    
+    // Setup known admin (using second client initialized with admin)
+    let cid2 = env.register(MarketplaceSettlement, ());
+    let c2 = MarketplaceSettlementClient::new(&env, &cid2);
+    c2.initialize(&admin);
+
+    let bidder = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let nft = Address::generate(&env);
+    let creator = Address::generate(&env);
+    reg(&env, &cid2, &nft, &creator);
+
+    let id = c2.create_auction(
+        &seller,
+        &nft,
+        &1u64,
+        &100_000i128,
+        &80_000i128,
+        &3600u64,
+        &1_000i128,
+        &AuctionType::English,
+        &mk_asset(&env),
+    );
+
+    // Default rate limit for place_bid is 5 calls / 60s
+    // Admin updates limit to 2 calls / 30s
+    let place_bid_sym = Symbol::new(&env, "place_bid");
+    c2.update_rate_limit(&place_bid_sym, &2u32, &30u64, &admin);
+
+    // Retrieve config to verify update
+    let config_opt = c2.get_rate_limit_config(&place_bid_sym);
+    assert!(config_opt.is_some());
+    let cfg = config_opt.unwrap();
+    assert_eq!(cfg.limit, 2u32);
+    assert_eq!(cfg.window_seconds, 30u64);
+
+   // place 2 bids successfully
+    c2.place_bid(&id, &bidder, &110_000i128, &None);
+    c2.place_bid(&id, &bidder, &120_000i128, &None);
+
+    // 3rd bid should fail under new configuration
+    let res = c2.try_place_bid(&id, &bidder, &130_000i128, &None);
+   
+    if let Ok(Err(invoke_error)) = res {
+        let actual_error: soroban_sdk::Error = invoke_error.into();
+        let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
+        assert_eq!(actual_error, expected_error);
+    } else {
+        panic!("Expected a contract invocation error (InvokeError), but got: {:?}", res);
+    }
 }

--- a/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
@@ -489,8 +489,6 @@ fn test_rate_limiter_defaults_and_cooldown_active() {
     let creator = Address::generate(&env);
     reg(&env, &cid, &nft, &creator);
 
-    // Default rate limit for create_sale is 10 calls / 60s
-    // Make 10 calls successfully
     for _ in 0..10 {
         let _id = client.create_sale(
             &seller,
@@ -511,7 +509,14 @@ fn test_rate_limiter_defaults_and_cooldown_active() {
         &mk_asset(&env),
         &86400u64,
     );
-    assert_eq!(res.unwrap().unwrap_err(), SettlementError::CooldownActive.into());
+    
+    if let Ok(Err(invoke_error)) = res {
+        let actual_error: soroban_sdk::Error = invoke_error.into();
+        let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
+        assert_eq!(actual_error, expected_error);
+    } else {
+       panic!("Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}", res);
+    }
 }
 
 #[test]
@@ -523,7 +528,6 @@ fn test_rate_limiter_independent_users_and_functions() {
     let creator = Address::generate(&env);
     reg(&env, &cid, &nft, &creator);
 
-    // seller_1 spams create_sale until throttled (10 calls)
     for _ in 0..10 {
         let _id = client.create_sale(
             &seller_1,
@@ -534,13 +538,17 @@ fn test_rate_limiter_independent_users_and_functions() {
             &86400u64,
         );
     }
-    // seller_1 is blocked
-    assert_eq!(
-        client.try_create_sale(&seller_1, &nft, &1u64, &1_000_000i128, &mk_asset(&env), &86400u64).unwrap().unwrap_err(),
-        SettlementError::CooldownActive.into()
-    );
+    
+    let res = client.try_create_sale(&seller_1, &nft, &1u64, &1_000_000i128, &mk_asset(&env), &86400u64);
+    if let Ok(Err(invoke_error)) = res {
+        let actual_error: soroban_sdk::Error = invoke_error.into();
+        let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
+        assert_eq!(actual_error, expected_error);
+    } else {
+        panic!("Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}", res);
+    }
 
-    // seller_2 should NOT be blocked (independent budgets)
+    // seller_2 should NOT be blocked
     let id_2 = client.create_sale(
         &seller_2,
         &nft,
@@ -549,9 +557,9 @@ fn test_rate_limiter_independent_users_and_functions() {
         &mk_asset(&env),
         &86400u64,
     );
-    assert_eq!(id_2, 11u64);
+    assert!(id_2 > 0);
 
-    // seller_1 can still create_auction (independent functions)
+    // seller_1 can still create_auction
     let auc_id = client.create_auction(
         &seller_1,
         &nft,
@@ -563,7 +571,7 @@ fn test_rate_limiter_independent_users_and_functions() {
         &AuctionType::English,
         &mk_asset(&env),
     );
-    assert_eq!(auc_id, 1u64);
+    assert!(auc_id > 0);
 }
 
 #[test]
@@ -574,7 +582,6 @@ fn test_rate_limiter_window_reset() {
     let creator = Address::generate(&env);
     reg(&env, &cid, &nft, &creator);
 
-    // Spam create_sale (10 calls)
     for _ in 0..10 {
         let _id = client.create_sale(
             &seller,
@@ -585,14 +592,18 @@ fn test_rate_limiter_window_reset() {
             &86400u64,
         );
     }
-    // Blocked
-    assert_eq!(
-        client.try_create_sale(&seller, &nft, &1u64, &1_000_000i128, &mk_asset(&env), &86400u64).unwrap().unwrap_err(),
-        SettlementError::CooldownActive.into()
-    );
+    
+    let res = client.try_create_sale(&seller, &nft, &1u64, &1_000_000i128, &mk_asset(&env), &86400u64);
+    if let Ok(Err(invoke_error)) = res {
+        let actual_error: soroban_sdk::Error = invoke_error.into();
+        let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
+        assert_eq!(actual_error, expected_error);
+    } else {
+       panic!("Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}", res);
+    }
 
-    // Move ledger time forward by 60 seconds (window duration is 60s)
-    let new_timestamp = env.ledger().timestamp() + 60;
+    // Move ledger time forward by 60 seconds
+    let new_timestamp = env.ledger().timestamp() + 61;
     env.ledger().set_timestamp(new_timestamp);
 
     // Now it should succeed again!
@@ -659,6 +670,6 @@ fn test_rate_limiter_admin_update_config() {
         let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
         assert_eq!(actual_error, expected_error);
     } else {
-        panic!("Expected a contract invocation error (InvokeError), but got: {:?}", res);
+      panic!("Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}", res);
     }
 }

--- a/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
@@ -1,14 +1,14 @@
 #![cfg(test)]
 
-use soroban_sdk::{
-    testutils::{Address as _, Ledger as _},
-    Address, Bytes, Env, Symbol,
-};
 use crate::{
     error::SettlementError,
     royalty_distributor::RoyaltyDistributor,
     settlement_core::{MarketplaceSettlement, MarketplaceSettlementClient},
     types::{Asset, AuctionType},
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Bytes, Env, Symbol,
 };
 
 fn mk_asset(env: &Env) -> Asset {
@@ -509,13 +509,16 @@ fn test_rate_limiter_defaults_and_cooldown_active() {
         &mk_asset(&env),
         &86400u64,
     );
-    
+
     if let Ok(Err(invoke_error)) = res {
         let actual_error: soroban_sdk::Error = invoke_error.into();
         let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
         assert_eq!(actual_error, expected_error);
     } else {
-       panic!("Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}", res);
+        panic!(
+            "Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}",
+            res
+        );
     }
 }
 
@@ -538,14 +541,24 @@ fn test_rate_limiter_independent_users_and_functions() {
             &86400u64,
         );
     }
-    
-    let res = client.try_create_sale(&seller_1, &nft, &1u64, &1_000_000i128, &mk_asset(&env), &86400u64);
+
+    let res = client.try_create_sale(
+        &seller_1,
+        &nft,
+        &1u64,
+        &1_000_000i128,
+        &mk_asset(&env),
+        &86400u64,
+    );
     if let Ok(Err(invoke_error)) = res {
         let actual_error: soroban_sdk::Error = invoke_error.into();
         let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
         assert_eq!(actual_error, expected_error);
     } else {
-        panic!("Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}", res);
+        panic!(
+            "Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}",
+            res
+        );
     }
 
     // seller_2 should NOT be blocked
@@ -592,14 +605,24 @@ fn test_rate_limiter_window_reset() {
             &86400u64,
         );
     }
-    
-    let res = client.try_create_sale(&seller, &nft, &1u64, &1_000_000i128, &mk_asset(&env), &86400u64);
+
+    let res = client.try_create_sale(
+        &seller,
+        &nft,
+        &1u64,
+        &1_000_000i128,
+        &mk_asset(&env),
+        &86400u64,
+    );
     if let Ok(Err(invoke_error)) = res {
         let actual_error: soroban_sdk::Error = invoke_error.into();
         let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
         assert_eq!(actual_error, expected_error);
     } else {
-       panic!("Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}", res);
+        panic!(
+            "Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}",
+            res
+        );
     }
 
     // Move ledger time forward by 60 seconds
@@ -622,7 +645,7 @@ fn test_rate_limiter_window_reset() {
 fn test_rate_limiter_admin_update_config() {
     let (env, _cid, _client) = new_env();
     let admin = Address::generate(&env);
-    
+
     // Setup known admin (using second client initialized with admin)
     let cid2 = env.register(MarketplaceSettlement, ());
     let c2 = MarketplaceSettlementClient::new(&env, &cid2);
@@ -658,18 +681,21 @@ fn test_rate_limiter_admin_update_config() {
     assert_eq!(cfg.limit, 2u32);
     assert_eq!(cfg.window_seconds, 30u64);
 
-   // place 2 bids successfully
+    // place 2 bids successfully
     c2.place_bid(&id, &bidder, &110_000i128, &None);
     c2.place_bid(&id, &bidder, &120_000i128, &None);
 
     // 3rd bid should fail under new configuration
     let res = c2.try_place_bid(&id, &bidder, &130_000i128, &None);
-   
+
     if let Ok(Err(invoke_error)) = res {
         let actual_error: soroban_sdk::Error = invoke_error.into();
         let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
         assert_eq!(actual_error, expected_error);
     } else {
-      panic!("Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}", res);
+        panic!(
+            "Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}",
+            res
+        );
     }
 }

--- a/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
@@ -510,15 +510,11 @@ fn test_rate_limiter_defaults_and_cooldown_active() {
         &86400u64,
     );
 
-    if let Ok(Err(invoke_error)) = res {
-        let actual_error: soroban_sdk::Error = invoke_error.into();
-        let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
-        assert_eq!(actual_error, expected_error);
+    if let Err(Ok(invoke_error)) = res {
+        let actual_error: SettlementError = invoke_error.into();
+        assert_eq!(actual_error, SettlementError::CooldownActive);
     } else {
-        panic!(
-            "Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}",
-            res
-        );
+        panic!("Expected Err(Ok(CooldownActive)), got: {:?}", res);
     }
 }
 
@@ -550,15 +546,12 @@ fn test_rate_limiter_independent_users_and_functions() {
         &mk_asset(&env),
         &86400u64,
     );
-    if let Ok(Err(invoke_error)) = res {
-        let actual_error: soroban_sdk::Error = invoke_error.into();
-        let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
-        assert_eq!(actual_error, expected_error);
+
+    if let Err(Ok(invoke_error)) = res {
+        let actual_error: SettlementError = invoke_error.into();
+        assert_eq!(actual_error, SettlementError::CooldownActive);
     } else {
-        panic!(
-            "Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}",
-            res
-        );
+        panic!("Expected Err(Ok(CooldownActive)), got: {:?}", res);
     }
 
     // seller_2 should NOT be blocked
@@ -614,15 +607,12 @@ fn test_rate_limiter_window_reset() {
         &mk_asset(&env),
         &86400u64,
     );
-    if let Ok(Err(invoke_error)) = res {
-        let actual_error: soroban_sdk::Error = invoke_error.into();
-        let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
-        assert_eq!(actual_error, expected_error);
+
+    if let Err(Ok(invoke_error)) = res {
+        let actual_error: SettlementError = invoke_error.into();
+        assert_eq!(actual_error, SettlementError::CooldownActive);
     } else {
-        panic!(
-            "Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}",
-            res
-        );
+        panic!("Expected Err(Ok(CooldownActive)), got: {:?}", res);
     }
 
     // Move ledger time forward by 60 seconds
@@ -688,14 +678,10 @@ fn test_rate_limiter_admin_update_config() {
     // 3rd bid should fail under new configuration
     let res = c2.try_place_bid(&id, &bidder, &130_000i128, &None);
 
-    if let Ok(Err(invoke_error)) = res {
-        let actual_error: soroban_sdk::Error = invoke_error.into();
-        let expected_error: soroban_sdk::Error = SettlementError::CooldownActive.into();
-        assert_eq!(actual_error, expected_error);
+    if let Err(Ok(invoke_error)) = res {
+        let actual_error: SettlementError = invoke_error.into();
+        assert_eq!(actual_error, SettlementError::CooldownActive);
     } else {
-        panic!(
-            "Expected Err(Ok(SettlementError::CooldownActive)), got: {:?}",
-            res
-        );
+        panic!("Expected Err(Ok(CooldownActive)), got: {:?}", res);
     }
 }

--- a/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
@@ -32,10 +32,18 @@ impl MockNft {
             .set(&soroban_sdk::Symbol::new(&env, "owner"), &owner);
     }
     pub fn owner_of(env: Env, _id: u64) -> Address {
-        env.storage()
+        if env
+            .storage()
             .instance()
-            .get(&soroban_sdk::Symbol::new(&env, "owner"))
-            .unwrap_or_else(|| Address::generate(&env))
+            .has(&soroban_sdk::Symbol::new(&env, "owner"))
+        {
+            env.storage()
+                .instance()
+                .get(&soroban_sdk::Symbol::new(&env, "owner"))
+                .unwrap()
+        } else {
+            Address::generate(&env)
+        }
     }
     pub fn transfer(_env: Env, _from: Address, _to: Address, _token_id: u64) {}
 }
@@ -291,7 +299,7 @@ fn test_get_nonexistent_auction_fails() {
 #[test]
 fn test_update_fee_config_by_admin() {
     use crate::types::FeeConfig;
-    let (env, _cid, _client) = new_env();
+    let (env, _cid, _client, _admin) = new_env();
     let admin = Address::generate(&env);
     let cfg = FeeConfig {
         platform_fee_bps: 300,
@@ -517,32 +525,20 @@ fn test_cleanup_expired_commitments() {
 
 #[test]
 fn test_rate_limiter_defaults_and_cooldown_active() {
-    let (env, cid, client) = new_env();
+    let (env, cid, client, admin) = new_env();
+    let asset = mk_asset(&env);
     let seller = Address::generate(&env);
-    let nft = Address::generate(&env);
+    let nft = env.register(MockNft, ());
     let creator = Address::generate(&env);
-    reg(&env, &cid, &nft, &creator);
+    reg(&env, &cid, &nft, &creator, &admin, &asset);
+    MockNftClient::new(&env, &nft).set_owner(&seller);
 
     for _ in 0..10 {
-        let _id = client.create_sale(
-            &seller,
-            &nft,
-            &1u64,
-            &1_000_000i128,
-            &mk_asset(&env),
-            &86400u64,
-        );
+        let _id = client.create_sale(&seller, &nft, &1u64, &1_000_000i128, &asset, &86400u64);
     }
 
     // The 11th call must fail with CooldownActive
-    let res = client.try_create_sale(
-        &seller,
-        &nft,
-        &1u64,
-        &1_000_000i128,
-        &mk_asset(&env),
-        &86400u64,
-    );
+    let res = client.try_create_sale(&seller, &nft, &1u64, &1_000_000i128, &asset, &86400u64);
 
     if let Err(Ok(invoke_error)) = res {
         let actual_error: SettlementError = invoke_error.into();
@@ -554,32 +550,20 @@ fn test_rate_limiter_defaults_and_cooldown_active() {
 
 #[test]
 fn test_rate_limiter_independent_users_and_functions() {
-    let (env, cid, client) = new_env();
+    let (env, cid, client, admin) = new_env();
+    let asset = mk_asset(&env);
     let seller_1 = Address::generate(&env);
     let seller_2 = Address::generate(&env);
-    let nft = Address::generate(&env);
+    let nft = env.register(MockNft, ());
     let creator = Address::generate(&env);
-    reg(&env, &cid, &nft, &creator);
+    reg(&env, &cid, &nft, &creator, &admin, &asset);
+    MockNftClient::new(&env, &nft).set_owner(&seller_1);
 
     for _ in 0..10 {
-        let _id = client.create_sale(
-            &seller_1,
-            &nft,
-            &1u64,
-            &1_000_000i128,
-            &mk_asset(&env),
-            &86400u64,
-        );
+        let _id = client.create_sale(&seller_1, &nft, &1u64, &1_000_000i128, &asset, &86400u64);
     }
 
-    let res = client.try_create_sale(
-        &seller_1,
-        &nft,
-        &1u64,
-        &1_000_000i128,
-        &mk_asset(&env),
-        &86400u64,
-    );
+    let res = client.try_create_sale(&seller_1, &nft, &1u64, &1_000_000i128, &asset, &86400u64);
 
     if let Err(Ok(invoke_error)) = res {
         let actual_error: SettlementError = invoke_error.into();
@@ -589,14 +573,8 @@ fn test_rate_limiter_independent_users_and_functions() {
     }
 
     // seller_2 should NOT be blocked
-    let id_2 = client.create_sale(
-        &seller_2,
-        &nft,
-        &1u64,
-        &1_000_000i128,
-        &mk_asset(&env),
-        &86400u64,
-    );
+    MockNftClient::new(&env, &nft).set_owner(&seller_2);
+    let id_2 = client.create_sale(&seller_2, &nft, &1u64, &1_000_000i128, &asset, &86400u64);
     assert!(id_2 > 0);
 
     // seller_1 can still create_auction
@@ -609,38 +587,26 @@ fn test_rate_limiter_independent_users_and_functions() {
         &3600u64,
         &1_000i128,
         &AuctionType::English,
-        &mk_asset(&env),
+        &asset,
     );
     assert!(auc_id > 0);
 }
 
 #[test]
 fn test_rate_limiter_window_reset() {
-    let (env, cid, client) = new_env();
+    let (env, cid, client, admin) = new_env();
+    let asset = mk_asset(&env);
     let seller = Address::generate(&env);
-    let nft = Address::generate(&env);
+    let nft = env.register(MockNft, ());
     let creator = Address::generate(&env);
-    reg(&env, &cid, &nft, &creator);
+    reg(&env, &cid, &nft, &creator, &admin, &asset);
+    MockNftClient::new(&env, &nft).set_owner(&seller);
 
     for _ in 0..10 {
-        let _id = client.create_sale(
-            &seller,
-            &nft,
-            &1u64,
-            &1_000_000i128,
-            &mk_asset(&env),
-            &86400u64,
-        );
+        let _id = client.create_sale(&seller, &nft, &1u64, &1_000_000i128, &asset, &86400u64);
     }
 
-    let res = client.try_create_sale(
-        &seller,
-        &nft,
-        &1u64,
-        &1_000_000i128,
-        &mk_asset(&env),
-        &86400u64,
-    );
+    let res = client.try_create_sale(&seller, &nft, &1u64, &1_000_000i128, &asset, &86400u64);
 
     if let Err(Ok(invoke_error)) = res {
         let actual_error: SettlementError = invoke_error.into();
@@ -654,21 +620,15 @@ fn test_rate_limiter_window_reset() {
     env.ledger().set_timestamp(new_timestamp);
 
     // Now it should succeed again!
-    let id = client.create_sale(
-        &seller,
-        &nft,
-        &1u64,
-        &1_000_000i128,
-        &mk_asset(&env),
-        &86400u64,
-    );
+    let id = client.create_sale(&seller, &nft, &1u64, &1_000_000i128, &asset, &86400u64);
     assert!(id > 0);
 }
 
 #[test]
 fn test_rate_limiter_admin_update_config() {
-    let (env, _cid, _client) = new_env();
+    let (env, _cid, _client, _admin) = new_env();
     let admin = Address::generate(&env);
+    let asset = mk_asset(&env);
 
     // Setup known admin (using second client initialized with admin)
     let cid2 = env.register(MarketplaceSettlement, ());
@@ -679,7 +639,7 @@ fn test_rate_limiter_admin_update_config() {
     let seller = Address::generate(&env);
     let nft = Address::generate(&env);
     let creator = Address::generate(&env);
-    reg(&env, &cid2, &nft, &creator);
+    reg(&env, &cid2, &nft, &creator, &admin, &asset);
 
     let id = c2.create_auction(
         &seller,
@@ -690,7 +650,7 @@ fn test_rate_limiter_admin_update_config() {
         &3600u64,
         &1_000i128,
         &AuctionType::English,
-        &mk_asset(&env),
+        &asset,
     );
 
     // Default rate limit for place_bid is 5 calls / 60s


### PR DESCRIPTION
This PR implements Issue #247 , introducing robust on-chain per-address rate limiting to protect high-frequency write paths (place_bid, reveal_bid, create_auction, create_sale, create_trade) from automated spam attacks, mitigating unnecessary ledger state inflation and compute exhaustion.

Closes #247 