### PR TITLE
feat(backend): add production Dockerfile with multi-stage build

### DIFF
--- a/nftopia-backend/.dockerignore
+++ b/nftopia-backend/.dockerignore
@@ -1,3 +1,14 @@
 node_modules
 dist
 .env
+.env.*
+!.env.example
+coverage
+*.log
+.git
+.gitignore
+README.md
+test
+**/*.spec.ts
+**/*.e2e-spec.ts
+jest*.json

--- a/nftopia-backend/Dockerfile
+++ b/nftopia-backend/Dockerfile
@@ -1,0 +1,43 @@
+# ── Stage 1: builder ──────────────────────────────────────────────────────────
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+# Copy manifests first for layer-cached dependency install
+COPY package*.json ./
+RUN npm ci --include=dev
+
+COPY . .
+RUN npm run build
+
+# Prune dev dependencies so only production deps land in the final image
+RUN npm prune --omit=dev
+
+# ── Stage 2: production ───────────────────────────────────────────────────────
+FROM node:22-slim AS production
+
+# Security: run as non-root
+RUN groupadd --gid 1001 nftopia && \
+    useradd  --uid 1001 --gid nftopia --shell /bin/bash --create-home nftopia
+
+WORKDIR /app
+
+# Copy built artifacts and pruned node_modules from builder
+COPY --from=builder --chown=nftopia:nftopia /app/dist       ./dist
+COPY --from=builder --chown=nftopia:nftopia /app/node_modules ./node_modules
+COPY --from=builder --chown=nftopia:nftopia /app/package.json ./package.json
+
+USER nftopia
+
+# REST API
+EXPOSE 3000
+# GraphQL endpoint (optional secondary port)
+EXPOSE 3001
+
+ENV NODE_ENV=production
+
+# Healthcheck wired to the /health endpoint already present in the app
+HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:'+process.env.PORT || 3000+'/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+
+CMD ["node", "dist/main"]


### PR DESCRIPTION
## Summary

- Two-stage build (builder → production): only compiled `dist/` and pruned `node_modules` land in the final image, keeping it small
- Runs as non-root user `nftopia` (uid 1001) per container security best practices
- `HEALTHCHECK` wired to the existing `/health` endpoint (30s interval, 3 retries, 45s start period)
- `.dockerignore` expanded to exclude test files, coverage, and secrets
- Exposes port `3000` (REST) and `3001` (GraphQL)
- Base: `node:22-slim` for minimal attack surface

## Test plan

- [ ] `docker build -t nftopia-backend ./nftopia-backend` — image builds successfully
- [ ] `docker run -p 3000:3000 --env-file .env nftopia-backend` — app starts and `/health` returns 200
- [ ] Confirm image runs as non-root: `docker run --rm nftopia-backend id` → uid=1001
- [ ] Confirm dev `node_modules` not present in final image
- [ ] HEALTHCHECK transitions to `healthy` within start period

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)