### PR TITLE
Implement real sales analytics with timeframe filtering

### DIFF
--- a/nftopia-backend/src/graphql/resolvers/order.resolver.spec.ts
+++ b/nftopia-backend/src/graphql/resolvers/order.resolver.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { OrderResolver } from './order.resolver';
 import { OrderService } from '../../modules/order/order.service';
 import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
+import { BadRequestException } from '@nestjs/common';
 import type { Request, Response } from 'express';
 
 describe('OrderResolver', () => {
@@ -127,14 +128,40 @@ describe('OrderResolver', () => {
   });
 
   describe('salesAnalytics', () => {
-    it('should fetch sales analytics', async () => {
+    it('should fetch sales analytics with valid timeframe', async () => {
       const mockStats = { volume: '100', count: 5, averagePrice: '20' };
-      (service.getSalesAnalytics as jest.Mock).mockReturnValue(mockStats);
+      (service.getSalesAnalytics as jest.Mock).mockResolvedValue(mockStats);
       const timeframe = { periodStart: '2024-01-01', periodEnd: '2024-01-31' };
       const result = await resolver.salesAnalytics(timeframe);
       expect(result.totalVolume).toBe('100');
       expect(result.totalSales).toBe(5);
       expect(result.averagePrice).toBe('20');
+      expect(service.getSalesAnalytics).toHaveBeenCalledWith(
+        new Date('2024-01-01'),
+        new Date('2024-01-31'),
+      );
+    });
+
+    it('should throw BadRequestException for invalid timeframe (end < start)', async () => {
+      const timeframe = { periodStart: '2024-01-31', periodEnd: '2024-01-01' };
+      await expect(resolver.salesAnalytics(timeframe)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(resolver.salesAnalytics(timeframe)).rejects.toThrow(
+        'Invalid timeframe: periodEnd must be after periodStart',
+      );
+    });
+
+    it('should accept timeframe with equal start and end dates', async () => {
+      const mockStats = { volume: '50', count: 1, averagePrice: '50' };
+      (service.getSalesAnalytics as jest.Mock).mockResolvedValue(mockStats);
+      const timeframe = { periodStart: '2024-01-01', periodEnd: '2024-01-01' };
+      const result = await resolver.salesAnalytics(timeframe);
+      expect(result.totalVolume).toBe('50');
+      expect(service.getSalesAnalytics).toHaveBeenCalledWith(
+        new Date('2024-01-01'),
+        new Date('2024-01-01'),
+      );
     });
   });
 });

--- a/nftopia-backend/src/graphql/resolvers/order.resolver.ts
+++ b/nftopia-backend/src/graphql/resolvers/order.resolver.ts
@@ -116,19 +116,32 @@ export class OrderResolver {
     description: 'Fetch sales analytics (admin only)',
   })
   @UseGuards(GqlAuthGuard)
-  salesAnalytics(
+  async salesAnalytics(
     @Args('timeframe', { type: () => TimeframeInput })
     timeframe: TimeframeInput,
   ): Promise<SalesAnalytics> {
     // TODO: Implement admin check using a real user lookup if needed
-    const stats = this.orderService.getSalesAnalytics();
-    return Promise.resolve({
+    const periodStart = new Date(timeframe.periodStart);
+    const periodEnd = new Date(timeframe.periodEnd);
+
+    // Validate timeframe
+    if (periodEnd < periodStart) {
+      throw new BadRequestException(
+        'Invalid timeframe: periodEnd must be after periodStart',
+      );
+    }
+
+    const stats = await this.orderService.getSalesAnalytics(
+      periodStart,
+      periodEnd,
+    );
+    return {
       totalVolume: stats.volume,
       totalSales: stats.count,
       averagePrice: stats.averagePrice,
-      periodStart: new Date(timeframe.periodStart),
-      periodEnd: new Date(timeframe.periodEnd),
-    });
+      periodStart,
+      periodEnd,
+    };
   }
 
   @ResolveField(() => GraphqlUserType, {

--- a/nftopia-backend/src/modules/order/order.service.spec.ts
+++ b/nftopia-backend/src/modules/order/order.service.spec.ts
@@ -5,9 +5,11 @@ import { ConfigService } from '@nestjs/config';
 import { OrderService } from './order.service';
 import { Order } from './entities/order.entity';
 import { MarketplaceSettlementClient } from '../stellar/marketplace-settlement.client';
+import { OrderType, OrderStatus } from './dto/create-order.dto';
 
 describe('OrderService', () => {
   let service: OrderService;
+  let orderRepository: jest.Mocked<Repository<Order>>;
 
   beforeEach(async () => {
     const mockConfigService = {
@@ -17,12 +19,17 @@ describe('OrderService', () => {
       createTrade: jest.fn(),
       createBundle: jest.fn(),
     };
+
+    const mockRepository = {
+      createQueryBuilder: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OrderService,
         {
           provide: getRepositoryToken(Order),
-          useClass: Repository,
+          useValue: mockRepository,
         },
         {
           provide: ConfigService,
@@ -36,9 +43,129 @@ describe('OrderService', () => {
     }).compile();
 
     service = module.get<OrderService>(OrderService);
+    orderRepository = module.get(getRepositoryToken(Order));
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getSalesAnalytics', () => {
+    it('should return analytics for completed sales within timeframe', async () => {
+      const periodStart = new Date('2024-01-01');
+      const periodEnd = new Date('2024-12-31');
+
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({
+          volume: '1000.50',
+          count: '10',
+          averagePrice: '100.05',
+        }),
+      };
+
+      orderRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getSalesAnalytics(periodStart, periodEnd);
+
+      expect(result).toEqual({
+        volume: '1000.50',
+        count: 10,
+        averagePrice: '100.05',
+      });
+
+      expect(orderRepository.createQueryBuilder).toHaveBeenCalledWith('order');
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('order.type = :type', {
+        type: OrderType.SALE,
+      });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'order.status = :status',
+        { status: OrderStatus.COMPLETED },
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'order.createdAt BETWEEN :periodStart AND :periodEnd',
+        { periodStart, periodEnd },
+      );
+    });
+
+    it('should return zero values when no orders match criteria', async () => {
+      const periodStart = new Date('2024-01-01');
+      const periodEnd = new Date('2024-12-31');
+
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue(null),
+      };
+
+      orderRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getSalesAnalytics(periodStart, periodEnd);
+
+      expect(result).toEqual({
+        volume: '0',
+        count: 0,
+        averagePrice: '0',
+      });
+    });
+
+    it('should handle null values from database', async () => {
+      const periodStart = new Date('2024-01-01');
+      const periodEnd = new Date('2024-12-31');
+
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({
+          volume: null,
+          count: null,
+          averagePrice: null,
+        }),
+      };
+
+      orderRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getSalesAnalytics(periodStart, periodEnd);
+
+      expect(result).toEqual({
+        volume: '0',
+        count: 0,
+        averagePrice: '0',
+      });
+    });
+
+    it('should filter only SALE type and COMPLETED status', async () => {
+      const periodStart = new Date('2024-01-01');
+      const periodEnd = new Date('2024-12-31');
+
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({
+          volume: '500.00',
+          count: '5',
+          averagePrice: '100.00',
+        }),
+      };
+
+      orderRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder as any);
+
+      await service.getSalesAnalytics(periodStart, periodEnd);
+
+      const whereCalls = mockQueryBuilder.where.mock.calls;
+      const andWhereCalls = mockQueryBuilder.andWhere.mock.calls;
+
+      expect(whereCalls[0]).toEqual(['order.type = :type', { type: OrderType.SALE }]);
+      expect(andWhereCalls[0]).toEqual(['order.status = :status', { status: OrderStatus.COMPLETED }]);
+    });
   });
 });

--- a/nftopia-backend/src/modules/order/order.service.ts
+++ b/nftopia-backend/src/modules/order/order.service.ts
@@ -137,13 +137,33 @@ export class OrderService {
     };
   }
 
-  // Placeholder for sales analytics
-  getSalesAnalytics() {
-    // TODO: Implement real analytics logic
+  async getSalesAnalytics(periodStart: Date, periodEnd: Date): Promise<{
+    volume: string;
+    count: number;
+    averagePrice: string;
+  }> {
+    const qb = this.orderRepository
+      .createQueryBuilder('order')
+      .select('SUM(order.price)', 'volume')
+      .addSelect('COUNT(order.id)', 'count')
+      .addSelect('AVG(order.price)', 'averagePrice')
+      .where('order.type = :type', { type: OrderType.SALE })
+      .andWhere('order.status = :status', { status: OrderStatus.COMPLETED })
+      .andWhere('order.createdAt BETWEEN :periodStart AND :periodEnd', {
+        periodStart,
+        periodEnd,
+      });
+
+    const stats = ((await qb.getRawOne()) as {
+      volume: string | null;
+      count: string | null;
+      averagePrice: string | null;
+    }) || { volume: '0', count: '0', averagePrice: '0' };
+
     return {
-      volume: '0',
-      count: 0,
-      averagePrice: '0',
+      volume: stats.volume ?? '0',
+      count: Number(stats.count ?? 0),
+      averagePrice: stats.averagePrice ?? '0',
     };
   }
 }


### PR DESCRIPTION
Closes #252

---

- Update getSalesAnalytics() to accept periodStart and periodEnd parameters
- Make getSalesAnalytics() async and implement DB query with filters
- Filter to completed sales only (type=SALE, status=COMPLETED)
- Apply timeframe bounds using createdAt BETWEEN periodStart AND periodEnd
- Return zero-safe values when no matching rows
- Update GraphQL resolver to pass timeframe dates into service
- Add validation for invalid timeframe (end < start) with BadRequestException
- Add comprehensive unit tests for service and resolver
- Tests cover: normal window, empty window, invalid window, null values