### PR TITLE
feat(notifications): add heartbeat and reconnect logic to gateway

### DIFF
--- a/nftopia-backend/src/modules/notifications/notifications.config.ts
+++ b/nftopia-backend/src/modules/notifications/notifications.config.ts
@@ -1,10 +1,16 @@
 import { ConfigService } from '@nestjs/config';
 
 export const DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES = 64 * 1024; // 64KB
+export const DEFAULT_WS_PING_INTERVAL_MS = 25_000;
+export const DEFAULT_WS_PING_TIMEOUT_MS = 10_000;
+export const DEFAULT_WS_STALE_CLEANUP_INTERVAL_MS = 60_000;
 
 export interface NotificationsConfig {
   websocket: {
     maxMessageSizeBytes: number;
+    pingIntervalMs: number;
+    pingTimeoutMs: number;
+    staleCleanupIntervalMs: number;
   };
 }
 
@@ -24,6 +30,18 @@ export const getNotificationsConfig = (
     maxMessageSizeBytes: toNumber(
       configService.get<string>('WEBSOCKET_MAX_MESSAGE_SIZE_BYTES'),
       DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
+    ),
+    pingIntervalMs: toNumber(
+      configService.get<string>('WEBSOCKET_PING_INTERVAL_MS'),
+      DEFAULT_WS_PING_INTERVAL_MS,
+    ),
+    pingTimeoutMs: toNumber(
+      configService.get<string>('WEBSOCKET_PING_TIMEOUT_MS'),
+      DEFAULT_WS_PING_TIMEOUT_MS,
+    ),
+    staleCleanupIntervalMs: toNumber(
+      configService.get<string>('WEBSOCKET_STALE_CLEANUP_INTERVAL_MS'),
+      DEFAULT_WS_STALE_CLEANUP_INTERVAL_MS,
     ),
   },
 });

--- a/nftopia-backend/src/modules/notifications/notifications.gateway.ts
+++ b/nftopia-backend/src/modules/notifications/notifications.gateway.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { Logger, OnApplicationShutdown } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import {
@@ -24,6 +24,7 @@ import {
 type AuthenticatedSocket = Socket & {
   data: {
     user?: AuthenticatedSocketUser;
+    lastPongAt?: number;
     [key: string]: unknown;
   };
 };
@@ -70,12 +71,13 @@ type AuthenticatedSocket = Socket & {
   maxHttpBufferSize: 1e6, // Set to 1MB initially, will be overridden in afterInit
 })
 export class NotificationsGateway
-  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect, OnApplicationShutdown
 {
   @WebSocketServer()
   private server!: Server;
 
   private readonly logger = new Logger(NotificationsGateway.name);
+  private staleCleanupTimer: NodeJS.Timeout | null = null;
 
   constructor(
     private readonly jwtService: JwtService,
@@ -91,9 +93,19 @@ export class NotificationsGateway
     const config = getNotificationsConfig(this.configService);
     this.server.engine.opts.maxHttpBufferSize =
       config.websocket.maxMessageSizeBytes;
+
+    // Configure Socket.IO-level ping/pong for transport-layer keepalive
+    this.server.engine.opts.pingInterval = config.websocket.pingIntervalMs;
+    this.server.engine.opts.pingTimeout  = config.websocket.pingTimeoutMs;
+
     this.logger.log(
-      `NotificationsGateway initialised on /notifications with max message size: ${config.websocket.maxMessageSizeBytes} bytes`,
+      `NotificationsGateway initialised on /notifications | maxMsg: ${config.websocket.maxMessageSizeBytes}B | ping: ${config.websocket.pingIntervalMs}ms / timeout: ${config.websocket.pingTimeoutMs}ms`,
     );
+
+    // Application-level stale connection cleanup
+    this.staleCleanupTimer = setInterval(() => {
+      void this.cleanupStaleConnections(config.websocket.pingIntervalMs + config.websocket.pingTimeoutMs);
+    }, config.websocket.staleCleanupIntervalMs);
 
     // Add error handling for oversized messages
 
@@ -149,6 +161,7 @@ export class NotificationsGateway
       const typedClient = client as AuthenticatedSocket;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       typedClient.data.user = user;
+      typedClient.data.lastPongAt = Date.now();
 
       void client.join(userRoom(user.userId));
       this.logger.debug(
@@ -166,13 +179,52 @@ export class NotificationsGateway
 
   handleDisconnect(client: Socket): void {
     const typedClient = client as AuthenticatedSocket;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     const user = typedClient.data.user;
     if (user) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       this.logger.debug(`User ${user.userId} disconnected (${client.id})`);
     } else {
       this.logger.debug(`Anonymous socket ${client.id} disconnected`);
+    }
+  }
+
+  onApplicationShutdown(): void {
+    if (this.staleCleanupTimer) {
+      clearInterval(this.staleCleanupTimer);
+      this.staleCleanupTimer = null;
+    }
+  }
+
+  /** Client-initiated ping for latency measurement and liveness confirmation. */
+  @SubscribeMessage('ping')
+  handlePing(
+    @MessageBody() _body: unknown,
+    @ConnectedSocket() client: Socket,
+  ): { event: string; serverTime: number } {
+    const typedClient = client as AuthenticatedSocket;
+    typedClient.data.lastPongAt = Date.now();
+    return { event: 'pong', serverTime: Date.now() };
+  }
+
+  private async cleanupStaleConnections(staleThresholdMs: number): Promise<void> {
+    const sockets = await this.server.fetchSockets();
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const socket of sockets) {
+      const typedSocket = socket as unknown as AuthenticatedSocket;
+      const lastPong = typedSocket.data.lastPongAt as number | undefined;
+      // Only force-disconnect if we have a recorded pong and it's older than threshold
+      if (lastPong !== undefined && now - lastPong > staleThresholdMs) {
+        this.logger.warn(
+          `Disconnecting stale socket ${socket.id} (last pong ${now - lastPong}ms ago)`,
+        );
+        socket.disconnect(true);
+        cleaned++;
+      }
+    }
+
+    if (cleaned > 0) {
+      this.logger.log(`Stale connection cleanup: disconnected ${cleaned} sockets`);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Socket.IO transport-level ping** configured via `pingInterval` / `pingTimeout` on the engine (env: `WEBSOCKET_PING_INTERVAL_MS` default 25s, `WEBSOCKET_PING_TIMEOUT_MS` default 10s) — Socket.IO handles TCP-level zombie detection automatically
- **Application-level `ping` handler** (`@SubscribeMessage('ping')`) returns `{ event: 'pong', serverTime }` for client latency measurement; updates `socket.data.lastPongAt`
- **Stale connection cleanup** runs on a configurable interval (default 60s, `WEBSOCKET_STALE_CLEANUP_INTERVAL_MS`): iterates `server.fetchSockets()` and force-disconnects any socket whose `lastPongAt` exceeds `pingInterval + pingTimeout`
- `lastPongAt` initialized on every successful `handleConnection` so new connections are never incorrectly cleaned up
- `OnApplicationShutdown` clears the cleanup timer
- `NotificationsConfig` extended with three new fields

## Test plan

- [ ] Connect a client, send `{ event: 'ping' }`, verify `pong` reply with `serverTime`
- [ ] Drop TCP without proper disconnect, wait 60s — verify server logs stale cleanup
- [ ] Verify `WEBSOCKET_PING_INTERVAL_MS=5000 WEBSOCKET_PING_TIMEOUT_MS=2000` overrides defaults
- [ ] Confirm no memory leak: `server.fetchSockets()` count drops after forced disconnects

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)