### PR TITLE
feat(backend): add migration locking to prevent concurrent schema changes

### DIFF
--- a/nftopia-backend/package.json
+++ b/nftopia-backend/package.json
@@ -18,7 +18,11 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "db:seed": "ts-node -r tsconfig-paths/register src/seed.ts"
+    "db:seed": "ts-node -r tsconfig-paths/register src/seed.ts",
+    "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/data-source.ts",
+    "migration:create": "typeorm-ts-node-commonjs migration:create",
+    "migration:run": "RUN_MIGRATIONS=true node dist/main",
+    "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/data-source.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.13.0",

--- a/nftopia-backend/src/app.module.ts
+++ b/nftopia-backend/src/app.module.ts
@@ -31,6 +31,7 @@ import { HealthModule } from './health/health.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
 import { OfferModule } from './modules/offer/offer.module';
 import { TransactionModule } from './modules/transaction/transaction.module';
+import { DatabaseModule } from './database/database.module';
 
 @Module({
   imports: [
@@ -96,7 +97,12 @@ import { TransactionModule } from './modules/transaction/transaction.module';
               password: config.get<string>('DB_PASS') || process.env.DB_PASS,
               database: config.get<string>('DB_NAME') || process.env.DB_NAME,
               autoLoadEntities: true,
-              synchronize: true,
+              // synchronize disabled in production — use MigrationLockService instead
+              synchronize: config.get('NODE_ENV') !== 'production',
+              migrations: config.get('NODE_ENV') === 'production'
+                ? ['dist/migrations/*.js']
+                : [],
+              migrationsRun: false, // controlled by MigrationLockService with advisory lock
               logging: config.get('NODE_ENV') === 'development',
               extra: {
                 max: parseInt(
@@ -123,6 +129,7 @@ import { TransactionModule } from './modules/transaction/transaction.module';
           UsersModule,
           AdminModule,
         ]),
+    DatabaseModule,
     CollectionModule,
     NftModule,
     AuctionModule,

--- a/nftopia-backend/src/database/database.module.ts
+++ b/nftopia-backend/src/database/database.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { MigrationLockService } from './migration-lock.service';
+
+@Module({
+  providers: [MigrationLockService],
+})
+export class DatabaseModule {}

--- a/nftopia-backend/src/database/migration-lock.service.ts
+++ b/nftopia-backend/src/database/migration-lock.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+const ADVISORY_LOCK_KEY = 8675309; // deterministic app-wide lock key
+
+@Injectable()
+export class MigrationLockService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(MigrationLockService.name);
+
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    if (process.env.NODE_ENV === 'test') return;
+    if (process.env.RUN_MIGRATIONS !== 'true') return;
+
+    await this.runWithAdvisoryLock();
+  }
+
+  private async runWithAdvisoryLock(): Promise<void> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+
+    try {
+      this.logger.log('Acquiring PostgreSQL advisory lock for migrations…');
+      await queryRunner.query(
+        `SELECT pg_advisory_lock($1)`,
+        [ADVISORY_LOCK_KEY],
+      );
+      this.logger.log('Advisory lock acquired — running pending migrations');
+
+      const migrations = await this.dataSource.runMigrations({
+        transaction: 'each',
+      });
+
+      if (migrations.length === 0) {
+        this.logger.log('No pending migrations to run');
+      } else {
+        this.logger.log(
+          `Ran ${migrations.length} migration(s): ${migrations.map((m) => m.name).join(', ')}`,
+        );
+      }
+    } catch (err) {
+      this.logger.error('Migration failed', err instanceof Error ? err.stack : String(err));
+      throw err;
+    } finally {
+      await queryRunner.query(
+        `SELECT pg_advisory_unlock($1)`,
+        [ADVISORY_LOCK_KEY],
+      );
+      this.logger.log('Advisory lock released');
+      await queryRunner.release();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `MigrationLockService` acquires a **PostgreSQL advisory lock** (`pg_advisory_lock(8675309)`) before running migrations, ensuring only one instance executes schema changes during rolling deploys / horizontal scale-up
- `synchronize` set to `false` in production (still `true` in dev/test for developer ergonomics)
- Opt-in via `RUN_MIGRATIONS=true` env var — normal restarts skip the lock
- `migrations:` path configured to `dist/migrations/*.js` in production
- Migration CLI scripts added to `package.json`: `generate`, `create`, `run`, `revert`
- `DatabaseModule` wired into `AppModule`

## Test plan

- [ ] Set `RUN_MIGRATIONS=true NODE_ENV=production` and start two instances simultaneously — verify only one runs migrations
- [ ] Verify advisory lock is released in the `finally` block even on migration failure
- [ ] Start with `NODE_ENV=development` — confirm `synchronize: true` behavior unchanged
- [ ] `npm run migration:run` on a fresh DB — confirm migrations execute and lock is released
- [ ] Kill process mid-migration — confirm PostgreSQL releases the advisory lock on connection close

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)