### PR TITLE
Fix creator profile and wallet auth integration

### DIFF
--- a/nftopia-frontend/__tests__/profile-page-integration.test.tsx
+++ b/nftopia-frontend/__tests__/profile-page-integration.test.tsx
@@ -1,0 +1,67 @@
+import { updateMyProfile } from "@/lib/services/profile";
+import { fetchWithAuth } from "@/lib/api/fetchWithAuth";
+
+jest.mock("@/lib/api/fetchWithAuth", () => ({
+  fetchWithAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/config", () => ({
+  API_CONFIG: {
+    baseUrl: "http://localhost:3000/api/v1",
+  },
+}));
+
+const mockFetchWithAuth = fetchWithAuth as jest.MockedFunction<typeof fetchWithAuth>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe("profile update integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("persists profile edits through PATCH /users/me with wallet header", async () => {
+    mockFetchWithAuth.mockResolvedValueOnce(
+      jsonResponse({
+          id: "user-1",
+          username: "stellarbuilder",
+          website: "https://mysite.com",
+        })
+    );
+
+    await updateMyProfile("GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ234", {
+      username: " stellarbuilder ",
+      bio: "NFT creator on Stellar",
+      avatarUrl: "",
+      bannerUrl: undefined,
+      twitterHandle: "@handle",
+      instagramHandle: "@handle",
+      website: "https://mysite.com",
+    });
+
+    expect(mockFetchWithAuth).toHaveBeenCalledWith(
+      "http://localhost:3000/api/v1/users/me",
+      expect.objectContaining({
+        method: "PATCH",
+        credentials: "include",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-wallet-address": "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ234",
+        }),
+        body: JSON.stringify({
+          username: "stellarbuilder",
+          bio: "NFT creator on Stellar",
+          twitterHandle: "@handle",
+          instagramHandle: "@handle",
+          website: "https://mysite.com",
+        }),
+      })
+    );
+  });
+});

--- a/nftopia-frontend/__tests__/wallet-link-flow.test.tsx
+++ b/nftopia-frontend/__tests__/wallet-link-flow.test.tsx
@@ -1,0 +1,134 @@
+import {
+  fetchLinkedWallets,
+  linkWalletWithChallenge,
+  unlinkWallet,
+} from "@/lib/services/profile";
+import { fetchWithAuth } from "@/lib/api/fetchWithAuth";
+import { signMessage } from "@stellar/freighter-api";
+
+jest.mock("@/lib/api/fetchWithAuth", () => ({
+  fetchWithAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/config", () => ({
+  API_CONFIG: {
+    baseUrl: "http://localhost:3000/api/v1",
+  },
+}));
+
+jest.mock(
+  "@stellar/freighter-api",
+  () => ({
+    signMessage: jest.fn(),
+  }),
+  { virtual: true }
+);
+
+const mockFetchWithAuth = fetchWithAuth as jest.MockedFunction<typeof fetchWithAuth>;
+const mockSignMessage = signMessage as jest.MockedFunction<typeof signMessage>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe("wallet link flow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it("links wallet through challenge, signature, and authenticated link request", async () => {
+    const walletAddress = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ234";
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      jsonResponse({
+          sessionId: `nonce:${walletAddress}`,
+          walletAddress,
+          nonce: "nonce-12345678",
+          message: "NFTopia Wallet Authentication\nNonce: nonce-12345678",
+          expiresAt: "2026-05-28T12:00:00.000Z",
+        })
+    );
+    mockSignMessage.mockResolvedValueOnce({
+      signedMessage: "base64-signature",
+      signerAddress: walletAddress,
+    });
+    mockFetchWithAuth.mockResolvedValueOnce(
+      jsonResponse({
+          success: true,
+          wallet: {
+            id: "wallet-1",
+            walletAddress,
+            walletProvider: "freighter",
+            isPrimary: false,
+          },
+        })
+    );
+
+    await linkWalletWithChallenge(walletAddress, "freighter");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:3000/api/v1/auth/wallet/challenge",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ walletAddress, walletProvider: "freighter" }),
+      })
+    );
+    expect(mockSignMessage).toHaveBeenCalledWith(
+      "NFTopia Wallet Authentication\nNonce: nonce-12345678",
+      { address: walletAddress }
+    );
+    expect(mockFetchWithAuth).toHaveBeenCalledWith(
+      "http://localhost:3000/api/v1/auth/wallet/link",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          walletAddress,
+          nonce: "nonce-12345678",
+          signature: "base64-signature",
+          walletProvider: "freighter",
+        }),
+      })
+    );
+  });
+
+  it("fetches and unlinks wallets through authenticated backend contracts", async () => {
+    const walletAddress = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ234";
+
+    mockFetchWithAuth
+      .mockResolvedValueOnce(
+        jsonResponse([
+            {
+              id: "wallet-1",
+              walletAddress,
+              walletProvider: "freighter",
+              isPrimary: true,
+              createdAt: "2026-05-28T10:00:00.000Z",
+            },
+          ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true }));
+
+    const wallets = await fetchLinkedWallets();
+    await unlinkWallet(walletAddress);
+
+    expect(wallets).toHaveLength(1);
+    expect(mockFetchWithAuth).toHaveBeenNthCalledWith(
+      1,
+      "http://localhost:3000/api/v1/users/wallets",
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(mockFetchWithAuth).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:3000/api/v1/auth/wallet/unlink",
+      expect.objectContaining({
+        method: "DELETE",
+        body: JSON.stringify({ walletAddress }),
+      })
+    );
+  });
+});

--- a/nftopia-frontend/app/[locale]/creator-dashboard/profile/page.tsx
+++ b/nftopia-frontend/app/[locale]/creator-dashboard/profile/page.tsx
@@ -1,102 +1,236 @@
 "use client";
 
-import { useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
-  Wallet,
+  AlertCircle,
+  CheckCircle2,
+  ExternalLink,
   Link2,
   Link2Off,
-  ExternalLink,
-  CheckCircle2,
-  AlertCircle,
   Plus,
+  Wallet,
 } from "lucide-react";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useAuthStore } from "@/lib/stores/auth-store";
 import { useStellarWallet } from "@/components/wallet/hooks/useStellarWallet";
-import { useStellarAuth } from "@/components/wallet/hooks/useStellarAuth";
 import { WalletModal } from "@/components/wallet/WalletModal";
 import { WalletBalance } from "@/components/wallet/WalletBalance";
 import { WalletNetworkStatus } from "@/components/wallet/WalletNetworkStatus";
-import { linkWalletToAccount } from "@/lib/stellar/auth/signature";
 import { getExplorerUrl } from "@/lib/stellar/network";
-import { LinkedWallet } from "@/types/auth";
+import {
+  LinkedWallet,
+  ProfileUser,
+  UpdateProfilePayload,
+  fetchLinkedWallets,
+  fetchProfileByAddress,
+  linkWalletWithChallenge,
+  updateMyProfile,
+} from "@/lib/services/profile";
 
+type ProfileForm = Required<UpdateProfilePayload>;
+type FormErrors = Partial<Record<keyof ProfileForm, string>>;
 
-function useCurrentUser() {
-  return {
-    user: null as null | { id: string; email?: string; linkedWallets?: LinkedWallet[] },
-    token: typeof window !== "undefined" ? localStorage.getItem("auth_token") : null,
-  };
-}
+const emptyForm: ProfileForm = {
+  username: "",
+  bio: "",
+  avatarUrl: "",
+  bannerUrl: "",
+  twitterHandle: "",
+  instagramHandle: "",
+  website: "",
+};
 
 export default function ProfilePage() {
   const { t } = useTranslation();
-  const { user, token } = useCurrentUser();
-  const linkedWallets: LinkedWallet[] = user?.linkedWallets ?? [];
+  const authUser = useAuthStore((state) => state.user);
+  const setAuthUser = useAuthStore((state) => state.setUser);
+  const getCurrentUser = useAuthStore((state) => state.getCurrentUser);
 
   const {
     connected,
     address,
     provider,
     network,
-    connect,
     disconnect,
-    clearError,
   } = useStellarWallet();
 
-  const { authenticateWithWallet, loading: authLoading } = useStellarAuth();
-
+  const [profile, setProfile] = useState<ProfileUser | null>(null);
+  const [form, setForm] = useState<ProfileForm>(emptyForm);
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [wallets, setWallets] = useState<LinkedWallet[]>([]);
   const [walletModalOpen, setWalletModalOpen] = useState(false);
-  const [linkError, setLinkError] = useState<string | null>(null);
-  const [linkSuccess, setLinkSuccess] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
   const [linking, setLinking] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const profileAddress = authUser?.walletAddress || authUser?.address || address || "";
+  const saveWalletAddress = address || authUser?.walletAddress || authUser?.address || "";
+
+  useEffect(() => {
+    if (!authUser) {
+      const storedUser = getCurrentUser();
+      if (storedUser) {
+        setAuthUser(storedUser);
+      }
+    }
+  }, [authUser, getCurrentUser, setAuthUser]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadProfile() {
+      if (!profileAddress) {
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setMessage(null);
+
+      try {
+        const [nextProfile, nextWallets] = await Promise.all([
+          fetchProfileByAddress(profileAddress),
+          fetchLinkedWallets(),
+        ]);
+
+        if (!active) return;
+
+        setProfile(nextProfile);
+        setForm(toProfileForm(nextProfile));
+        setWallets(nextWallets);
+      } catch (error) {
+        if (active) {
+          setMessage({
+            type: "error",
+            text: error instanceof Error ? error.message : "Failed to load profile.",
+          });
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    loadProfile();
+    return () => {
+      active = false;
+    };
+  }, [profileAddress]);
+
+  const isAlreadyLinked = useMemo(
+    () => !!address && wallets.some((wallet) => wallet.walletAddress === address),
+    [address, wallets]
+  );
+
+  const handleChange = (field: keyof ProfileForm, value: string) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setFormErrors((current) => ({ ...current, [field]: undefined }));
+  };
+
+  const handleSaveProfile = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setMessage(null);
+
+    const errors = validateProfile(form);
+    setFormErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    if (!saveWalletAddress) {
+      setMessage({ type: "error", text: "Connect or authenticate a Stellar wallet before saving." });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const updated = await updateMyProfile(saveWalletAddress, form);
+      setProfile(updated);
+      setForm(toProfileForm(updated));
+      setAuthUser({
+        ...(authUser || {}),
+        ...updated,
+        walletAddress: updated.walletAddress || updated.address || saveWalletAddress,
+      } as NonNullable<typeof authUser>);
+      setMessage({ type: "success", text: "Profile saved successfully." });
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to save profile.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const handleLinkWallet = async () => {
-    if (!address || !provider || !token) {
-      setLinkError("Connect your wallet first, and make sure you are logged in.");
+    if (!address || !provider) {
+      setMessage({ type: "error", text: "Connect your wallet before linking it." });
       return;
     }
 
     setLinking(true);
-    setLinkError(null);
-    setLinkSuccess(null);
+    setMessage(null);
 
     try {
-      // 1. Auth-sign to prove ownership
-      const result = await authenticateWithWallet(address, provider);
-
-      // 2. Link to account
-      await linkWalletToAccount(
-        { publicKey: address, signature: "", nonce: "", provider },
-        token
-      );
-
-      setLinkSuccess(`Wallet ${address.slice(0, 6)}…${address.slice(-4)} linked successfully.`);
-    } catch (err) {
-      setLinkError(err instanceof Error ? err.message : "Failed to link wallet.");
+      await linkWalletWithChallenge(address, provider);
+      setWallets(await fetchLinkedWallets());
+      setMessage({
+        type: "success",
+        text: `Wallet ${shortAddress(address)} linked successfully.`,
+      });
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to link wallet.",
+      });
     } finally {
       setLinking(false);
     }
   };
 
-  const isAlreadyLinked = linkedWallets.some((w) => w.walletAddress === address);
-
   return (
-    <div className="p-6 lg:p-8 min-h-screen bg-background">
-      <div className="max-w-2xl mx-auto space-y-8">
-
-        {/* Header */}
-        <div>
+    <div className="min-h-screen bg-background p-6 lg:p-8">
+      <div className="mx-auto max-w-3xl space-y-8">
+        <header>
           <h1 className="text-3xl font-bold text-foreground">
             {t("profile.title") || "Profile"}
           </h1>
-          <p className="text-muted-foreground mt-1">
+          <p className="mt-1 text-muted-foreground">
             {t("profile.subtitle") || "Manage your account and linked wallets"}
           </p>
-        </div>
+        </header>
 
-        {/* Linked wallets section */}
-        <section className="bg-card border border-border rounded-xl p-6">
-          <div className="flex items-center justify-between mb-5">
+        {message && <StatusMessage type={message.type} text={message.text} />}
+
+        <section className="rounded-xl border border-border bg-card p-6">
+          <h2 className="mb-5 text-lg font-semibold text-card-foreground">Creator Profile</h2>
+
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading profile...</p>
+          ) : !profileAddress ? (
+            <p className="text-sm text-muted-foreground">Sign in to edit your profile.</p>
+          ) : (
+            <form className="space-y-4" onSubmit={handleSaveProfile}>
+              <TextField label="Username" value={form.username} error={formErrors.username} onChange={(value) => handleChange("username", value)} maxLength={50} />
+              <TextArea label="Bio" value={form.bio} error={formErrors.bio} onChange={(value) => handleChange("bio", value)} />
+              <TextField label="Avatar URL" value={form.avatarUrl} error={formErrors.avatarUrl} onChange={(value) => handleChange("avatarUrl", value)} />
+              <TextField label="Banner URL" value={form.bannerUrl} error={formErrors.bannerUrl} onChange={(value) => handleChange("bannerUrl", value)} />
+              <TextField label="Twitter Handle" value={form.twitterHandle} error={formErrors.twitterHandle} onChange={(value) => handleChange("twitterHandle", value)} placeholder="@handle" maxLength={16} />
+              <TextField label="Instagram Handle" value={form.instagramHandle} error={formErrors.instagramHandle} onChange={(value) => handleChange("instagramHandle", value)} placeholder="@handle" maxLength={31} />
+              <TextField label="Website" value={form.website} error={formErrors.website} onChange={(value) => handleChange("website", value)} />
+
+              <button
+                type="submit"
+                disabled={saving}
+                className="rounded-lg bg-gradient-to-r from-[#4e3bff] to-[#9747ff] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                {saving ? "Saving..." : "Save Profile"}
+              </button>
+            </form>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-border bg-card p-6">
+          <div className="mb-5 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Wallet className="h-5 w-5 text-purple-400" />
               <h2 className="text-lg font-semibold text-card-foreground">
@@ -105,73 +239,53 @@ export default function ProfilePage() {
             </div>
             <button
               onClick={() => setWalletModalOpen(true)}
-              className="flex items-center gap-1.5 text-sm text-purple-400 hover:text-purple-300 transition-colors"
+              className="flex items-center gap-1.5 text-sm text-purple-400 transition-colors hover:text-purple-300"
             >
               <Plus className="h-4 w-4" />
               {t("profile.addWallet") || "Add Wallet"}
             </button>
           </div>
 
-          {/* Feedback banners */}
-          {linkError && (
-            <div className="mb-4 flex items-start gap-2 p-3 rounded-lg bg-red-900/30 border border-red-500/30 text-red-300 text-sm">
-              <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-              {linkError}
-            </div>
-          )}
-          {linkSuccess && (
-            <div className="mb-4 flex items-center gap-2 p-3 rounded-lg bg-green-900/30 border border-green-500/30 text-green-300 text-sm">
-              <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
-              {linkSuccess}
-            </div>
-          )}
-
-          {/* Existing linked wallets */}
-          {linkedWallets.length > 0 ? (
-            <div className="space-y-3 mb-5">
-              {linkedWallets.map((w) => (
-                <LinkedWalletRow key={w.walletAddress} wallet={w} />
+          {wallets.length > 0 ? (
+            <div className="mb-5 space-y-3">
+              {wallets.map((wallet) => (
+                <LinkedWalletRow key={wallet.walletAddress} wallet={wallet} />
               ))}
             </div>
           ) : (
-            <p className="text-sm text-muted-foreground mb-5">
-              {t("profile.noWallets") ||
-                "No wallets linked yet. Connect a Stellar wallet to enable wallet-based login and NFT transactions."}
+            <p className="mb-5 text-sm text-muted-foreground">
+              {loading ? "Loading wallets..." : "No wallets linked yet."}
             </p>
           )}
 
-          {/* Currently connected wallet — link prompt */}
           {connected && address && (
-            <div className="border border-purple-500/20 rounded-lg p-4 bg-purple-500/5">
-              <div className="flex items-center justify-between mb-3">
-                <div>
+            <div className="rounded-lg border border-purple-500/20 bg-purple-500/5 p-4">
+              <div className="mb-3 flex items-center justify-between gap-4">
+                <div className="min-w-0">
                   <p className="text-sm font-medium text-white">
                     {t("profile.connectedWallet") || "Connected Wallet"}
                   </p>
-                  <p className="text-xs font-mono text-gray-400 mt-0.5">
-                    {address}
-                  </p>
+                  <p className="mt-0.5 truncate font-mono text-xs text-gray-400">{address}</p>
                 </div>
                 <WalletNetworkStatus network={network} />
               </div>
 
-              {/* Balance */}
               <WalletBalance address={address} network={network} className="mb-4" />
 
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 {!isAlreadyLinked && (
                   <button
                     onClick={handleLinkWallet}
-                    disabled={linking || authLoading}
-                    className="flex items-center gap-1.5 text-sm px-4 py-2 rounded-lg bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+                    disabled={linking}
+                    className="flex items-center gap-1.5 rounded-lg bg-gradient-to-r from-[#4e3bff] to-[#9747ff] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
                   >
                     <Link2 className="h-4 w-4" />
-                    {linking || authLoading ? "Linking…" : t("profile.linkWallet") || "Link to Account"}
+                    {linking ? "Linking..." : t("profile.linkWallet") || "Link to Account"}
                   </button>
                 )}
                 <button
                   onClick={disconnect}
-                  className="flex items-center gap-1.5 text-sm px-4 py-2 rounded-lg border border-red-500/30 text-red-400 hover:bg-red-500/10 transition-colors"
+                  className="flex items-center gap-1.5 rounded-lg border border-red-500/30 px-4 py-2 text-sm text-red-400 transition-colors hover:bg-red-500/10"
                 >
                   <Link2Off className="h-4 w-4" />
                   {t("connectWallet.disconnect") || "Disconnect"}
@@ -179,7 +293,7 @@ export default function ProfilePage() {
               </div>
 
               {isAlreadyLinked && (
-                <p className="text-xs text-green-400 mt-2 flex items-center gap-1">
+                <p className="mt-2 flex items-center gap-1 text-xs text-green-400">
                   <CheckCircle2 className="h-3.5 w-3.5" />
                   This wallet is already linked to your account.
                 </p>
@@ -194,39 +308,149 @@ export default function ProfilePage() {
   );
 }
 
-function LinkedWalletRow({ wallet }: { wallet: LinkedWallet }) {
-  const network = wallet.walletAddress.startsWith("G") ? "mainnet" : "testnet";
+function toProfileForm(profile: ProfileUser): ProfileForm {
+  return {
+    username: profile.username || "",
+    bio: profile.bio || "",
+    avatarUrl: profile.avatarUrl || "",
+    bannerUrl: profile.bannerUrl || "",
+    twitterHandle: profile.twitterHandle || "",
+    instagramHandle: profile.instagramHandle || "",
+    website: profile.website || "",
+  };
+}
+
+function validateProfile(form: ProfileForm): FormErrors {
+  const errors: FormErrors = {};
+  const handlePattern = /^@?[A-Za-z0-9_]{1,15}$/;
+  const instagramPattern = /^@?[A-Za-z0-9_.]{1,30}$/;
+
+  if (form.username.trim().length > 50) errors.username = "Username must be 50 characters or less.";
+  if (form.avatarUrl && (!isValidUrl(form.avatarUrl) || form.avatarUrl.length > 500)) errors.avatarUrl = "Enter a valid avatar URL under 500 characters.";
+  if (form.bannerUrl && (!isValidUrl(form.bannerUrl) || form.bannerUrl.length > 500)) errors.bannerUrl = "Enter a valid banner URL under 500 characters.";
+  if (form.website && (!isValidUrl(form.website) || form.website.length > 500)) errors.website = "Enter a valid website URL under 500 characters.";
+  if (form.twitterHandle && !handlePattern.test(form.twitterHandle)) errors.twitterHandle = "Use a valid Twitter handle, up to 15 characters.";
+  if (form.instagramHandle && !instagramPattern.test(form.instagramHandle)) errors.instagramHandle = "Use a valid Instagram handle, up to 30 characters.";
+
+  return errors;
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function StatusMessage({ type, text }: { type: "success" | "error"; text: string }) {
+  const Icon = type === "success" ? CheckCircle2 : AlertCircle;
+  const classes =
+    type === "success"
+      ? "border-green-500/30 bg-green-900/30 text-green-300"
+      : "border-red-500/30 bg-red-900/30 text-red-300";
 
   return (
-    <div className="flex items-center justify-between p-3 rounded-lg bg-muted/40 border border-border">
-      <div className="flex items-center gap-3 min-w-0">
-        <div className="w-8 h-8 rounded-full bg-purple-500/20 flex items-center justify-center flex-shrink-0">
+    <div className={`flex items-start gap-2 rounded-lg border p-3 text-sm ${classes}`}>
+      <Icon className="mt-0.5 h-4 w-4 flex-shrink-0" />
+      <span>{text}</span>
+    </div>
+  );
+}
+
+function TextField({
+  label,
+  value,
+  error,
+  onChange,
+  placeholder,
+  maxLength,
+}: {
+  label: string;
+  value: string;
+  error?: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  maxLength?: number;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-sm font-medium text-card-foreground">{label}</span>
+      <input
+        value={value}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors focus:border-purple-400"
+      />
+      {error && <span className="mt-1 block text-xs text-red-400">{error}</span>}
+    </label>
+  );
+}
+
+function TextArea({
+  label,
+  value,
+  error,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  error?: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-sm font-medium text-card-foreground">{label}</span>
+      <textarea
+        value={value}
+        rows={4}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors focus:border-purple-400"
+      />
+      {error && <span className="mt-1 block text-xs text-red-400">{error}</span>}
+    </label>
+  );
+}
+
+function LinkedWalletRow({ wallet }: { wallet: LinkedWallet }) {
+  const linkedAt = wallet.createdAt || wallet.lastUsedAt;
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-border bg-muted/40 p-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-purple-500/20">
           <Wallet className="h-4 w-4 text-purple-400" />
         </div>
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <p className="text-sm font-mono text-foreground truncate">
-              {wallet.walletAddress.slice(0, 6)}…{wallet.walletAddress.slice(-6)}
-            </p>
+            <p className="truncate font-mono text-sm text-foreground">{shortAddress(wallet.walletAddress)}</p>
             {wallet.isPrimary && (
-              <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-purple-500/20 text-purple-300">
+              <span className="rounded-full bg-purple-500/20 px-1.5 py-0.5 text-[10px] font-medium text-purple-300">
                 Primary
               </span>
             )}
           </div>
-          <p className="text-xs text-muted-foreground capitalize">
-            {wallet.walletProvider} · Linked {new Date(wallet.lastUsedAt).toLocaleDateString()}
+          <p className="text-xs capitalize text-muted-foreground">
+            {wallet.walletProvider}
+            {linkedAt ? ` · Linked ${new Date(linkedAt).toLocaleDateString()}` : ""}
           </p>
         </div>
       </div>
       <a
-        href={getExplorerUrl(network as "testnet" | "mainnet", undefined, wallet.walletAddress)}
+        href={getExplorerUrl("testnet", undefined, wallet.walletAddress)}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-purple-400 hover:text-purple-300 transition-colors ml-2"
+        className="ml-2 text-purple-400 transition-colors hover:text-purple-300"
+        aria-label="View wallet in explorer"
       >
         <ExternalLink className="h-4 w-4" />
       </a>
     </div>
   );
+}
+
+function shortAddress(value: string): string {
+  return `${value.slice(0, 6)}...${value.slice(-6)}`;
 }

--- a/nftopia-frontend/app/[locale]/creator-dashboard/settings/page.tsx
+++ b/nftopia-frontend/app/[locale]/creator-dashboard/settings/page.tsx
@@ -1,79 +1,181 @@
 "use client";
 
-import { useAuthContext } from "@/lib/context/AuthContext";
-import { useState } from "react";
-import { connectFreighter, getFreighterAddress } from "@/lib/stellar/wallet/freighter";
+import { useEffect, useState } from "react";
+import { AlertCircle, CheckCircle2, Link2, Link2Off, Wallet } from "lucide-react";
+import { connectFreighter } from "@/lib/stellar/wallet/freighter";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import {
+  LinkedWallet,
+  fetchLinkedWallets,
+  linkWalletWithChallenge,
+  unlinkWallet,
+} from "@/lib/services/profile";
 
 export default function SettingsPage() {
-  const { user, wallets, linkWallet, unlinkWallet, isLoading } = useAuthContext();
+  const authUser = useAuthStore((state) => state.user);
+  const setAuthUser = useAuthStore((state) => state.setUser);
+  const getCurrentUser = useAuthStore((state) => state.getCurrentUser);
+
+  const [wallets, setWallets] = useState<LinkedWallet[]>([]);
+  const [loading, setLoading] = useState(true);
   const [linking, setLinking] = useState(false);
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
+  const [unlinkingAddress, setUnlinkingAddress] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  useEffect(() => {
+    if (!authUser) {
+      const storedUser = getCurrentUser();
+      if (storedUser) setAuthUser(storedUser);
+    }
+  }, [authUser, getCurrentUser, setAuthUser]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadWallets() {
+      setLoading(true);
+      setMessage(null);
+
+      try {
+        const nextWallets = await fetchLinkedWallets();
+        if (active) setWallets(nextWallets);
+      } catch (error) {
+        if (active) {
+          setMessage({
+            type: "error",
+            text: error instanceof Error ? error.message : "Failed to load linked wallets.",
+          });
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    loadWallets();
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleLinkFreighter = async () => {
-    setError("");
-    setSuccess("");
+    setMessage(null);
     setLinking(true);
+
     try {
-      // 1. Connect to Freighter and get address
-      const address = await connectFreighter();
-      // 2. (In a real app, get challenge from backend, sign, and send signature)
-      // Here, just call linkWallet for demo (should be completed with challenge/response)
-      await linkWallet(address, "freighter");
-      setSuccess("Wallet linked successfully!");
-    } catch (e: any) {
-      setError(e.message || "Failed to link wallet");
+      const walletAddress = await connectFreighter();
+      await linkWalletWithChallenge(walletAddress, "freighter");
+      setWallets(await fetchLinkedWallets());
+      setMessage({ type: "success", text: "Wallet linked successfully." });
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to link wallet.",
+      });
     } finally {
       setLinking(false);
     }
   };
 
   const handleUnlink = async (walletAddress: string) => {
-    setError("");
-    setSuccess("");
+    setMessage(null);
+    setUnlinkingAddress(walletAddress);
+
     try {
       await unlinkWallet(walletAddress);
-      setSuccess("Wallet unlinked successfully!");
-    } catch (e: any) {
-      setError(e.message || "Failed to unlink wallet");
+      setWallets(await fetchLinkedWallets());
+      setMessage({ type: "success", text: "Wallet unlinked successfully." });
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to unlink wallet.",
+      });
+    } finally {
+      setUnlinkingAddress(null);
     }
   };
 
   return (
-    <div className="max-w-xl mx-auto py-10">
-      <h1 className="text-3xl font-bold text-nftopia-text mb-4">Settings</h1>
-      <div className="mb-8">
-        <h2 className="text-xl font-semibold mb-2">Linked Stellar Wallets</h2>
-        {isLoading ? (
-          <div>Loading...</div>
+    <div className="mx-auto max-w-2xl px-6 py-10">
+      <h1 className="mb-6 text-3xl font-bold text-nftopia-text">Settings</h1>
+
+      {message && <StatusMessage type={message.type} text={message.text} />}
+
+      <section className="mt-6 rounded-xl border border-border bg-card p-6">
+        <div className="mb-5 flex items-center gap-2">
+          <Wallet className="h-5 w-5 text-purple-400" />
+          <h2 className="text-xl font-semibold text-card-foreground">Linked Stellar Wallets</h2>
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading wallets...</p>
         ) : wallets.length === 0 ? (
-          <div className="text-nftopia-subtext">No wallets linked.</div>
+          <p className="mb-4 text-sm text-nftopia-subtext">No wallets linked.</p>
         ) : (
-          <ul className="mb-4">
-            {wallets.map((w) => (
-              <li key={w.walletAddress} className="flex items-center justify-between py-2 border-b">
-                <span>{w.walletAddress} ({w.walletProvider}) {w.isPrimary && <span className="ml-2 text-xs text-green-500">Primary</span>}</span>
+          <ul className="mb-5 space-y-3">
+            {wallets.map((wallet) => (
+              <li
+                key={wallet.walletAddress}
+                className="flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/40 p-3"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-mono text-sm text-foreground">
+                      {shortAddress(wallet.walletAddress)}
+                    </span>
+                    {wallet.isPrimary && (
+                      <span className="rounded-full bg-green-500/15 px-2 py-0.5 text-xs text-green-400">
+                        Primary
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs capitalize text-muted-foreground">
+                    {wallet.walletProvider}
+                    {wallet.createdAt ? ` · Linked ${new Date(wallet.createdAt).toLocaleDateString()}` : ""}
+                  </p>
+                </div>
+
                 <button
-                  className="ml-4 px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600"
-                  onClick={() => handleUnlink(w.walletAddress)}
-                  disabled={linking}
+                  className="flex items-center gap-1.5 rounded-lg border border-red-500/30 px-3 py-1.5 text-sm text-red-400 transition-colors hover:bg-red-500/10 disabled:opacity-50"
+                  onClick={() => handleUnlink(wallet.walletAddress)}
+                  disabled={linking || unlinkingAddress === wallet.walletAddress}
                 >
-                  Unlink
+                  <Link2Off className="h-4 w-4" />
+                  {unlinkingAddress === wallet.walletAddress ? "Unlinking..." : "Unlink"}
                 </button>
               </li>
             ))}
           </ul>
         )}
+
         <button
-          className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+          className="flex items-center gap-1.5 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-700 disabled:opacity-50"
           onClick={handleLinkFreighter}
           disabled={linking}
         >
+          <Link2 className="h-4 w-4" />
           {linking ? "Linking..." : "Link Freighter Wallet"}
         </button>
-        {error && <div className="text-red-500 mt-2">{error}</div>}
-        {success && <div className="text-green-600 mt-2">{success}</div>}
-      </div>
+      </section>
     </div>
   );
 }
+
+function StatusMessage({ type, text }: { type: "success" | "error"; text: string }) {
+  const Icon = type === "success" ? CheckCircle2 : AlertCircle;
+  const classes =
+    type === "success"
+      ? "border-green-500/30 bg-green-900/30 text-green-300"
+      : "border-red-500/30 bg-red-900/30 text-red-300";
+
+  return (
+    <div className={`flex items-start gap-2 rounded-lg border p-3 text-sm ${classes}`}>
+      <Icon className="mt-0.5 h-4 w-4 flex-shrink-0" />
+      <span>{text}</span>
+    </div>
+  );
+}
+
+function shortAddress(value: string): string {
+  return `${value.slice(0, 6)}...${value.slice(-6)}`;
+}
+

--- a/nftopia-frontend/features/auth/store/authStore.ts
+++ b/nftopia-frontend/features/auth/store/authStore.ts
@@ -64,6 +64,7 @@ export const useAuthStore = create<AuthStore>()(
           refreshToken: async () => {
             throw new Error("Not implemented");
           },
+          getCurrentUser: () => get().user,
         }))
       ),
       {

--- a/nftopia-frontend/lib/services/profile.ts
+++ b/nftopia-frontend/lib/services/profile.ts
@@ -1,0 +1,217 @@
+import { fetchWithAuth } from "@/lib/api/fetchWithAuth";
+import { API_CONFIG } from "@/lib/config";
+import { signMessageWithAlbedo } from "@/lib/stellar/wallet/albedo";
+import { WalletProvider } from "@/types/stellar";
+
+export interface ProfileUser {
+  id?: string;
+  address?: string;
+  walletAddress?: string;
+  email?: string;
+  username?: string;
+  bio?: string;
+  avatarUrl?: string;
+  bannerUrl?: string;
+  twitterHandle?: string;
+  instagramHandle?: string;
+  website?: string;
+  walletProvider?: string;
+}
+
+export interface UpdateProfilePayload {
+  username?: string;
+  bio?: string;
+  avatarUrl?: string;
+  bannerUrl?: string;
+  twitterHandle?: string;
+  instagramHandle?: string;
+  website?: string;
+}
+
+export interface LinkedWallet {
+  id: string;
+  walletAddress: string;
+  walletProvider: string;
+  isPrimary: boolean;
+  createdAt?: string;
+  lastUsedAt?: string;
+}
+
+export interface WalletChallenge {
+  sessionId: string;
+  walletAddress: string;
+  nonce: string;
+  message: string;
+  expiresAt: string;
+}
+
+const jsonHeaders = {
+  "Content-Type": "application/json",
+};
+
+function unwrapApiData<T>(payload: unknown): T {
+  const typed = payload as { data?: { data?: T } | T };
+  if (typed?.data && typeof typed.data === "object" && "data" in typed.data) {
+    return (typed.data as { data: T }).data;
+  }
+  if ("data" in (typed || {})) {
+    return typed.data as T;
+  }
+  return payload as T;
+}
+
+async function parseResponse<T>(response: Response, fallbackMessage: string): Promise<T> {
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const errorPayload = payload as { message?: string; error?: string };
+    throw new Error(errorPayload.message || errorPayload.error || fallbackMessage);
+  }
+
+  return unwrapApiData<T>(payload);
+}
+
+export function cleanProfilePayload(values: UpdateProfilePayload): UpdateProfilePayload {
+  return Object.fromEntries(
+    Object.entries(values)
+      .map(([key, value]) => [key, typeof value === "string" ? value.trim() : value])
+      .filter(([, value]) => value !== undefined && value !== "")
+  ) as UpdateProfilePayload;
+}
+
+export async function fetchProfileByAddress(address: string): Promise<ProfileUser> {
+  const response = await fetchWithAuth(`${API_CONFIG.baseUrl}/users/${address}`, {
+    method: "GET",
+    credentials: "include",
+  });
+
+  return parseResponse<ProfileUser>(response, "Failed to load profile");
+}
+
+export async function updateMyProfile(
+  walletAddress: string,
+  payload: UpdateProfilePayload
+): Promise<ProfileUser> {
+  const response = await fetchWithAuth(`${API_CONFIG.baseUrl}/users/me`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      ...jsonHeaders,
+      "x-wallet-address": walletAddress,
+    },
+    body: JSON.stringify(cleanProfilePayload(payload)),
+  });
+
+  return parseResponse<ProfileUser>(response, "Failed to save profile");
+}
+
+export async function fetchLinkedWallets(): Promise<LinkedWallet[]> {
+  const response = await fetchWithAuth(`${API_CONFIG.baseUrl}/users/wallets`, {
+    method: "GET",
+    credentials: "include",
+    headers: jsonHeaders,
+  });
+
+  return parseResponse<LinkedWallet[]>(response, "Failed to load linked wallets");
+}
+
+export async function requestWalletChallenge(
+  walletAddress: string,
+  walletProvider?: WalletProvider
+): Promise<WalletChallenge> {
+  const response = await fetch(`${API_CONFIG.baseUrl}/auth/wallet/challenge`, {
+    method: "POST",
+    credentials: "include",
+    headers: jsonHeaders,
+    body: JSON.stringify({ walletAddress, walletProvider }),
+  });
+
+  return parseResponse<WalletChallenge>(response, "Failed to request wallet challenge");
+}
+
+export async function signWalletChallenge(
+  message: string,
+  walletProvider: WalletProvider,
+  walletAddress: string
+): Promise<string> {
+  if (walletProvider === "freighter") {
+    const freighterApi = (await import("@stellar/freighter-api")) as {
+      signMessage?: (
+        message: string,
+        opts: { address: string }
+      ) => Promise<{ signedMessage: string | null; signerAddress?: string; error?: string }>;
+    };
+
+    if (!freighterApi.signMessage) {
+      throw new Error("Freighter message signing is unavailable in this browser.");
+    }
+
+    const result = await freighterApi.signMessage(message, { address: walletAddress });
+    if (result.error || !result.signedMessage) {
+      throw new Error(result.error || "Freighter did not return a signature.");
+    }
+
+    return result.signedMessage;
+  }
+
+  if (walletProvider === "albedo") {
+    const result = await signMessageWithAlbedo(message);
+    if (result.publicKey !== walletAddress) {
+      throw new Error("Signed wallet does not match the connected wallet.");
+    }
+    return result.signature;
+  }
+
+  throw new Error(`Wallet provider "${walletProvider}" does not support message signing yet.`);
+}
+
+export async function linkWalletWithChallenge(
+  walletAddress: string,
+  walletProvider: WalletProvider
+): Promise<{ success: boolean; wallet: LinkedWallet }> {
+  const challenge = await requestWalletChallenge(walletAddress, walletProvider);
+  const signature = await signWalletChallenge(
+    challenge.message,
+    walletProvider,
+    walletAddress
+  );
+
+  const response = await fetchWithAuth(`${API_CONFIG.baseUrl}/auth/wallet/link`, {
+    method: "POST",
+    credentials: "include",
+    headers: jsonHeaders,
+    body: JSON.stringify({
+      walletAddress,
+      nonce: challenge.nonce,
+      signature,
+      walletProvider,
+    }),
+  });
+
+  return parseResponse<{ success: boolean; wallet: LinkedWallet }>(
+    response,
+    "Failed to link wallet"
+  );
+}
+
+export async function unlinkWallet(walletAddress: string): Promise<{ success: boolean }> {
+  const requestInit: RequestInit = {
+    method: "DELETE",
+    credentials: "include",
+    headers: jsonHeaders,
+    body: JSON.stringify({ walletAddress }),
+  };
+
+  const response = await fetchWithAuth(`${API_CONFIG.baseUrl}/auth/wallet/unlink`, requestInit);
+
+  if (response.status === 404 || response.status === 405) {
+    const legacyResponse = await fetchWithAuth(`${API_CONFIG.baseUrl}/auth/wallet/unlink`, {
+      ...requestInit,
+      method: "POST",
+    });
+    return parseResponse<{ success: boolean }>(legacyResponse, "Failed to unlink wallet");
+  }
+
+  return parseResponse<{ success: boolean }>(response, "Failed to unlink wallet");
+}
+

--- a/nftopia-frontend/lib/stores/types.ts
+++ b/nftopia-frontend/lib/stores/types.ts
@@ -1,11 +1,19 @@
 // Auth Store Types
 export interface User {
-  sub: string;
+  id?: string;
+  sub?: string;
+  address?: string;
   walletAddress: string;
+  walletProvider?: string;
   isArtist?: boolean;
   username?: string;
   email?: string;
   profileImage?: string;
+  avatarUrl?: string;
+  bannerUrl?: string;
+  twitterHandle?: string;
+  instagramHandle?: string;
+  website?: string;
   bio?: string;
   createdAt?: string;
   updatedAt?: string;
@@ -51,6 +59,7 @@ export type AuthStore = {
   ) => Promise<void>;
   logout: () => Promise<void>;
   refreshToken: () => Promise<string>;
+  getCurrentUser: () => User | null;
 };
 
 // Collection Store Types


### PR DESCRIPTION
Closes #222 

## PR Description

This PR completes the frontend creator profile/settings integration by removing stubbed current-user behavior and using the shared auth-store identity as the canonical user source. The profile page now loads real backend profile data, renders linked Stellar wallets from the authenticated wallet endpoint, and persists profile edits through `PATCH /users/me` with the required `x-wallet-address` header.

Wallet management now follows the backend-authenticated contract instead of shortcut/stub logic. Linking requests a wallet challenge, signs the returned challenge message with the connected wallet, and submits the nonce/signature to the authenticated wallet link endpoint. Unlinking uses the backend unlink contract and refreshes the wallet list after successful changes.

The implementation also adds user-facing loading, success, and error states for profile saving, wallet linking, and wallet unlinking. Profile form validation is aligned with the backend DTO constraints for username length, URL fields, and social handle formats.

### Changed

- Replaced profile `useCurrentUser()` stub usage with auth-store backed identity.
- Added a focused frontend profile/wallet service for authenticated profile and wallet requests.
- Wired profile edits to `PATCH /users/me`.
- Loaded linked wallets from `GET /users/wallets`.
- Implemented challenge/sign/authenticated-link wallet linking.
- Implemented wallet unlink and wallet-list refresh.
- Added focused integration tests for profile save and wallet link/unlink request contracts.