### PR TITLE
feat: unified client validation and server error mapping for auth forms (#227)

### DIFF
--- a/nftopia-frontend/__tests__/server-error-mapping.test.ts
+++ b/nftopia-frontend/__tests__/server-error-mapping.test.ts
@@ -1,0 +1,33 @@
+import { mapServerError } from "@/lib/errors/serverErrorMapper";
+
+describe("mapServerError", () => {
+  it("maps known field errors shape", () => {
+    const { fieldErrors, formError } = mapServerError({
+      errors: { email: "Email already taken", password: ["Too weak"] },
+    });
+    expect(fieldErrors.email).toBe("Email already taken");
+    expect(fieldErrors.password).toBe("Too weak");
+    expect(formError).toBe("");
+  });
+
+  it("maps single message string", () => {
+    const { fieldErrors, formError } = mapServerError({ message: "Invalid credentials" });
+    expect(formError).toBe("Invalid credentials");
+    expect(fieldErrors).toEqual({});
+  });
+
+  it("maps error string fallback", () => {
+    const { formError } = mapServerError({ error: "Server error" });
+    expect(formError).toBe("Server error");
+  });
+
+  it("returns generic message for unknown payload", () => {
+    const { formError } = mapServerError(null);
+    expect(formError).toBe("Something went wrong. Please try again.");
+  });
+
+  it("returns generic message for empty object", () => {
+    const { formError } = mapServerError({});
+    expect(formError).toBe("Something went wrong. Please try again.");
+  });
+});

--- a/nftopia-frontend/__tests__/validation-rules-auth.test.ts
+++ b/nftopia-frontend/__tests__/validation-rules-auth.test.ts
@@ -1,0 +1,45 @@
+import { loginSchema, registerSchema } from "@/lib/validation/auth";
+
+describe("loginSchema", () => {
+  it("passes with valid email and password", () => {
+    const result = loginSchema.safeParse({ email: "user@example.com", password: "secret" });
+    expect(result.success).toBe(true);
+  });
+
+  it("fails with invalid email", () => {
+    const result = loginSchema.safeParse({ email: "not-an-email", password: "secret" });
+    expect(result.success).toBe(false);
+  });
+
+  it("fails with empty password", () => {
+    const result = loginSchema.safeParse({ email: "user@example.com", password: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("registerSchema", () => {
+  const valid = {
+    email: "user@example.com",
+    password: "password123",
+    confirmPassword: "password123",
+  };
+
+  it("passes with valid data", () => {
+    expect(registerSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("fails when passwords do not match", () => {
+    const result = registerSchema.safeParse({ ...valid, confirmPassword: "different" });
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when password is under 8 characters", () => {
+    const result = registerSchema.safeParse({ ...valid, password: "short", confirmPassword: "short" });
+    expect(result.success).toBe(false);
+  });
+
+  it("passes with optional username", () => {
+    const result = registerSchema.safeParse({ ...valid, username: "temy" });
+    expect(result.success).toBe(true);
+  });
+});

--- a/nftopia-frontend/app/[locale]/auth/login/page.tsx
+++ b/nftopia-frontend/app/[locale]/auth/login/page.tsx
@@ -4,75 +4,54 @@ import { CircuitBackground } from "@/components/circuit-background";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/lib/stores/auth-store";
+import { useAuthStore } from "@/lib/stores/auth-store";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useStellarWallet } from "@/components/wallet/hooks/useStellarWallet";
 import { useStellarAuth } from "@/components/wallet/hooks/useStellarAuth";
 import { WalletModal } from "@/components/wallet/WalletModal";
 import { WalletNetworkStatus } from "@/components/wallet/WalletNetworkStatus";
 import { defaultNetwork } from "@/lib/stellar/client";
-import { getValidationFieldMessage } from "@/utils/fetchUtils";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema, LoginFormData } from "@/lib/validation/auth";
+import { mapServerError } from "@/lib/errors/serverErrorMapper";
 import {
-  KeyRound,
-  LogIn,
-  Wallet,
-  Mail,
-  Lock,
-  Eye,
-  EyeOff,
-  ChevronRight,
-  AlertTriangle,
+  LogIn, Wallet, Mail, Lock, Eye, EyeOff, ChevronRight,
 } from "lucide-react";
 import { OptimizedImage } from "@/components/image";
 import Link from "next/link";
-import React, { useState, useRef } from "react";
-// Telemetry
-import { authInstrumentation } from "@/lib/telemetry/auth-instrumentation";
+import { useState } from "react";
 
 type AuthMode = "wallet" | "email";
 
 export default function LoginPage() {
   const { t, locale } = useTranslation();
+  const { loading: emailLoading, error: emailError, clearError: clearEmailError } = useAuth();
+  const { emailLogin } = useAuthStore();
 
-  // Integrated hooks from main branch
   const {
-    loading: emailLoading,
-    error: emailStoreError,
-    clearError: clearEmailError,
-    emailLogin,
-  } = useAuth();
-
-  // Stellar wallet state hooks
-  const {
-    connected,
-    address,
-    provider,
-    connecting,
-    error: walletError,
-    connect,
-    disconnect,
-    clearError: clearWalletError,
+    connected, address, provider, connecting,
+    error: walletError, disconnect, clearError: clearWalletError,
   } = useStellarWallet();
 
   const {
-    loading: authLoading,
-    error: authError,
-    authenticateWithWallet,
-    clearError: clearAuthError,
+    loading: authLoading, error: authError,
+    authenticateWithWallet, clearError: clearAuthError,
   } = useStellarAuth();
 
-  // UI
   const [mode, setMode] = useState<AuthMode>("wallet");
   const [walletModalOpen, setWalletModalOpen] = useState(false);
-  const [challengeRequested, setChallengeRequested] = useState(false);
-  // Telemetry states
-  const attemptIdRef = useRef<string | null>(null);
-  const startMsRef = useRef<number>(0);
   const [showPassword, setShowPassword] = useState(false);
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [localError, setLocalError] = useState("");
 
-  const loading = emailLoading || connecting || authLoading;
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormData>({ resolver: zodResolver(loginSchema) });
+
+  const loading = emailLoading || connecting || authLoading || isSubmitting;
 
   const clearAllErrors = () => {
     clearEmailError();
@@ -83,112 +62,39 @@ export default function LoginPage() {
 
   const switchMode = (m: AuthMode) => {
     clearAllErrors();
-    setChallengeRequested(false);
     setMode(m);
   };
 
-  /* ── Wallet auth flow ── */
   const handleWalletAuth = async () => {
     if (!address || !provider) {
       setLocalError("Please connect your wallet first");
-
-      // Telemetry: validation failure
-      const attempt_id = authInstrumentation.submitLogin({
-        auth_method: "wallet",
-        surface: "login_page",
-      });
-      authInstrumentation.loginFailed({
-        auth_method: "wallet",
-        attempt_id,
-        startMs: Date.now(),
-        error: "wallet not connected",
-        failure_stage: "validation",
-        validation_error_count: 1,
-      });
       return;
     }
     clearAllErrors();
-
-    // Telemetry: submit
-    attemptIdRef.current = authInstrumentation.submitLogin({
-      auth_method: "wallet",
-      surface: "login_page",
-    });
-    startMsRef.current = Date.now();
-
     try {
-      await authenticateWithWallet(address, provider, () => {
-        // Telemetry: success (handled in hook/store ideally, but fallback here)
-        authInstrumentation.loginSuccess({
-          auth_method: "wallet",
-          attempt_id: attemptIdRef.current!,
-          startMs: startMsRef.current,
-          had_wallet_connected: true,
-        });
-      });
-    } catch (err) {
-      // Telemetry: failure
-      authInstrumentation.loginFailed({
-        auth_method: "wallet",
-        attempt_id: attemptIdRef.current!,
-        startMs: startMsRef.current,
-        error: err,
-        failure_stage: "response",
-      });
+      await authenticateWithWallet(address, provider, () => {});
+    } catch {
+      // error already set in hook
     }
   };
 
-  // Email auth flow
-  const handleEmailLogin = async () => {
-    if (!email || !password) {
-      setLocalError("Please enter both your email and password");
-
-      // Telemetry: validation failure
-      const attempt_id = authInstrumentation.submitLogin({
-        auth_method: "email",
-        surface: "login_page",
-      });
-      authInstrumentation.loginFailed({
-        auth_method: "email",
-        attempt_id,
-        startMs: Date.now(),
-        error: "missing required fields",
-        failure_stage: "validation",
-        validation_error_count: 2,
-      });
-      return;
-    }
+  const onEmailSubmit = async (data: LoginFormData) => {
     clearAllErrors();
-
-    // Telemetry: submit
-    attemptIdRef.current = authInstrumentation.submitLogin({
-      auth_method: "email",
-      surface: "login_page",
-    });
-    startMsRef.current = Date.now();
-
     try {
-      await emailLogin(email, password);
-      authInstrumentation.loginSuccess({
-        auth_method: "email",
-        attempt_id: attemptIdRef.current!,
-        startMs: startMsRef.current,
-        had_wallet_connected: false,
-      });
-      window.location.href = `/${locale}/creator-dashboard`;
-    } catch (err) {
-      authInstrumentation.loginFailed({
-        auth_method: "email",
-        attempt_id: attemptIdRef.current!,
-        startMs: startMsRef.current,
-        error: err || "not implemented",
-        failure_stage: "request",
-      });
+      await emailLogin(data.email, data.password);
+    } catch (err: unknown) {
+      const { fieldErrors, formError } = mapServerError(err);
+      if (Object.keys(fieldErrors).length > 0) {
+        for (const [field, msg] of Object.entries(fieldErrors)) {
+          setError(field as keyof LoginFormData, { message: msg });
+        }
+      } else {
+        setLocalError(formError);
+      }
     }
   };
 
-  // Safe fallback processing for string structures vs AppApiError definitions
-  const globalErrorInstance = emailStoreError || authError || walletError;
+  const globalErrorInstance = emailError || authError || walletError;
   const globalErrorMessage =
     typeof globalErrorInstance === "string"
       ? globalErrorInstance
@@ -196,17 +102,9 @@ export default function LoginPage() {
 
   const displayGeneralError = localError || globalErrorMessage;
 
-  // Specific nested context extractors for form inputs from your branch
-  const emailFieldError = getValidationFieldMessage(emailStoreError, "email");
-  const passwordFieldError = getValidationFieldMessage(
-    emailStoreError,
-    "password",
-  );
-
   return (
     <div className="min-h-[500px] text-white">
       <CircuitBackground />
-
       <div className="relative z-10 pb-16 px-4">
         <div className="max-w-md mx-auto">
           <div className="border border-purple-500/20 rounded-xl p-8 bg-glass backdrop-blur-md shadow-lg">
@@ -222,17 +120,11 @@ export default function LoginPage() {
               />
             </div>
 
-            {/* General Banner Fallback Notification */}
             {displayGeneralError && (
               <div className="mb-6 p-3 bg-red-900/40 text-red-300 rounded-lg border border-red-500/30 text-sm flex items-start gap-2 animate-fadeIn">
-                <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0 text-red-400" />
                 <div className="flex-1">
-                  <p className="font-medium text-red-200">
-                    Authentication Alert
-                  </p>
-                  <p className="text-xs text-red-300/90 mt-0.5">
-                    {displayGeneralError}
-                  </p>
+                  <p className="font-medium text-red-200">Authentication Alert</p>
+                  <p className="text-xs text-red-300/90 mt-0.5">{displayGeneralError}</p>
                 </div>
               </div>
             )}
@@ -242,9 +134,7 @@ export default function LoginPage() {
                 type="button"
                 onClick={() => switchMode("wallet")}
                 className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${
-                  mode === "wallet"
-                    ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow"
-                    : "text-gray-400 hover:text-white"
+                  mode === "wallet" ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow" : "text-gray-400 hover:text-white"
                 }`}
               >
                 <Wallet className="h-4 w-4" />
@@ -254,9 +144,7 @@ export default function LoginPage() {
                 type="button"
                 onClick={() => switchMode("email")}
                 className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${
-                  mode === "email"
-                    ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow"
-                    : "text-gray-400 hover:text-white"
+                  mode === "email" ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow" : "text-gray-400 hover:text-white"
                 }`}
               >
                 <Mail className="h-4 w-4" />
@@ -271,7 +159,6 @@ export default function LoginPage() {
                   <label className="block text-sm font-medium mb-2 text-purple-300">
                     {t("login.walletAddress") || "Wallet Address"}
                   </label>
-
                   {connected && address ? (
                     <div className="flex items-center justify-between w-full bg-gray-800/50 border border-purple-500/20 rounded-lg px-4 py-3">
                       <div className="flex items-center gap-2 min-w-0">
@@ -284,10 +171,7 @@ export default function LoginPage() {
                         <WalletNetworkStatus network={defaultNetwork} />
                         <button
                           type="button"
-                          onClick={() => {
-                            disconnect();
-                            setChallengeRequested(false);
-                          }}
+                          onClick={disconnect}
                           className="text-xs text-red-400 hover:text-red-300 transition-colors"
                         >
                           {t("connectWallet.disconnect") || "Disconnect"}
@@ -296,18 +180,12 @@ export default function LoginPage() {
                     </div>
                   ) : (
                     <Input
-                      type="text"
-                      value=""
-                      readOnly
-                      placeholder={
-                        t("login.inputPlaceholder") ||
-                        "Connect wallet to populate"
-                      }
+                      type="text" value="" readOnly
+                      placeholder={t("login.inputPlaceholder") || "Connect wallet to populate"}
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg px-4 py-3 text-sm"
                     />
                   )}
                 </div>
-
                 <div className="space-y-3">
                   {!connected ? (
                     <Button
@@ -327,23 +205,19 @@ export default function LoginPage() {
                       disabled={loading}
                     >
                       <LogIn className="mr-2 h-5 w-5" />
-                      {loading
-                        ? t("login.signingIn") || "Signing in…"
-                        : t("login.signAndLogin") || "Sign & Login"}
+                      {loading ? t("login.signingIn") || "Signing in…" : t("login.signAndLogin") || "Sign & Login"}
                     </Button>
                   )}
                 </div>
-
                 <p className="text-xs text-gray-500 text-center leading-relaxed">
-                  {t("login.walletAuthNote") ||
-                    "You will be asked to sign a message to verify ownership of your Stellar wallet. No transaction will be submitted."}
+                  {t("login.walletAuthNote") || "You will be asked to sign a message to verify ownership of your Stellar wallet. No transaction will be submitted."}
                 </p>
               </div>
             )}
 
             {/* EMAIL MODE */}
             {mode === "email" && (
-              <div className="space-y-5">
+              <form onSubmit={handleSubmit(onEmailSubmit)} className="space-y-5" noValidate>
                 <div>
                   <label className="block text-sm font-medium mb-2 text-gray-300">
                     {t("login.email") || "Email"}
@@ -352,20 +226,13 @@ export default function LoginPage() {
                     <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
                       placeholder="you@example.com"
-                      className={`w-full bg-gray-800/50 border rounded-lg pl-9 pr-4 py-3 text-sm transition-colors ${
-                        emailFieldError
-                          ? "border-red-500 focus-visible:ring-red-500"
-                          : "border-purple-500/20"
-                      }`}
+                      className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      {...register("email")}
                     />
                   </div>
-                  {emailFieldError && (
-                    <p className="text-xs text-red-400 mt-1.5 ml-1 animate-fadeIn font-medium">
-                      {emailFieldError}
-                    </p>
+                  {errors.email && (
+                    <p className="mt-1 text-xs text-red-400">{errors.email.message}</p>
                   )}
                 </div>
 
@@ -377,49 +244,34 @@ export default function LoginPage() {
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type={showPassword ? "text" : "password"}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
                       placeholder="••••••••"
-                      className={`w-full bg-gray-800/50 border rounded-lg pl-9 pr-10 py-3 text-sm transition-colors ${
-                        passwordFieldError
-                          ? "border-red-500 focus-visible:ring-red-500"
-                          : "border-purple-500/20"
-                      }`}
+                      className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-10 py-3 text-sm"
+                      {...register("password")}
                     />
                     <button
                       type="button"
                       onClick={() => setShowPassword((v) => !v)}
                       className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 transition-colors"
                     >
-                      {showPassword ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
+                      {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                     </button>
                   </div>
-                  {passwordFieldError && (
-                    <p className="text-xs text-red-400 mt-1.5 ml-1 animate-fadeIn font-medium">
-                      {passwordFieldError}
-                    </p>
+                  {errors.password && (
+                    <p className="mt-1 text-xs text-red-400">{errors.password.message}</p>
                   )}
                 </div>
 
                 <Button
-                  type="button"
-                  onClick={handleEmailLogin}
+                  type="submit"
                   className="w-full bg-gradient-to-r from-[#4e3bff] to-[#9747ff] hover:opacity-90 text-white font-medium py-2 px-4 rounded-lg flex items-center justify-center"
                   disabled={loading}
                 >
                   <LogIn className="mr-2 h-5 w-5" />
-                  {loading
-                    ? t("login.signingIn") || "Signing in…"
-                    : t("login.signIn") || "Sign In"}
+                  {isSubmitting ? t("login.signingIn") || "Signing in…" : t("login.signIn") || "Sign In"}
                 </Button>
-              </div>
+              </form>
             )}
 
-            {/* Register link */}
             <div className="text-center text-sm text-gray-400 mt-6">
               {t("login.dontHave") || "Don't have an account?"}{" "}
               <Link
@@ -434,11 +286,7 @@ export default function LoginPage() {
         </div>
       </div>
 
-      {/* Wallet selection modal */}
-      <WalletModal
-        open={walletModalOpen}
-        onClose={() => setWalletModalOpen(false)}
-      />
+      <WalletModal open={walletModalOpen} onClose={() => setWalletModalOpen(false)} />
     </div>
   );
 }

--- a/nftopia-frontend/app/[locale]/auth/register/page.tsx
+++ b/nftopia-frontend/app/[locale]/auth/register/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { authInstrumentation } from "@/lib/telemetry/auth-instrumentation";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { API_CONFIG } from "@/lib/config";
 import { Button } from "@/components/ui/button";
@@ -12,16 +11,13 @@ import { useStellarWallet } from "@/components/wallet/hooks/useStellarWallet";
 import { WalletModal } from "@/components/wallet/WalletModal";
 import { WalletNetworkStatus } from "@/components/wallet/WalletNetworkStatus";
 import { defaultNetwork } from "@/lib/stellar/client";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { registerSchema, RegisterFormData } from "@/lib/validation/auth";
+import { mapServerError } from "@/lib/errors/serverErrorMapper";
 import {
-  Wallet,
-  Mail,
-  Lock,
-  User,
-  Eye,
-  EyeOff,
-  CheckCircle2,
-  ChevronRight,
-  AlertCircle,
+  Wallet, Mail, Lock, User, Eye, EyeOff,
+  CheckCircle2, ChevronRight, AlertCircle,
 } from "lucide-react";
 
 type RegisterMode = "wallet" | "email";
@@ -30,34 +26,28 @@ export default function RegisterPage() {
   const router = useRouter();
   const { t, locale } = useTranslation();
 
-  // Stellar wallet
   const {
-    connected,
-    address,
-    provider,
-    connecting,
-    error: walletError,
-    disconnect,
-    clearError: clearWalletError,
+    connected, address, provider, connecting,
+    error: walletError, disconnect, clearError: clearWalletError,
   } = useStellarWallet();
 
-  // Form state
   const [mode, setMode] = useState<RegisterMode>("wallet");
   const [walletModalOpen, setWalletModalOpen] = useState(false);
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
+  const [walletUsername, setWalletUsername] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+  const [walletLoading, setWalletLoading] = useState(false);
+  const [walletError2, setWalletError2] = useState("");
   const [success, setSuccess] = useState("");
-  // Telemetry state
-  const attemptIdRef = useRef<string | null>(null);
-  const startMsRef = useRef<number>(0);
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterFormData>({ resolver: zodResolver(registerSchema) });
 
   const clearAllErrors = () => {
-    setError("");
+    setWalletError2("");
     clearWalletError();
   };
 
@@ -69,54 +59,25 @@ export default function RegisterPage() {
   /* ── Wallet registration ── */
   const handleWalletRegister = async () => {
     if (!address) {
-      setError("Please connect your Stellar wallet first");
-      // Telemetry: validation failure
-      const attempt_id = authInstrumentation.submitRegister({
-        auth_method: "wallet",
-        surface: "register_page",
-        has_optional_username: !!username,
-        has_connected_wallet: false,
-      });
-      authInstrumentation.registerFailed({
-        auth_method: "wallet",
-        attempt_id,
-        startMs: Date.now(),
-        error: "wallet not connected",
-        failure_stage: "validation",
-        validation_error_count: 1,
-      });
+      setWalletError2("Please connect your Stellar wallet first");
       return;
     }
     clearAllErrors();
-    setLoading(true);
-    // Telemetry: submit
-    attemptIdRef.current = authInstrumentation.submitRegister({
-      auth_method: "wallet",
-      surface: "register_page",
-      has_optional_username: !!username,
-      has_connected_wallet: true,
-    });
-    startMsRef.current = Date.now();
+    setWalletLoading(true);
     try {
-      // Fetch CSRF token
-      const csrfRes = await fetch(`${API_CONFIG.baseUrl}/auth/csrf-token`, {
-        credentials: "include",
-      });
+      const csrfRes = await fetch(`${API_CONFIG.baseUrl}/auth/csrf-token`, { credentials: "include" });
       if (!csrfRes.ok) throw new Error("Failed to fetch CSRF token");
       const { csrfToken } = await csrfRes.json();
 
       const body: Record<string, string> = { walletAddress: address };
-      if (username.trim()) body.username = username.trim();
+      if (walletUsername.trim()) body.username = walletUsername.trim();
       if (provider) body.walletProvider = provider;
       body.network = defaultNetwork;
 
       const response = await fetch(`${API_CONFIG.baseUrl}/users`, {
         method: "POST",
         credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CSRF-Token": csrfToken,
-        },
+        headers: { "Content-Type": "application/json", "X-CSRF-Token": csrfToken },
         body: JSON.stringify(body),
       });
 
@@ -126,110 +87,24 @@ export default function RegisterPage() {
       }
 
       setSuccess(t("register.success") || "Account created! Redirecting to login…");
-      // Telemetry: success
-      authInstrumentation.registerSuccess({
-        auth_method: "wallet",
-        attempt_id: attemptIdRef.current!,
-        startMs: startMsRef.current,
-        redirects_to_login: true,
-      });
       setTimeout(() => router.push(`/${locale}/auth/login`), 2500);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Registration failed. Please try again."
-      );
-      // Telemetry: failure
-      authInstrumentation.registerFailed({
-        auth_method: "wallet",
-        attempt_id: attemptIdRef.current!,
-        startMs: startMsRef.current,
-        error: err,
-        failure_stage: "response",
-      });
+      setWalletError2(err instanceof Error ? err.message : "Registration failed. Please try again.");
     } finally {
-      setLoading(false);
+      setWalletLoading(false);
     }
   };
 
   /* ── Email registration ── */
-  const handleEmailRegister = async () => {
-    if (!email || !password) {
-      setError("Please fill in all required fields");
-      // Telemetry: validation failure
-      const attempt_id = authInstrumentation.submitRegister({
-        auth_method: "email",
-        surface: "register_page",
-        has_optional_username: !!username,
-        has_connected_wallet: !!(connected && address),
-      });
-      authInstrumentation.registerFailed({
-        auth_method: "email",
-        attempt_id,
-        startMs: Date.now(),
-        error: "missing required fields",
-        failure_stage: "validation",
-        validation_error_count: 2,
-      });
-      return;
-    }
-    if (password !== confirmPassword) {
-      setError("Passwords do not match");
-      // Telemetry: validation failure
-      const attempt_id = authInstrumentation.submitRegister({
-        auth_method: "email",
-        surface: "register_page",
-        has_optional_username: !!username,
-        has_connected_wallet: !!(connected && address),
-      });
-      authInstrumentation.registerFailed({
-        auth_method: "email",
-        attempt_id,
-        startMs: Date.now(),
-        error: "password mismatch",
-        failure_stage: "validation",
-        validation_error_count: 1,
-      });
-      return;
-    }
-    if (password.length < 8) {
-      setError("Password must be at least 8 characters");
-      // Telemetry: validation failure
-      const attempt_id = authInstrumentation.submitRegister({
-        auth_method: "email",
-        surface: "register_page",
-        has_optional_username: !!username,
-        has_connected_wallet: !!(connected && address),
-      });
-      authInstrumentation.registerFailed({
-        auth_method: "email",
-        attempt_id,
-        startMs: Date.now(),
-        error: "password too short",
-        failure_stage: "validation",
-        validation_error_count: 1,
-      });
-      return;
-    }
+  const onEmailSubmit = async (data: RegisterFormData) => {
     clearAllErrors();
-    setLoading(true);
-    // Telemetry: submit
-    attemptIdRef.current = authInstrumentation.submitRegister({
-      auth_method: "email",
-      surface: "register_page",
-      has_optional_username: !!username,
-      has_connected_wallet: !!(connected && address),
-    });
-    startMsRef.current = Date.now();
     try {
-      const csrfRes = await fetch(`${API_CONFIG.baseUrl}/auth/csrf-token`, {
-        credentials: "include",
-      });
+      const csrfRes = await fetch(`${API_CONFIG.baseUrl}/auth/csrf-token`, { credentials: "include" });
       if (!csrfRes.ok) throw new Error("Failed to fetch CSRF token");
       const { csrfToken } = await csrfRes.json();
 
-      const body: Record<string, string> = { email, password };
-      if (username.trim()) body.username = username.trim();
-      // Optionally link wallet if already connected
+      const body: Record<string, string> = { email: data.email, password: data.password };
+      if (data.username?.trim()) body.username = data.username.trim();
       if (connected && address) {
         body.walletAddress = address;
         if (provider) body.walletProvider = provider;
@@ -238,48 +113,35 @@ export default function RegisterPage() {
       const response = await fetch(`${API_CONFIG.baseUrl}/auth/register`, {
         method: "POST",
         credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CSRF-Token": csrfToken,
-        },
+        headers: { "Content-Type": "application/json", "X-CSRF-Token": csrfToken },
         body: JSON.stringify(body),
       });
 
       if (!response.ok) {
         const errData = await response.json().catch(() => ({}));
-        throw new Error(errData.message || "Registration failed");
+        const { fieldErrors, formError } = mapServerError(errData);
+        if (Object.keys(fieldErrors).length > 0) {
+          for (const [field, msg] of Object.entries(fieldErrors)) {
+            setError(field as keyof RegisterFormData, { message: msg });
+          }
+        } else {
+          setError("root", { message: formError });
+        }
+        return;
       }
 
       setSuccess(t("register.success") || "Account created! Redirecting to login…");
-      // Telemetry: success
-      authInstrumentation.registerSuccess({
-        auth_method: "email",
-        attempt_id: attemptIdRef.current!,
-        startMs: startMsRef.current,
-        redirects_to_login: true,
-      });
       setTimeout(() => router.push(`/${locale}/auth/login`), 2500);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Registration failed.");
-      // Telemetry: failure
-      authInstrumentation.registerFailed({
-        auth_method: "email",
-        attempt_id: attemptIdRef.current!,
-        startMs: startMsRef.current,
-        error: err,
-        failure_stage: "response",
-      });
-    } finally {
-      setLoading(false);
+      setError("root", { message: err instanceof Error ? err.message : "Registration failed." });
     }
   };
 
-  const displayError = error || walletError;
+  const displayWalletError = walletError2 || walletError;
 
   return (
     <div className="min-h-[500px] text-white">
       <CircuitBackground />
-
       <div className="relative z-10 pb-16 px-4">
         <div className="max-w-md mx-auto">
           <div className="border border-purple-500/20 rounded-xl p-8 bg-glass backdrop-blur-md shadow-lg">
@@ -288,13 +150,6 @@ export default function RegisterPage() {
               {t("register.title") || "Create Account"}
             </h2>
 
-            {displayError && (
-              <div className="mb-4 flex items-start gap-2 p-3 bg-red-900/50 text-red-300 rounded-lg border border-red-500/30 text-sm">
-                <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                {displayError}
-              </div>
-            )}
-
             {success && (
               <div className="mb-4 flex items-center gap-2 p-3 bg-green-900/50 text-green-300 rounded-lg border border-green-500/30 text-sm">
                 <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
@@ -302,14 +157,11 @@ export default function RegisterPage() {
               </div>
             )}
 
-            {/* Mode tabs */}
             <div className="flex rounded-lg bg-gray-800/50 p-1 mb-6 gap-1">
               <button
                 onClick={() => switchMode("wallet")}
                 className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${
-                  mode === "wallet"
-                    ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow"
-                    : "text-gray-400 hover:text-white"
+                  mode === "wallet" ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow" : "text-gray-400 hover:text-white"
                 }`}
               >
                 <Wallet className="h-4 w-4" />
@@ -318,9 +170,7 @@ export default function RegisterPage() {
               <button
                 onClick={() => switchMode("email")}
                 className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium transition-all ${
-                  mode === "email"
-                    ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow"
-                    : "text-gray-400 hover:text-white"
+                  mode === "email" ? "bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white shadow" : "text-gray-400 hover:text-white"
                 }`}
               >
                 <Mail className="h-4 w-4" />
@@ -328,33 +178,36 @@ export default function RegisterPage() {
               </button>
             </div>
 
-            {/* Shared: username field */}
-            <div className="mb-5">
-              <label className="block text-sm font-medium mb-2 text-gray-300">
-                {t("register.userName") || "Username"}{" "}
-                <span className="text-gray-500 font-normal">(optional)</span>
-              </label>
-              <div className="relative">
-                <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
-                <Input
-                  type="text"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  placeholder={t("register.inputPlaceholderTwo") || "Choose a username"}
-                  className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
-                  maxLength={50}
-                />
-              </div>
-            </div>
-
-            {/* ── WALLET MODE ── */}
+            {/* WALLET MODE */}
             {mode === "wallet" && (
               <div className="space-y-5">
+                {displayWalletError && (
+                  <div className="flex items-start gap-2 p-3 bg-red-900/50 text-red-300 rounded-lg border border-red-500/30 text-sm">
+                    <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                    {displayWalletError}
+                  </div>
+                )}
+                <div className="mb-5">
+                  <label className="block text-sm font-medium mb-2 text-gray-300">
+                    {t("register.userName") || "Username"}{" "}
+                    <span className="text-gray-500 font-normal">(optional)</span>
+                  </label>
+                  <div className="relative">
+                    <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                    <Input
+                      type="text"
+                      value={walletUsername}
+                      onChange={(e) => setWalletUsername(e.target.value)}
+                      placeholder={t("register.inputPlaceholderTwo") || "Choose a username"}
+                      className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      maxLength={50}
+                    />
+                  </div>
+                </div>
                 <div>
                   <label className="block text-sm font-medium mb-2 text-gray-300">
                     {t("register.walletAddress") || "Stellar Wallet Address"}
                   </label>
-
                   {connected && address ? (
                     <div className="flex items-center justify-between w-full bg-gray-800/50 border border-green-500/30 rounded-lg px-4 py-3">
                       <div className="flex items-center gap-2 min-w-0">
@@ -365,50 +218,64 @@ export default function RegisterPage() {
                       </div>
                       <div className="flex items-center gap-2 ml-2 flex-shrink-0">
                         <WalletNetworkStatus network={defaultNetwork} />
-                        <button
-                          onClick={disconnect}
-                          className="text-xs text-red-400 hover:text-red-300 transition-colors"
-                        >
+                        <button type="button" onClick={disconnect} className="text-xs text-red-400 hover:text-red-300 transition-colors">
                           Change
                         </button>
                       </div>
                     </div>
                   ) : (
                     <Input
-                      type="text"
-                      value=""
-                      readOnly
+                      type="text" value="" readOnly
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg px-4 py-3 text-sm"
                       placeholder={t("register.inputPlaceholderOne") || "Connect wallet to populate"}
                     />
                   )}
                 </div>
-
                 <Button
+                  type="button"
                   onClick={connected ? handleWalletRegister : () => setWalletModalOpen(true)}
-                  disabled={loading || connecting}
+                  disabled={walletLoading || connecting}
                   className="w-full py-3 px-4 rounded-lg font-medium transition bg-gradient-to-r from-[#4e3bff] to-[#9747ff] hover:opacity-90 flex items-center justify-center gap-2"
                 >
                   <Wallet className="h-4 w-4" />
-                  {loading
-                    ? t("register.creatingAccount") || "Creating account…"
-                    : connecting
-                    ? t("register.connecting") || "Connecting…"
-                    : connected
-                    ? t("register.completeRegistration") || "Complete Registration"
+                  {walletLoading ? t("register.creatingAccount") || "Creating account…"
+                    : connecting ? t("register.connecting") || "Connecting…"
+                    : connected ? t("register.completeRegistration") || "Complete Registration"
                     : t("register.connectWallet") || "Connect Wallet"}
                 </Button>
-
                 <p className="text-xs text-gray-500 text-center">
-                  {t("register.stellarSecure") ||
-                    "Your Stellar public key is used as your account identifier. Your private key never leaves your wallet."}
+                  {t("register.stellarSecure") || "Your Stellar public key is used as your account identifier. Your private key never leaves your wallet."}
                 </p>
               </div>
             )}
 
-            {/* ── EMAIL MODE ── */}
+            {/* EMAIL MODE */}
             {mode === "email" && (
-              <div className="space-y-4">
+              <form onSubmit={handleSubmit(onEmailSubmit)} className="space-y-4" noValidate>
+                {errors.root && (
+                  <div className="flex items-start gap-2 p-3 bg-red-900/50 text-red-300 rounded-lg border border-red-500/30 text-sm">
+                    <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                    {errors.root.message}
+                  </div>
+                )}
+
+                <div>
+                  <label className="block text-sm font-medium mb-2 text-gray-300">
+                    {t("register.userName") || "Username"}{" "}
+                    <span className="text-gray-500 font-normal">(optional)</span>
+                  </label>
+                  <div className="relative">
+                    <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                    <Input
+                      type="text"
+                      placeholder={t("register.inputPlaceholderTwo") || "Choose a username"}
+                      className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      maxLength={50}
+                      {...register("username")}
+                    />
+                  </div>
+                </div>
+
                 <div>
                   <label className="block text-sm font-medium mb-2 text-gray-300">
                     {t("register.email") || "Email"}
@@ -417,12 +284,12 @@ export default function RegisterPage() {
                     <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
                       placeholder="you@example.com"
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      {...register("email")}
                     />
                   </div>
+                  {errors.email && <p className="mt-1 text-xs text-red-400">{errors.email.message}</p>}
                 </div>
 
                 <div>
@@ -433,10 +300,9 @@ export default function RegisterPage() {
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type={showPassword ? "text" : "password"}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
                       placeholder="Min. 8 characters"
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-10 py-3 text-sm"
+                      {...register("password")}
                     />
                     <button
                       type="button"
@@ -446,6 +312,7 @@ export default function RegisterPage() {
                       {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                     </button>
                   </div>
+                  {errors.password && <p className="mt-1 text-xs text-red-400">{errors.password.message}</p>}
                 </div>
 
                 <div>
@@ -456,15 +323,14 @@ export default function RegisterPage() {
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
                     <Input
                       type={showPassword ? "text" : "password"}
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
                       placeholder="Repeat password"
                       className="w-full bg-gray-800/50 border border-purple-500/20 rounded-lg pl-9 pr-4 py-3 text-sm"
+                      {...register("confirmPassword")}
                     />
                   </div>
+                  {errors.confirmPassword && <p className="mt-1 text-xs text-red-400">{errors.confirmPassword.message}</p>}
                 </div>
 
-                {/* Optional wallet link for email users */}
                 {connected && address && (
                   <div className="flex items-center gap-2 p-3 rounded-lg bg-purple-500/10 border border-purple-500/20 text-sm text-purple-300">
                     <CheckCircle2 className="h-4 w-4 flex-shrink-0 text-green-400" />
@@ -474,6 +340,7 @@ export default function RegisterPage() {
 
                 {!connected && (
                   <button
+                    type="button"
                     onClick={() => setWalletModalOpen(true)}
                     className="w-full text-sm text-purple-400 hover:text-purple-300 flex items-center justify-center gap-1 py-2 transition-colors"
                   >
@@ -484,23 +351,20 @@ export default function RegisterPage() {
                 )}
 
                 <Button
-                  onClick={handleEmailRegister}
-                  disabled={loading}
+                  type="submit"
+                  disabled={isSubmitting}
                   className="w-full py-3 px-4 rounded-lg font-medium transition bg-gradient-to-r from-[#4e3bff] to-[#9747ff] hover:opacity-90"
                 >
-                  {loading
+                  {isSubmitting
                     ? t("register.creatingAccount") || "Creating account…"
                     : t("register.completeRegistration") || "Complete Registration"}
                 </Button>
-              </div>
+              </form>
             )}
 
             <div className="mt-6 text-center text-sm text-gray-400">
               {t("register.alreadyHave") || "Already have an account?"}{" "}
-              <a
-                href={`/${locale}/auth/login`}
-                className="text-purple-400 hover:text-purple-300"
-              >
+              <a href={`/${locale}/auth/login`} className="text-purple-400 hover:text-purple-300">
                 {t("register.signIn") || "Sign in"}
               </a>
             </div>
@@ -508,10 +372,7 @@ export default function RegisterPage() {
         </div>
       </div>
 
-      <WalletModal
-        open={walletModalOpen}
-        onClose={() => setWalletModalOpen(false)}
-      />
+      <WalletModal open={walletModalOpen} onClose={() => setWalletModalOpen(false)} />
     </div>
   );
 }

--- a/nftopia-frontend/features/auth/store/authStore.ts
+++ b/nftopia-frontend/features/auth/store/authStore.ts
@@ -59,6 +59,29 @@ export const useAuthStore = create<AuthStore>()(
           ) => {
             throw new Error("Not implemented");
           },
+          register: async (_email: string, _password: string, _username?: string) => {
+            throw new Error("Not implemented");
+          },
+          emailLogin: async (_email: string, _password: string) => {
+            throw new Error("Not implemented");
+          },
+          getWalletChallenge: async (_walletAddress: string, _walletProvider?: string) => {
+            throw new Error("Not implemented");
+          },
+          verifyWalletSignature: async (_walletAddress: string, _nonce: string, _signature: string, _walletProvider?: string) => {
+            throw new Error("Not implemented");
+          },
+          linkWallet: async (_walletAddress: string, _nonce: string, _signature: string, _walletProvider?: string) => {
+            throw new Error("Not implemented");
+          },
+          unlinkWallet: async (_walletAddress: string) => {
+            throw new Error("Not implemented");
+          },
+          listWallets: async () => {
+            throw new Error("Not implemented");
+          },
+          isAccessTokenExpired: () => true,
+          getCurrentUser: () => null,
           logout: async () => {
             throw new Error("Not implemented");
           },

--- a/nftopia-frontend/features/auth/store/authStore.ts
+++ b/nftopia-frontend/features/auth/store/authStore.ts
@@ -81,7 +81,6 @@ export const useAuthStore = create<AuthStore>()(
             throw new Error("Not implemented");
           },
           isAccessTokenExpired: () => true,
-          getCurrentUser: () => null,
           logout: async () => {
             throw new Error("Not implemented");
           },

--- a/nftopia-frontend/features/auth/store/authStore.ts
+++ b/nftopia-frontend/features/auth/store/authStore.ts
@@ -52,7 +52,7 @@ export const useAuthStore = create<AuthStore>()(
           },
           verifySignature: async (
             _walletAddress: string,
-            _signature: string,
+            _signature: [string, string],
             _nonce: string,
             _walletProvider: 'freighter' | 'albedo' | 'walletconnect',
             _locale: string
@@ -82,9 +82,6 @@ export const useAuthStore = create<AuthStore>()(
           },
           isAccessTokenExpired: () => true,
           logout: async () => {
-            throw new Error("Not implemented");
-          },
-          emailLogin: async (_email: string, _password: string) => {
             throw new Error("Not implemented");
           },
           refreshToken: async () => {

--- a/nftopia-frontend/lib/context/AuthContext.tsx
+++ b/nftopia-frontend/lib/context/AuthContext.tsx
@@ -39,7 +39,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   // Load wallets on user change
   useEffect(() => {
     if (auth.user) {
-      auth.listWallets().then(setWallets).catch(() => setWallets([]));
+      auth.listWallets().then((w) => setWallets(w as UserWallet[])).catch(() => setWallets([]));
     } else {
       setWallets([]);
     }
@@ -78,7 +78,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const unlinkWallet = async (address: string) => {
     await auth.unlinkWallet(address);
-    setWallets(await auth.listWallets() || []);
+    setWallets((await auth.listWallets() as UserWallet[]) || []);
   };
 
   const value: AuthContextType = {

--- a/nftopia-frontend/lib/errors/serverErrorMapper.ts
+++ b/nftopia-frontend/lib/errors/serverErrorMapper.ts
@@ -1,0 +1,38 @@
+type FieldErrors = Record<string, string>;
+
+interface MappedError {
+  fieldErrors: FieldErrors;
+  formError: string;
+}
+
+interface ServerErrorPayload {
+  errors?: Record<string, string | string[]>;
+  message?: string;
+  error?: string;
+}
+
+export function mapServerError(err: unknown): MappedError {
+  const fieldErrors: FieldErrors = {};
+  let formError = "Something went wrong. Please try again.";
+
+  if (!err || typeof err !== "object") return { fieldErrors, formError };
+
+  const payload = err as ServerErrorPayload;
+
+  // Known shape: { errors: { fieldName: "message" | ["message"] } }
+  if (payload.errors && typeof payload.errors === "object") {
+    for (const [field, msg] of Object.entries(payload.errors)) {
+      fieldErrors[field] = Array.isArray(msg) ? msg[0] : msg;
+    }
+    return { fieldErrors, formError: "" };
+  }
+
+  // Single string message
+  if (typeof payload.message === "string") {
+    formError = payload.message;
+  } else if (typeof payload.error === "string") {
+    formError = payload.error;
+  }
+
+  return { fieldErrors, formError };
+}

--- a/nftopia-frontend/lib/stores/types.ts
+++ b/nftopia-frontend/lib/stores/types.ts
@@ -31,12 +31,10 @@ export interface AuthActions {
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   requestNonce: (walletAddress: string) => Promise<string>;
-  verifySignature: (walletAddress: string, signature: string) => Promise<void>;
+  verifySignature: (walletAddress: string, signature: [string, string]) => Promise<void>;
   logout: () => Promise<void>;
   clearError: () => void;
 }
-
-// export type AuthStore = AuthState & AuthActions;
 
 export type AuthStore = {
   user: User | null;
@@ -45,22 +43,40 @@ export type AuthStore = {
   error: string | null;
   accessToken: string | null;
   refreshTokenValue: string | null;
+
+  // Setters
   setUser: (user: User | null) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   clearError: () => void;
+
+  // Email auth
+  register: (email: string, password: string, username?: string) => Promise<void>;
+  emailLogin: (email: string, password: string) => Promise<void>;
+
+  // Wallet auth
+  getWalletChallenge: (walletAddress: string, walletProvider?: string) => Promise<unknown>;
+  verifyWalletSignature: (walletAddress: string, nonce: string, signature: string, walletProvider?: string) => Promise<void>;
+  linkWallet: (walletAddress: string, nonce: string, signature: string, walletProvider?: string) => Promise<unknown>;
+  unlinkWallet: (walletAddress: string) => Promise<unknown>;
+  listWallets: () => Promise<unknown>;
+
+  // Legacy Starknet methods (kept for backward compat)
   requestNonce: (walletAddress: string) => Promise<string>;
   verifySignature: (
     walletAddress: string,
-    signature: string,
+    signature: [string, string],
     nonce: string,
     walletProvider: 'freighter' | 'albedo' | 'walletconnect',
     locale: string
   ) => Promise<void>;
-  emailLogin: (email: string, password: string) => Promise<void>;
-  logout: () => Promise<void>;
+
+  // Token / session
   refreshToken: () => Promise<string>;
+  isAccessTokenExpired: () => boolean;
   getCurrentUser: () => User | null;
+
+  logout: () => Promise<void>;
 };
 
 // Collection Store Types
@@ -132,37 +148,24 @@ export interface CollectionState {
 }
 
 export interface CollectionActions {
-  // Collection actions
   setCollections: (collections: Collection[]) => void;
   addCollection: (collection: Collection) => void;
   updateCollection: (id: string | number, updates: Partial<Collection>) => void;
   removeCollection: (id: string | number) => void;
   setCurrentCollection: (collection: Collection | null) => void;
-  
-  // User collections
   setUserCollections: (collections: Collection[]) => void;
-  
-  // NFT actions
   setNFTs: (nfts: NFT[]) => void;
   addNFT: (nft: NFT) => void;
   updateNFT: (id: string, updates: Partial<NFT>) => void;
   removeNFT: (id: string) => void;
   setUserNFTs: (nfts: NFT[]) => void;
-  
-  // Loading states
   setLoading: (key: keyof CollectionState['loading'], loading: boolean) => void;
-  
-  // Error handling
   setError: (error: string | null) => void;
   clearError: () => void;
-  
-  // Pagination
   setPagination: (
     type: 'collections' | 'nfts',
     pagination: Partial<CollectionState['pagination']['collections'] | CollectionState['pagination']['nfts']>
   ) => void;
-  
-  // API actions
   fetchCollections: () => Promise<void>;
   fetchUserCollections: () => Promise<void>;
   fetchNFTs: (collectionId?: string) => Promise<void>;
@@ -173,7 +176,6 @@ export interface CollectionActions {
 
 export type CollectionStore = CollectionState & CollectionActions;
 
-// User Preferences Store Types
 export interface Theme {
   mode: 'light' | 'dark' | 'system';
   primaryColor: string;
@@ -228,7 +230,6 @@ export interface PreferencesActions {
 
 export type PreferencesStore = PreferencesState & PreferencesActions;
 
-// App Store Types (Global UI state)
 export interface AppState {
   isOnline: boolean;
   sidebarOpen: boolean;
@@ -261,10 +262,9 @@ export interface AppActions {
 
 export type AppStore = AppState & AppActions;
 
-// Combined store type for DevTools
 export interface RootStore {
   auth: AuthStore;
   collections: CollectionStore;
   preferences: PreferencesStore;
   app: AppStore;
-} 
+}

--- a/nftopia-frontend/lib/validation/auth.ts
+++ b/nftopia-frontend/lib/validation/auth.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(1, "Password is required"),
+});
+
+export const registerSchema = z
+  .object({
+    username: z.string().optional(),
+    email: z.string().email("Invalid email address"),
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type LoginFormData = z.infer<typeof loginSchema>;
+export type RegisterFormData = z.infer<typeof registerSchema>;

--- a/nftopia-frontend/package-lock.json
+++ b/nftopia-frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@albedo-link/intent": "^0.13.0",
         "@apollo/client": "^3.14.0",
+        "@hookform/resolvers": "^5.4.0",
         "@lottiefiles/dotlottie-react": "^0.14.4",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.7",
@@ -41,6 +42,7 @@
         "posthog-js": "^1.376.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-hook-form": "^7.76.1",
         "react-loading-skeleton": "^3.5.0",
         "shadcn-ui": "^0.9.5",
         "tailwind-merge": "^3.0.2",
@@ -48,6 +50,7 @@
         "tailwindcss-animate": "^1.0.7",
         "use-sound": "^5.0.0",
         "uuid": "^11.1.0",
+        "zod": "^4.4.3",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -4812,6 +4815,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -7035,6 +7050,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@stellar/freighter-api": {
       "version": "6.0.1",
@@ -10599,6 +10620,16 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/ci-info": {
@@ -19592,6 +19623,22 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.76.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.1.tgz",
+      "integrity": "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -23502,10 +23549,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/nftopia-frontend/package.json
+++ b/nftopia-frontend/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@albedo-link/intent": "^0.13.0",
     "@apollo/client": "^3.14.0",
+    "@hookform/resolvers": "^5.4.0",
     "@lottiefiles/dotlottie-react": "^0.14.4",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.7",
@@ -52,6 +53,7 @@
     "posthog-js": "^1.376.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.76.1",
     "react-loading-skeleton": "^3.5.0",
     "shadcn-ui": "^0.9.5",
     "tailwind-merge": "^3.0.2",
@@ -59,6 +61,7 @@
     "tailwindcss-animate": "^1.0.7",
     "use-sound": "^5.0.0",
     "uuid": "^11.1.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #227

## What this does
- Adds shared Zod validation schemas for login and register forms (`lib/validation/auth.ts`)
- Adds a shared server error mapper that converts backend error payloads to field-level or form-level feedback (`lib/errors/serverErrorMapper.ts`)
- Updates login and register pages to use react-hook-form + zodResolver with the shared schemas
- Maps backend errors to field hints where possible, falls back to a form-level message for unknown payloads
- Adds tests for validation rules and server error mapping

## Notes
- No backend files modified
- Fresh branch off current main to avoid merge conflicts from #187