### PR TITLE
feat: Build public creator profile page

### DIFF
--- a/nftopia-backend/migrations/20260701000000_user_follows_and_created_at.sql
+++ b/nftopia-backend/migrations/20260701000000_user_follows_and_created_at.sql
@@ -1,0 +1,14 @@
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+CREATE TABLE IF NOT EXISTS user_follows (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  follower_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  following_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_user_follows_pair UNIQUE (follower_id, following_id),
+  CONSTRAINT chk_user_follows_not_self CHECK (follower_id <> following_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_follows_following_id ON user_follows (following_id);
+CREATE INDEX IF NOT EXISTS idx_user_follows_follower_id ON user_follows (follower_id);

--- a/nftopia-backend/src/graphql/resolvers/index.ts
+++ b/nftopia-backend/src/graphql/resolvers/index.ts
@@ -7,6 +7,7 @@ import { OrderResolver } from './order.resolver';
 import { UserResolver } from './user.resolver';
 import { AuctionResolver } from './auction.resolver';
 import { BidResolver } from './bid.resolver';
+import { PublicCreatorResolver } from './public-creator.resolver';
 
 export const graphqlResolvers = [
   BaseResolver,
@@ -17,6 +18,7 @@ export const graphqlResolvers = [
   UserResolver,
   AuctionResolver,
   BidResolver,
+  PublicCreatorResolver,
 ] as const;
 
 export const graphqlScalarClasses = [JsonScalar] as const;
@@ -30,3 +32,4 @@ export { OrderResolver };
 export { UserResolver };
 export { AuctionResolver };
 export { BidResolver };
+export { PublicCreatorResolver };

--- a/nftopia-backend/src/graphql/resolvers/public-creator.resolver.spec.ts
+++ b/nftopia-backend/src/graphql/resolvers/public-creator.resolver.spec.ts
@@ -1,0 +1,177 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PublicCreatorResolver } from './public-creator.resolver';
+import { CreatorNftSort } from '../types/public-creator.types';
+
+describe('PublicCreatorResolver', () => {
+  const mockUser = {
+    id: 'creator-1',
+    username: 'artist',
+    bio: 'Creator bio',
+    avatarUrl: 'https://cdn.example/avatar.png',
+    bannerUrl: null,
+    website: 'https://example.com',
+    twitterHandle: '@artist',
+    instagramHandle: null,
+    isBanned: false,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  };
+
+  const createResolver = (overrides?: {
+    usersService?: Partial<Record<string, jest.Mock>>;
+    followService?: Partial<Record<string, jest.Mock>>;
+    nftService?: Partial<Record<string, jest.Mock>>;
+    collectionService?: Partial<Record<string, jest.Mock>>;
+    listingService?: Partial<Record<string, jest.Mock>>;
+    orderService?: Partial<Record<string, jest.Mock>>;
+  }) =>
+    new PublicCreatorResolver(
+      {
+        findPublicCreator: jest.fn().mockResolvedValue(mockUser),
+        findById: jest.fn().mockResolvedValue(mockUser),
+        countNftsCreated: jest.fn().mockResolvedValue(3),
+        getCreatorSalesVolume: jest.fn().mockResolvedValue('12.5000000'),
+        isVerifiedCreator: jest.fn().mockResolvedValue(true),
+        ...overrides?.usersService,
+      } as never,
+      {
+        followerCount: jest.fn().mockResolvedValue(10),
+        followingCount: jest.fn().mockResolvedValue(2),
+        isFollowing: jest.fn().mockResolvedValue(false),
+        follow: jest.fn().mockResolvedValue(true),
+        unfollow: jest.fn().mockResolvedValue(true),
+        ...overrides?.followService,
+      } as never,
+      {
+        findConnection: jest.fn().mockResolvedValue({
+          data: [],
+          total: 0,
+          hasNextPage: false,
+        }),
+        ...overrides?.nftService,
+      } as never,
+      {
+        findConnection: jest.fn().mockResolvedValue({
+          data: [],
+          total: 0,
+          hasNextPage: false,
+        }),
+        ...overrides?.collectionService,
+      } as never,
+      {
+        findConnection: jest.fn().mockResolvedValue({
+          data: [],
+          total: 0,
+          hasNextPage: false,
+        }),
+        ...overrides?.listingService,
+      } as never,
+      {
+        findAllWithCount: jest.fn().mockResolvedValue({
+          items: [],
+          totalCount: 0,
+          hasNextPage: false,
+        }),
+        ...overrides?.orderService,
+      } as never,
+    );
+
+  it('returns a public creator profile', async () => {
+    const resolver = createResolver();
+    const result = await resolver.publicCreator('artist', {
+      req: {} as never,
+      res: {} as never,
+      user: { userId: 'viewer-1' },
+      loaders: {} as never,
+    });
+
+    expect(result.id).toBe('creator-1');
+    expect(result.username).toBe('artist');
+    expect(result.isVerified).toBe(true);
+    expect(result.followerCount).toBe(10);
+    expect(result.totalNftsCreated).toBe(3);
+  });
+
+  it('throws when creator is missing', async () => {
+    const resolver = createResolver({
+      usersService: {
+        findPublicCreator: jest.fn().mockResolvedValue(null),
+      },
+    });
+
+    await expect(
+      resolver.publicCreator('missing', {
+        req: {} as never,
+        res: {} as never,
+        loaders: {} as never,
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects invalid identifiers', async () => {
+    const resolver = createResolver();
+
+    await expect(
+      resolver.publicCreator('   ', {
+        req: {} as never,
+        res: {} as never,
+        loaders: {} as never,
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('follows a creator when authenticated', async () => {
+    const resolver = createResolver();
+    const result = await resolver.followCreator('creator-1', {
+      req: {} as never,
+      res: {} as never,
+      user: { userId: 'viewer-1' },
+      loaders: {} as never,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.isFollowing).toBe(true);
+    expect(result.followerCount).toBe(10);
+  });
+
+  it('loads creator nfts with sort filter', async () => {
+    const nftService = {
+      findConnection: jest.fn().mockResolvedValue({
+        data: [
+          {
+            id: 'nft-1',
+            tokenId: '1',
+            contractAddress: 'C1',
+            name: 'Art',
+            description: null,
+            imageUrl: 'https://cdn.example/nft.png',
+            attributes: [],
+            ownerId: 'owner-1',
+            creatorId: 'creator-1',
+            collectionId: null,
+            mintedAt: new Date('2024-02-01T00:00:00.000Z'),
+            lastPrice: '5.0000000',
+            createdAt: new Date('2024-02-01T00:00:00.000Z'),
+          },
+        ],
+        total: 1,
+        hasNextPage: false,
+      }),
+    };
+    const resolver = createResolver({ nftService });
+
+    const connection = await resolver.nfts(
+      { id: 'creator-1' } as never,
+      { first: 10 },
+      CreatorNftSort.PRICE,
+    );
+
+    expect(nftService.findConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creatorId: 'creator-1',
+        sortBy: 'PRICE',
+      }),
+    );
+    expect(connection.totalCount).toBe(1);
+    expect(connection.edges[0]?.node.id).toBe('nft-1');
+  });
+});

--- a/nftopia-backend/src/graphql/resolvers/public-creator.resolver.ts
+++ b/nftopia-backend/src/graphql/resolvers/public-creator.resolver.ts
@@ -2,7 +2,6 @@ import {
   Args,
   Context,
   ID,
-  Int,
   Mutation,
   Parent,
   Query,
@@ -56,7 +55,8 @@ export class PublicCreatorResolver {
 
   @Query(() => PublicCreatorType, {
     name: 'publicCreator',
-    description: 'Fetch a public creator profile by id, username, or wallet address',
+    description:
+      'Fetch a public creator profile by id, username, or wallet address',
   })
   async publicCreator(
     @Args('identifier', { type: () => String }) identifier: string,
@@ -147,8 +147,7 @@ export class PublicCreatorResolver {
     sortBy?: CreatorNftSort,
   ): Promise<NFTConnection> {
     const first = pagination?.first ?? 20;
-    const resolvedSort =
-      sortBy === CreatorNftSort.PRICE ? 'PRICE' : 'NEWEST';
+    const resolvedSort = sortBy === CreatorNftSort.PRICE ? 'PRICE' : 'NEWEST';
 
     const result = await this.nftService.findConnection({
       first,
@@ -244,9 +243,7 @@ export class PublicCreatorResolver {
       })),
     ];
 
-    items.sort(
-      (a, b) => b.occurredAt.getTime() - a.occurredAt.getTime(),
-    );
+    items.sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
 
     const filtered = after
       ? items.filter(

--- a/nftopia-backend/src/graphql/resolvers/public-creator.resolver.ts
+++ b/nftopia-backend/src/graphql/resolvers/public-creator.resolver.ts
@@ -397,7 +397,7 @@ export class PublicCreatorResolver {
       name: collection.name,
       symbol: collection.symbol,
       description: collection.description ?? null,
-      image: collection.image,
+      image: collection.imageUrl,
       creatorId: collection.creatorId,
       totalVolume: this.toDecimalString(collection.totalVolume),
       floorPrice: this.toDecimalString(collection.floorPrice),

--- a/nftopia-backend/src/graphql/resolvers/public-creator.resolver.ts
+++ b/nftopia-backend/src/graphql/resolvers/public-creator.resolver.ts
@@ -1,0 +1,523 @@
+import {
+  Args,
+  Context,
+  ID,
+  Int,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver,
+} from '@nestjs/graphql';
+import {
+  BadRequestException,
+  NotFoundException,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
+import type { GraphqlContext } from '../context/context.interface';
+import { UsersService } from '../../users/users.service';
+import { UserFollowService } from '../../users/user-follow.service';
+import { NftService } from '../../modules/nft/nft.service';
+import { CollectionService } from '../../modules/collection/collection.service';
+import { ListingService } from '../../modules/listing/listing.service';
+import { OrderService } from '../../modules/order/order.service';
+import { PaginationInput } from '../inputs/nft.inputs';
+import { NFTConnection, GraphqlNft } from '../types/nft.types';
+import {
+  CollectionConnection,
+  GraphqlCollection,
+} from '../types/collection.types';
+import type { User } from '../../users/user.entity';
+import type { Nft } from '../../modules/nft/entities/nft.entity';
+import type { Collection } from '../../modules/collection/entities/collection.entity';
+import {
+  CreatorActivityConnection,
+  CreatorActivityItem,
+  CreatorActivityKind,
+  CreatorNftSort,
+  FollowResultType,
+  PublicCreatorType,
+} from '../types/public-creator.types';
+
+const IDENTIFIER_MAX_LENGTH = 100;
+
+@Resolver(() => PublicCreatorType)
+export class PublicCreatorResolver {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly followService: UserFollowService,
+    private readonly nftService: NftService,
+    private readonly collectionService: CollectionService,
+    private readonly listingService: ListingService,
+    private readonly orderService: OrderService,
+  ) {}
+
+  @Query(() => PublicCreatorType, {
+    name: 'publicCreator',
+    description: 'Fetch a public creator profile by id, username, or wallet address',
+  })
+  async publicCreator(
+    @Args('identifier', { type: () => String }) identifier: string,
+    @Context() context: GraphqlContext,
+  ): Promise<PublicCreatorType> {
+    this.assertValidIdentifier(identifier);
+    const user = await this.usersService.findPublicCreator(identifier);
+    if (!user || user.isBanned) {
+      throw new NotFoundException('Creator not found');
+    }
+    return this.buildPublicCreator(user, context);
+  }
+
+  @Mutation(() => FollowResultType, {
+    name: 'followCreator',
+    description: 'Follow a creator (authenticated)',
+  })
+  @UseGuards(GqlAuthGuard)
+  async followCreator(
+    @Args('creatorId', { type: () => ID }) creatorId: string,
+    @Context() context: GraphqlContext,
+  ): Promise<FollowResultType> {
+    const followerId = context.user?.userId;
+    if (!followerId) {
+      throw new UnauthorizedException('Authentication is required');
+    }
+
+    const creator = await this.usersService.findById(creatorId);
+    if (!creator || creator.isBanned) {
+      throw new NotFoundException('Creator not found');
+    }
+
+    await this.followService.follow(followerId, creatorId);
+    const followerCount = await this.followService.followerCount(creatorId);
+
+    return {
+      success: true,
+      followerCount,
+      isFollowing: true,
+    };
+  }
+
+  @Mutation(() => FollowResultType, {
+    name: 'unfollowCreator',
+    description: 'Unfollow a creator (authenticated)',
+  })
+  @UseGuards(GqlAuthGuard)
+  async unfollowCreator(
+    @Args('creatorId', { type: () => ID }) creatorId: string,
+    @Context() context: GraphqlContext,
+  ): Promise<FollowResultType> {
+    const followerId = context.user?.userId;
+    if (!followerId) {
+      throw new UnauthorizedException('Authentication is required');
+    }
+
+    try {
+      await this.followService.unfollow(followerId, creatorId);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        const followerCount = await this.followService.followerCount(creatorId);
+        return {
+          success: true,
+          followerCount,
+          isFollowing: false,
+        };
+      }
+      throw error;
+    }
+
+    const followerCount = await this.followService.followerCount(creatorId);
+    return {
+      success: true,
+      followerCount,
+      isFollowing: false,
+    };
+  }
+
+  @ResolveField(() => NFTConnection, {
+    name: 'nfts',
+    nullable: true,
+  })
+  async nfts(
+    @Parent() creator: PublicCreatorType,
+    @Args('pagination', { type: () => PaginationInput, nullable: true })
+    pagination?: PaginationInput,
+    @Args('sortBy', { type: () => CreatorNftSort, nullable: true })
+    sortBy?: CreatorNftSort,
+  ): Promise<NFTConnection> {
+    const first = pagination?.first ?? 20;
+    const resolvedSort =
+      sortBy === CreatorNftSort.PRICE ? 'PRICE' : 'NEWEST';
+
+    const result = await this.nftService.findConnection({
+      first,
+      after: pagination?.after
+        ? this.decodeNftCursor(pagination.after)
+        : undefined,
+      creatorId: creator.id,
+      sortBy: resolvedSort,
+    });
+
+    return this.toNftConnection(result.data, result.total, result.hasNextPage);
+  }
+
+  @ResolveField(() => CollectionConnection, {
+    name: 'collections',
+    nullable: true,
+  })
+  async collections(
+    @Parent() creator: PublicCreatorType,
+    @Args('pagination', { type: () => PaginationInput, nullable: true })
+    pagination?: PaginationInput,
+  ): Promise<CollectionConnection> {
+    const first = pagination?.first ?? 20;
+    const result = await this.collectionService.findConnection({
+      first,
+      after: pagination?.after
+        ? this.decodeCollectionCursor(pagination.after)
+        : undefined,
+      creatorId: creator.id,
+    });
+
+    return this.toCollectionConnection(
+      result.data,
+      result.total,
+      result.hasNextPage,
+    );
+  }
+
+  @ResolveField(() => CreatorActivityConnection, {
+    name: 'activity',
+    nullable: true,
+  })
+  async activity(
+    @Parent() creator: PublicCreatorType,
+    @Args('pagination', { type: () => PaginationInput, nullable: true })
+    pagination?: PaginationInput,
+  ): Promise<CreatorActivityConnection> {
+    const first = Math.min(pagination?.first ?? 20, 50);
+    const after = pagination?.after
+      ? this.decodeActivityCursor(pagination.after)
+      : undefined;
+
+    const fetchSize = first + 1;
+    const [minted, listings, sales] = await Promise.all([
+      this.nftService.findConnection({
+        first: fetchSize,
+        creatorId: creator.id,
+      }),
+      this.listingService.findConnection({
+        first: fetchSize,
+        sellerId: creator.id,
+      }),
+      this.orderService.findAllWithCount({
+        sellerId: creator.id,
+        page: 1,
+        limit: fetchSize,
+        sortBy: 'createdAt',
+        sortOrder: 'DESC',
+      }),
+    ]);
+
+    const items: CreatorActivityItem[] = [
+      ...minted.data.map((nft) => ({
+        type: CreatorActivityKind.MINT,
+        occurredAt: nft.mintedAt ?? nft.createdAt,
+        nftId: nft.id,
+        price: nft.lastPrice ?? null,
+        currency: null,
+      })),
+      ...listings.data.map((listing) => ({
+        type: CreatorActivityKind.LISTING,
+        occurredAt: listing.createdAt,
+        nftId: `${listing.nftContractId}:${listing.nftTokenId}`,
+        price: this.toDecimalString(listing.price),
+        currency: listing.currency,
+      })),
+      ...sales.items.map((order) => ({
+        type: CreatorActivityKind.SALE,
+        occurredAt: order.createdAt,
+        nftId: order.nftId,
+        price: order.price,
+        currency: order.currency,
+      })),
+    ];
+
+    items.sort(
+      (a, b) => b.occurredAt.getTime() - a.occurredAt.getTime(),
+    );
+
+    const filtered = after
+      ? items.filter(
+          (item) =>
+            item.occurredAt.getTime() < after.occurredAt.getTime() ||
+            (item.occurredAt.getTime() === after.occurredAt.getTime() &&
+              `${item.type}:${item.nftId ?? ''}` <
+                `${after.type}:${after.nftId ?? ''}`),
+        )
+      : items;
+
+    const page = filtered.slice(0, first);
+    const edges = page.map((node) => ({
+      node,
+      cursor: this.encodeActivityCursor(node),
+    }));
+
+    return {
+      edges,
+      totalCount: items.length,
+    };
+  }
+
+  private async buildPublicCreator(
+    user: User,
+    context: GraphqlContext,
+  ): Promise<PublicCreatorType> {
+    const viewerId = context.user?.userId;
+
+    const [
+      followerCount,
+      followingCount,
+      totalNftsCreated,
+      totalSalesVolume,
+      isVerified,
+      isFollowing,
+    ] = await Promise.all([
+      this.followService.followerCount(user.id),
+      this.followService.followingCount(user.id),
+      this.usersService.countNftsCreated(user.id),
+      this.usersService.getCreatorSalesVolume(user.id),
+      this.usersService.isVerifiedCreator(user.id),
+      viewerId
+        ? this.followService.isFollowing(viewerId, user.id)
+        : Promise.resolve(null),
+    ]);
+
+    return {
+      id: user.id,
+      username: user.username ?? null,
+      bio: user.bio ?? null,
+      avatarUrl: user.avatarUrl ?? null,
+      bannerUrl: user.bannerUrl ?? null,
+      website: user.website ?? null,
+      twitterHandle: user.twitterHandle ?? null,
+      instagramHandle: user.instagramHandle ?? null,
+      isVerified,
+      followerCount,
+      followingCount,
+      totalNftsCreated,
+      totalSalesVolume,
+      createdAt: user.createdAt,
+      isFollowing,
+      nfts: undefined,
+      collections: undefined,
+      activity: undefined,
+      listings: undefined,
+      sales: undefined,
+    };
+  }
+
+  private assertValidIdentifier(identifier: string): void {
+    const trimmed = identifier.trim();
+    if (!trimmed || trimmed.length > IDENTIFIER_MAX_LENGTH) {
+      throw new BadRequestException('Invalid creator identifier');
+    }
+  }
+
+  private toNftConnection(
+    nfts: Nft[],
+    totalCount: number,
+    hasNextPage: boolean,
+  ): NFTConnection {
+    const edges = nfts.map((nft) => ({
+      node: this.toGraphqlNft(nft),
+      cursor: this.encodeNftCursor(nft),
+    }));
+
+    return {
+      edges,
+      pageInfo: {
+        hasNextPage,
+        startCursor: edges[0]?.cursor,
+        endCursor: edges.at(-1)?.cursor,
+      },
+      totalCount,
+    };
+  }
+
+  private toCollectionConnection(
+    collections: Collection[],
+    totalCount: number,
+    hasNextPage: boolean,
+  ): CollectionConnection {
+    const edges = collections.map((collection) => ({
+      node: this.toGraphqlCollection(collection),
+      cursor: this.encodeCollectionCursor(collection),
+    }));
+
+    return {
+      edges,
+      pageInfo: {
+        hasNextPage,
+        startCursor: edges[0]?.cursor,
+        endCursor: edges.at(-1)?.cursor,
+      },
+      totalCount,
+    };
+  }
+
+  private toGraphqlNft(nft: Nft): GraphqlNft {
+    return {
+      id: nft.id,
+      tokenId: nft.tokenId,
+      contractAddress: nft.contractAddress,
+      name: nft.name,
+      description: nft.description ?? null,
+      image: nft.imageUrl ?? null,
+      attributes: (nft.attributes ?? []).map((attribute) => ({
+        traitType: attribute.traitType,
+        value: attribute.value,
+        ...(attribute.displayType
+          ? { displayType: attribute.displayType }
+          : {}),
+      })),
+      ownerId: nft.ownerId,
+      creatorId: nft.creatorId,
+      collectionId: nft.collectionId ?? null,
+      mintedAt: nft.mintedAt,
+      lastPrice: nft.lastPrice ?? null,
+    };
+  }
+
+  private toGraphqlCollection(collection: Collection): GraphqlCollection {
+    return {
+      id: collection.id,
+      contractAddress: collection.contractAddress ?? null,
+      name: collection.name,
+      symbol: collection.symbol,
+      description: collection.description ?? null,
+      image: collection.image,
+      creatorId: collection.creatorId,
+      totalVolume: this.toDecimalString(collection.totalVolume),
+      floorPrice: this.toDecimalString(collection.floorPrice),
+      totalSupply: collection.totalSupply,
+      createdAt: collection.createdAt,
+      nfts: undefined,
+    };
+  }
+
+  private toDecimalString(value: string | number | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '0.0000000';
+    }
+
+    const parsed = Number(value);
+    if (Number.isNaN(parsed)) {
+      return '0.0000000';
+    }
+
+    return parsed.toFixed(7);
+  }
+
+  private encodeNftCursor(nft: Nft): string {
+    return Buffer.from(
+      JSON.stringify({
+        createdAt: nft.createdAt.toISOString(),
+        id: nft.id,
+        price: nft.lastPrice ?? '0',
+      }),
+      'utf8',
+    ).toString('base64url');
+  }
+
+  private decodeNftCursor(cursor: string): {
+    createdAt: string;
+    id: string;
+    price?: string;
+  } {
+    try {
+      const payload = JSON.parse(
+        Buffer.from(cursor, 'base64url').toString('utf8'),
+      ) as { createdAt: string; id: string; price?: string };
+
+      if (!payload.createdAt || !payload.id) {
+        throw new Error('Invalid cursor');
+      }
+
+      return payload;
+    } catch {
+      throw new BadRequestException('Invalid pagination cursor');
+    }
+  }
+
+  private encodeCollectionCursor(
+    collection: Pick<Collection, 'createdAt' | 'id'>,
+  ): string {
+    return Buffer.from(
+      JSON.stringify({
+        createdAt: collection.createdAt.toISOString(),
+        id: collection.id,
+      }),
+      'utf8',
+    ).toString('base64url');
+  }
+
+  private decodeCollectionCursor(cursor: string): {
+    createdAt: string;
+    id: string;
+  } {
+    try {
+      const payload = JSON.parse(
+        Buffer.from(cursor, 'base64url').toString('utf8'),
+      ) as { createdAt: string; id: string };
+
+      if (!payload.createdAt || !payload.id) {
+        throw new Error('Invalid cursor');
+      }
+
+      return payload;
+    } catch {
+      throw new BadRequestException('Invalid pagination cursor');
+    }
+  }
+
+  private encodeActivityCursor(item: CreatorActivityItem): string {
+    return Buffer.from(
+      JSON.stringify({
+        occurredAt: item.occurredAt.toISOString(),
+        type: item.type,
+        nftId: item.nftId ?? '',
+      }),
+      'utf8',
+    ).toString('base64url');
+  }
+
+  private decodeActivityCursor(cursor: string): {
+    occurredAt: Date;
+    type: CreatorActivityKind;
+    nftId?: string;
+  } {
+    try {
+      const payload = JSON.parse(
+        Buffer.from(cursor, 'base64url').toString('utf8'),
+      ) as {
+        occurredAt: string;
+        type: CreatorActivityKind;
+        nftId?: string;
+      };
+
+      if (!payload.occurredAt || !payload.type) {
+        throw new Error('Invalid cursor');
+      }
+
+      return {
+        occurredAt: new Date(payload.occurredAt),
+        type: payload.type,
+        nftId: payload.nftId,
+      };
+    } catch {
+      throw new BadRequestException('Invalid pagination cursor');
+    }
+  }
+}

--- a/nftopia-backend/src/graphql/types/auction.ts
+++ b/nftopia-backend/src/graphql/types/auction.ts
@@ -1,4 +1,9 @@
-import { GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLFloat } from 'graphql';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLFloat,
+} from 'graphql';
 
 export const AuctionType = new GraphQLObjectType({
   name: 'Auction',

--- a/nftopia-backend/src/graphql/types/public-creator.types.ts
+++ b/nftopia-backend/src/graphql/types/public-creator.types.ts
@@ -1,0 +1,131 @@
+import { Field, ID, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
+import { NFTConnection } from './nft.types';
+import { ListingConnection } from './listing.types';
+import { OrderConnection } from './order.types';
+import { CollectionConnection } from './collection.types';
+
+export enum CreatorNftSort {
+  NEWEST = 'NEWEST',
+  PRICE = 'PRICE',
+}
+
+registerEnumType(CreatorNftSort, { name: 'CreatorNftSort' });
+
+export enum CreatorActivityKind {
+  MINT = 'MINT',
+  SALE = 'SALE',
+  LISTING = 'LISTING',
+}
+
+registerEnumType(CreatorActivityKind, { name: 'CreatorActivityType' });
+
+@ObjectType('CreatorActivityItem')
+export class CreatorActivityItem {
+  @Field(() => CreatorActivityKind)
+  type: CreatorActivityKind;
+
+  @Field(() => Date)
+  occurredAt: Date;
+
+  @Field(() => ID, { nullable: true })
+  nftId?: string | null;
+
+  @Field(() => String, { nullable: true })
+  price?: string | null;
+
+  @Field(() => String, { nullable: true })
+  currency?: string | null;
+}
+
+@ObjectType('CreatorActivityEdge')
+export class CreatorActivityEdge {
+  @Field(() => CreatorActivityItem)
+  node: CreatorActivityItem;
+
+  @Field(() => String)
+  cursor: string;
+}
+
+@ObjectType('CreatorActivityConnection')
+export class CreatorActivityConnection {
+  @Field(() => [CreatorActivityEdge])
+  edges: CreatorActivityEdge[];
+
+  @Field(() => Int)
+  totalCount: number;
+}
+
+@ObjectType('PublicCreator')
+export class PublicCreatorType {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => String, { nullable: true })
+  username?: string | null;
+
+  @Field(() => String, { nullable: true })
+  bio?: string | null;
+
+  @Field(() => String, { nullable: true })
+  avatarUrl?: string | null;
+
+  @Field(() => String, { nullable: true })
+  bannerUrl?: string | null;
+
+  @Field(() => String, { nullable: true })
+  website?: string | null;
+
+  @Field(() => String, { nullable: true })
+  twitterHandle?: string | null;
+
+  @Field(() => String, { nullable: true })
+  instagramHandle?: string | null;
+
+  @Field(() => Boolean)
+  isVerified: boolean;
+
+  @Field(() => Int)
+  followerCount: number;
+
+  @Field(() => Int)
+  followingCount: number;
+
+  @Field(() => Int)
+  totalNftsCreated: number;
+
+  @Field(() => String)
+  totalSalesVolume: string;
+
+  @Field(() => Date)
+  createdAt: Date;
+
+  @Field(() => Boolean, { nullable: true })
+  isFollowing?: boolean | null;
+
+  @Field(() => NFTConnection, { nullable: true })
+  nfts?: NFTConnection;
+
+  @Field(() => CollectionConnection, { nullable: true })
+  collections?: CollectionConnection;
+
+  @Field(() => CreatorActivityConnection, { nullable: true })
+  activity?: CreatorActivityConnection;
+
+  @Field(() => ListingConnection, { nullable: true })
+  listings?: ListingConnection;
+
+  @Field(() => OrderConnection, { nullable: true })
+  sales?: OrderConnection;
+}
+
+@ObjectType('FollowResult')
+export class FollowResultType {
+  @Field(() => Boolean)
+  success: boolean;
+
+  @Field(() => Int)
+  followerCount: number;
+
+  @Field(() => Boolean)
+  isFollowing: boolean;
+}

--- a/nftopia-backend/src/modules/nft/interfaces/nft.interface.ts
+++ b/nftopia-backend/src/modules/nft/interfaces/nft.interface.ts
@@ -15,6 +15,7 @@ export interface NftQueryResult<T> {
 export interface NftConnectionCursor {
   createdAt: string;
   id: string;
+  price?: string;
 }
 
 export interface NftConnectionQuery {
@@ -25,6 +26,7 @@ export interface NftConnectionQuery {
   collectionId?: string;
   search?: string;
   includeBurned?: boolean;
+  sortBy?: 'NEWEST' | 'PRICE';
 }
 
 export interface NftConnectionResult<T> {

--- a/nftopia-backend/src/modules/nft/nft.service.ts
+++ b/nftopia-backend/src/modules/nft/nft.service.ts
@@ -561,13 +561,30 @@ export class NftService {
     const qb = this.createBaseQuery(query);
 
     if (query.after) {
-      qb.andWhere(
-        '(nft.createdAt < :cursorCreatedAt OR (nft.createdAt = :cursorCreatedAt AND nft.id < :cursorId))',
-        {
-          cursorCreatedAt: new Date(query.after.createdAt),
-          cursorId: query.after.id,
-        },
-      );
+      if (query.sortBy === 'PRICE') {
+        qb.andWhere(
+          '(nft.lastPrice < :cursorPrice OR (nft.lastPrice = :cursorPrice AND nft.id < :cursorId) OR (nft.lastPrice IS NULL AND nft.id < :cursorId))',
+          {
+            cursorPrice: query.after.price ?? '0',
+            cursorId: query.after.id,
+          },
+        );
+      } else {
+        qb.andWhere(
+          '(nft.createdAt < :cursorCreatedAt OR (nft.createdAt = :cursorCreatedAt AND nft.id < :cursorId))',
+          {
+            cursorCreatedAt: new Date(query.after.createdAt),
+            cursorId: query.after.id,
+          },
+        );
+      }
+    }
+
+    if (query.sortBy === 'PRICE') {
+      return qb
+        .orderBy('nft.lastPrice', 'DESC', 'NULLS LAST')
+        .addOrderBy('nft.id', 'DESC')
+        .take(first + 1);
     }
 
     return qb

--- a/nftopia-backend/src/users/user-follow.entity.ts
+++ b/nftopia-backend/src/users/user-follow.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+
+@Entity('user_follows')
+@Unique('uq_user_follows_pair', ['followerId', 'followingId'])
+export class UserFollow {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index('idx_user_follows_follower_id')
+  @Column({ name: 'follower_id', type: 'uuid' })
+  followerId: string;
+
+  @Index('idx_user_follows_following_id')
+  @Column({ name: 'following_id', type: 'uuid' })
+  followingId: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/nftopia-backend/src/users/user-follow.service.ts
+++ b/nftopia-backend/src/users/user-follow.service.ts
@@ -1,0 +1,58 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserFollow } from './user-follow.entity';
+
+@Injectable()
+export class UserFollowService {
+  constructor(
+    @InjectRepository(UserFollow)
+    private readonly followRepo: Repository<UserFollow>,
+  ) {}
+
+  async followerCount(userId: string): Promise<number> {
+    return this.followRepo.count({ where: { followingId: userId } });
+  }
+
+  async followingCount(userId: string): Promise<number> {
+    return this.followRepo.count({ where: { followerId: userId } });
+  }
+
+  async isFollowing(followerId: string, followingId: string): Promise<boolean> {
+    if (!followerId || !followingId) return false;
+    const row = await this.followRepo.findOne({
+      where: { followerId, followingId },
+    });
+    return !!row;
+  }
+
+  async follow(followerId: string, followingId: string): Promise<boolean> {
+    if (followerId === followingId) {
+      throw new BadRequestException('Cannot follow yourself');
+    }
+
+    const existing = await this.followRepo.findOne({
+      where: { followerId, followingId },
+    });
+    if (existing) {
+      return true;
+    }
+
+    await this.followRepo.save(
+      this.followRepo.create({ followerId, followingId }),
+    );
+    return true;
+  }
+
+  async unfollow(followerId: string, followingId: string): Promise<boolean> {
+    const result = await this.followRepo.delete({ followerId, followingId });
+    if (!result.affected) {
+      throw new NotFoundException('Follow relationship not found');
+    }
+    return true;
+  }
+}

--- a/nftopia-backend/src/users/user.entity.ts
+++ b/nftopia-backend/src/users/user.entity.ts
@@ -1,4 +1,10 @@
-import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { UserWallet } from '../auth/entities/user-wallet.entity';
 import { UserRole } from '../common/enums/user-role.enum';
 

--- a/nftopia-backend/src/users/user.entity.ts
+++ b/nftopia-backend/src/users/user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { UserWallet } from '../auth/entities/user-wallet.entity';
 import { UserRole } from '../common/enums/user-role.enum';
 
@@ -93,4 +93,7 @@ export class User {
 
   @OneToMany(() => UserWallet, (wallet) => wallet.user)
   wallets?: UserWallet[];
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
 }

--- a/nftopia-backend/src/users/users.controller.ts
+++ b/nftopia-backend/src/users/users.controller.ts
@@ -63,7 +63,9 @@ export class UsersController {
     if (!user || user.isBanned) {
       throw new NotFoundException('User not found');
     }
-    const { email, passwordHash, ...publicFields } = user;
+    const publicFields = { ...user };
+    delete publicFields.email;
+    delete publicFields.passwordHash;
     return publicFields;
   }
 

--- a/nftopia-backend/src/users/users.controller.ts
+++ b/nftopia-backend/src/users/users.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Headers,
+  NotFoundException,
   Param,
   Patch,
   Req,
@@ -55,8 +56,15 @@ export class UsersController {
   }
 
   @Get(':address')
-  getPublicProfile(@Param('address') address: string) {
-    return this.usersService.findByAddress(address);
+  async getPublicProfile(@Param('address') address: string) {
+    const user =
+      (await this.usersService.findByStellarAddress(address)) ??
+      (await this.usersService.findByUsername(address));
+    if (!user || user.isBanned) {
+      throw new NotFoundException('User not found');
+    }
+    const { email, passwordHash, ...publicFields } = user;
+    return publicFields;
   }
 
   // TEMP ownership enforcement

--- a/nftopia-backend/src/users/users.module.ts
+++ b/nftopia-backend/src/users/users.module.ts
@@ -5,11 +5,16 @@ import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { User } from './user.entity'; // Point to the entity file
 import { UserWallet } from '../auth/entities/user-wallet.entity';
+import { UserFollow } from './user-follow.entity';
+import { UserFollowService } from './user-follow.service';
 
 @Module({
-  imports: [EventEmitterModule, TypeOrmModule.forFeature([User, UserWallet])], // Registers the Repository
+  imports: [
+    EventEmitterModule,
+    TypeOrmModule.forFeature([User, UserWallet, UserFollow]),
+  ],
   controllers: [UsersController],
-  providers: [UsersService],
-  exports: [UsersService], // Good practice to export if other modules need it
+  providers: [UsersService, UserFollowService],
+  exports: [UsersService, UserFollowService],
 })
 export class UsersModule {}

--- a/nftopia-backend/src/users/users.service.ts
+++ b/nftopia-backend/src/users/users.service.ts
@@ -41,6 +41,49 @@ export class UsersService {
       .getOne();
   }
 
+  findByUsername(username: string): Promise<User | null> {
+    return this.repo.findOne({
+      where: { username },
+    });
+  }
+
+  async findPublicCreator(identifier: string): Promise<User | null> {
+    const trimmed = identifier.trim();
+    if (!trimmed) return null;
+
+    const byId = await this.findById(trimmed);
+    if (byId) return byId;
+
+    if (trimmed.startsWith('G') && trimmed.length >= 56) {
+      return this.findByStellarAddress(trimmed);
+    }
+
+    return this.findByUsername(trimmed);
+  }
+
+  async countNftsCreated(userId: string): Promise<number> {
+    const result = (await this.dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)', 'count')
+      .from('nfts', 'n')
+      .where('n.creator_id = :userId', { userId })
+      .getRawOne()) as { count?: string } | null;
+
+    return Number(result?.count ?? 0);
+  }
+
+  async isVerifiedCreator(userId: string): Promise<boolean> {
+    const result = (await this.dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)', 'count')
+      .from('collections', 'c')
+      .where('c.creator_id = :userId', { userId })
+      .andWhere('c.is_verified = true')
+      .getRawOne()) as { count?: string } | null;
+
+    return Number(result?.count ?? 0) > 0;
+  }
+
   async updateProfile(address: string, data: UpdateProfileDto) {
     const user = await this.findByAddress(address);
     if (!user) throw new NotFoundException('User not found');
@@ -66,6 +109,18 @@ export class UsersService {
       .select('COALESCE(SUM(t.amount), 0)', 'volume')
       .from('transactions', 't')
       .where('t.buyerId = :userId OR t.sellerId = :userId', { userId })
+      .andWhere('t.state = :state', { state: 'completed' })
+      .getRawOne()) as { volume?: string } | null;
+
+    return result?.volume || '0';
+  }
+
+  async getCreatorSalesVolume(userId: string): Promise<string> {
+    const result = (await this.dataSource
+      .createQueryBuilder()
+      .select('COALESCE(SUM(t.amount), 0)', 'volume')
+      .from('transactions', 't')
+      .where('t.sellerId = :userId', { userId })
       .andWhere('t.state = :state', { state: 'completed' })
       .getRawOne()) as { volume?: string } | null;
 

--- a/nftopia-frontend/__tests__/creator-profile-utils.test.ts
+++ b/nftopia-frontend/__tests__/creator-profile-utils.test.ts
@@ -1,0 +1,41 @@
+import {
+  buildCreatorProfilePath,
+  buildInstagramUrl,
+  buildTwitterUrl,
+  getCreatorAvatarUrl,
+  getCreatorDisplayName,
+  sanitizeExternalUrl,
+} from "@/lib/utils/creator-profile";
+
+describe("creator-profile utils", () => {
+  it("builds dicebear avatar when avatar url is missing", () => {
+    const url = getCreatorAvatarUrl("creator-123", null);
+    expect(url).toContain("api.dicebear.com");
+    expect(url).toContain("creator-123");
+  });
+
+  it("prefers provided avatar url", () => {
+    expect(getCreatorAvatarUrl("creator-123", "https://cdn.example/a.png")).toBe(
+      "https://cdn.example/a.png",
+    );
+  });
+
+  it("builds display name from username or id", () => {
+    expect(getCreatorDisplayName("artist", "id-1")).toBe("artist");
+    expect(getCreatorDisplayName(null, "12345678-abcd-efgh")).toMatch(/123456…/);
+  });
+
+  it("builds locale-aware profile paths", () => {
+    expect(buildCreatorProfilePath("artist", "en")).toBe("/en/creator/artist");
+  });
+
+  it("sanitizes external urls", () => {
+    expect(sanitizeExternalUrl("https://example.com")).toBe("https://example.com/");
+    expect(sanitizeExternalUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("builds social urls from handles", () => {
+    expect(buildTwitterUrl("@artist")).toBe("https://twitter.com/artist");
+    expect(buildInstagramUrl("artist")).toBe("https://instagram.com/artist");
+  });
+});

--- a/nftopia-frontend/__tests__/share-profile.test.ts
+++ b/nftopia-frontend/__tests__/share-profile.test.ts
@@ -1,0 +1,54 @@
+import { shareCreatorProfile } from "@/lib/utils/share-profile";
+
+describe("shareCreatorProfile", () => {
+  const originalShare = navigator.share;
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    Object.assign(navigator, {
+      share: undefined,
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.assign(navigator, {
+      share: originalShare,
+      clipboard: originalClipboard,
+    });
+  });
+
+  it("falls back to clipboard when native share is unavailable", async () => {
+    const result = await shareCreatorProfile({
+      url: "https://nftopia.test/en/creator/artist",
+      title: "Artist",
+    });
+
+    expect(result.method).toBe("clipboard");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "https://nftopia.test/en/creator/artist",
+    );
+  });
+
+  it("uses native share when available", async () => {
+    Object.assign(navigator, {
+      share: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await shareCreatorProfile({
+      url: "https://nftopia.test/en/creator/artist",
+      title: "Artist",
+      text: "Check this creator",
+    });
+
+    expect(result.method).toBe("native");
+    expect(navigator.share).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://nftopia.test/en/creator/artist",
+        title: "Artist",
+      }),
+    );
+  });
+});

--- a/nftopia-frontend/app/[locale]/creator-dashboard/profile/page.tsx
+++ b/nftopia-frontend/app/[locale]/creator-dashboard/profile/page.tsx
@@ -27,6 +27,8 @@ import {
   fetchProfileByAddress,
   updateMyProfile,
 } from "@/lib/services/profile";
+import { ImageUploadField } from "@/components/ui/image-upload-field";
+import { uploadToFirebase } from "@/lib/firebase/uploadtofirebase";
 
 type ProfileForm = Required<UpdateProfilePayload>;
 type FormErrors = Partial<Record<keyof ProfileForm, string>>;
@@ -70,6 +72,8 @@ export default function ProfilePage() {
     type: "success" | "error";
     text: string;
   } | null>(null);
+  const [pendingAvatarFile, setPendingAvatarFile] = useState<File | null>(null);
+  const [pendingBannerFile, setPendingBannerFile] = useState<File | null>(null);
 
   const profileAddress =
     authUser?.walletAddress || authUser?.address || address || "";
@@ -163,9 +167,21 @@ export default function ProfilePage() {
 
     setSaving(true);
     try {
-      const updated = await updateMyProfile(saveWalletAddress, form);
+      const payload: UpdateProfilePayload = { ...form };
+
+      if (pendingAvatarFile) {
+        payload.avatarUrl = await uploadToFirebase(pendingAvatarFile);
+      }
+
+      if (pendingBannerFile) {
+        payload.bannerUrl = await uploadToFirebase(pendingBannerFile);
+      }
+
+      const updated = await updateMyProfile(saveWalletAddress, payload);
       setProfile(updated);
       setForm(toProfileForm(updated));
+      setPendingAvatarFile(null);
+      setPendingBannerFile(null);
       setAuthUser({
         ...(authUser || {}),
         ...updated,
@@ -268,18 +284,21 @@ export default function ProfilePage() {
                 error={formErrors.bio}
                 onChange={(value) => handleChange("bio", value)}
               />
-              <TextField
-                label="Avatar URL"
-                value={form.avatarUrl}
-                error={formErrors.avatarUrl}
-                onChange={(value) => handleChange("avatarUrl", value)}
-              />
-              <TextField
-                label="Banner URL"
-                value={form.bannerUrl}
-                error={formErrors.bannerUrl}
-                onChange={(value) => handleChange("bannerUrl", value)}
-              />
+              <div className="grid gap-4 md:grid-cols-2">
+                <ImageUploadField
+                  label="Avatar"
+                  value={form.avatarUrl}
+                  fallbackSeed={profile?.id || profileAddress}
+                  onPendingFileChange={setPendingAvatarFile}
+                />
+                <ImageUploadField
+                  label="Banner"
+                  value={form.bannerUrl}
+                  fallbackSeed={`${profile?.id || profileAddress}-banner`}
+                  aspect="banner"
+                  onPendingFileChange={setPendingBannerFile}
+                />
+              </div>
               <TextField
                 label="Twitter Handle"
                 value={form.twitterHandle}

--- a/nftopia-frontend/app/[locale]/creator/[usernameOrId]/creator-profile-client.tsx
+++ b/nftopia-frontend/app/[locale]/creator/[usernameOrId]/creator-profile-client.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useQuery } from "@apollo/client";
+import { useParams } from "next/navigation";
+import { CircuitBackground } from "@/components/circuit-background";
+import { EmptyState } from "@/components/ui/empty-state";
+import { CreatorProfileHeader } from "@/components/creator/creator-profile-header";
+import { CreatorProfileSkeleton } from "@/components/creator/creator-profile-skeleton";
+import { CreatorProfileTabs } from "@/components/creator/creator-profile-tabs";
+import { useTranslation } from "@/hooks/useTranslation";
+import { GET_PUBLIC_CREATOR_QUERY } from "@/lib/graphql/queries/creator.queries";
+
+type CreatorNftSort = "NEWEST" | "PRICE";
+
+type PublicCreatorData = {
+  publicCreator: {
+    id: string;
+    username?: string | null;
+    bio?: string | null;
+    avatarUrl?: string | null;
+    bannerUrl?: string | null;
+    website?: string | null;
+    twitterHandle?: string | null;
+    instagramHandle?: string | null;
+    isVerified: boolean;
+    followerCount: number;
+    followingCount: number;
+    totalNftsCreated: number;
+    totalSalesVolume: string;
+    createdAt: string;
+    isFollowing?: boolean | null;
+    nfts?: {
+      edges: Array<{
+        node: {
+          id: string;
+          name: string;
+          image?: string | null;
+          lastPrice?: string | null;
+        };
+        cursor: string;
+      }>;
+      pageInfo: { hasNextPage: boolean; endCursor?: string | null };
+      totalCount: number;
+    } | null;
+    collections?: {
+      edges: Array<{
+        node: {
+          id: string;
+          name: string;
+          image: string;
+          floorPrice?: string | null;
+          totalSupply?: number | null;
+        };
+        cursor: string;
+      }>;
+      pageInfo: { hasNextPage: boolean; endCursor?: string | null };
+      totalCount: number;
+    } | null;
+    activity?: {
+      edges: Array<{
+        node: {
+          type: "MINT" | "SALE" | "LISTING";
+          occurredAt: string;
+          nftId?: string | null;
+          price?: string | null;
+          currency?: string | null;
+        };
+        cursor: string;
+      }>;
+      totalCount: number;
+    } | null;
+  };
+};
+
+export function CreatorProfileClient() {
+  const params = useParams<{ locale: string; usernameOrId: string }>();
+  const { t } = useTranslation();
+  const identifier = decodeURIComponent(params.usernameOrId);
+  const locale = params.locale;
+
+  const [nftSort, setNftSort] = useState<CreatorNftSort>("NEWEST");
+  const [nftAfter, setNftAfter] = useState<string | undefined>();
+  const [collectionAfter, setCollectionAfter] = useState<string | undefined>();
+  const [activityAfter, setActivityAfter] = useState<string | undefined>();
+
+  const { data, loading, error, fetchMore } = useQuery<PublicCreatorData>(
+    GET_PUBLIC_CREATOR_QUERY,
+    {
+      variables: {
+        identifier,
+        nftSort,
+        nftAfter,
+        collectionAfter,
+        activityAfter,
+      },
+      fetchPolicy: "cache-and-network",
+    },
+  );
+
+  const creator = data?.publicCreator;
+
+  const loadMoreNfts = useCallback(async () => {
+    const endCursor = creator?.nfts?.pageInfo.endCursor;
+    if (!endCursor) return;
+
+    await fetchMore({
+      variables: {
+        nftAfter: endCursor,
+      },
+      updateQuery: (previous, { fetchMoreResult }) => {
+        if (!fetchMoreResult.publicCreator?.nfts) return previous;
+
+        return {
+          publicCreator: {
+            ...previous.publicCreator!,
+            nfts: {
+              ...fetchMoreResult.publicCreator.nfts,
+              edges: [
+                ...(previous.publicCreator?.nfts?.edges ?? []),
+                ...fetchMoreResult.publicCreator.nfts.edges,
+              ],
+            },
+          },
+        };
+      },
+    });
+    setNftAfter(endCursor);
+  }, [creator?.nfts?.pageInfo.endCursor, fetchMore]);
+
+  const loadMoreCollections = useCallback(async () => {
+    const endCursor = creator?.collections?.pageInfo.endCursor;
+    if (!endCursor) return;
+
+    await fetchMore({
+      variables: {
+        collectionAfter: endCursor,
+      },
+      updateQuery: (previous, { fetchMoreResult }) => {
+        if (!fetchMoreResult.publicCreator?.collections) return previous;
+
+        return {
+          publicCreator: {
+            ...previous.publicCreator!,
+            collections: {
+              ...fetchMoreResult.publicCreator.collections,
+              edges: [
+                ...(previous.publicCreator?.collections?.edges ?? []),
+                ...fetchMoreResult.publicCreator.collections.edges,
+              ],
+            },
+          },
+        };
+      },
+    });
+    setCollectionAfter(endCursor);
+  }, [creator?.collections?.pageInfo.endCursor, fetchMore]);
+
+  const loadMoreActivity = useCallback(async () => {
+    const lastEdge = creator?.activity?.edges.at(-1);
+    if (!lastEdge) return;
+
+    await fetchMore({
+      variables: {
+        activityAfter: lastEdge.cursor,
+      },
+      updateQuery: (previous, { fetchMoreResult }) => {
+        if (!fetchMoreResult.publicCreator?.activity) return previous;
+
+        return {
+          publicCreator: {
+            ...previous.publicCreator!,
+            activity: {
+              ...fetchMoreResult.publicCreator.activity,
+              edges: [
+                ...(previous.publicCreator?.activity?.edges ?? []),
+                ...fetchMoreResult.publicCreator.activity.edges,
+              ],
+            },
+          },
+        };
+      },
+    });
+    setActivityAfter(lastEdge.cursor);
+  }, [creator?.activity?.edges, fetchMore]);
+
+  const content = useMemo(() => {
+    if (loading && !creator) {
+      return <CreatorProfileSkeleton />;
+    }
+
+    if (error || !creator) {
+      return (
+        <EmptyState
+          title={t("creatorProfile.notFound")}
+          description={t("common.error")}
+          className="py-20"
+        />
+      );
+    }
+
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 px-4 py-8">
+        <CreatorProfileHeader
+          creator={creator}
+          profileSlug={identifier}
+          locale={locale}
+        />
+        <CreatorProfileTabs
+          creator={creator}
+          nftSort={nftSort}
+          onNftSortChange={(sort) => {
+            setNftSort(sort);
+            setNftAfter(undefined);
+          }}
+          onLoadMoreNfts={loadMoreNfts}
+          onLoadMoreCollections={loadMoreCollections}
+          onLoadMoreActivity={loadMoreActivity}
+        />
+      </div>
+    );
+  }, [
+    loading,
+    creator,
+    error,
+    t,
+    identifier,
+    locale,
+    nftSort,
+    loadMoreNfts,
+    loadMoreCollections,
+    loadMoreActivity,
+  ]);
+
+  return (
+    <div className="relative min-h-screen">
+      <CircuitBackground />
+      <div className="relative z-10">{content}</div>
+    </div>
+  );
+}

--- a/nftopia-frontend/app/[locale]/creator/[usernameOrId]/page.tsx
+++ b/nftopia-frontend/app/[locale]/creator/[usernameOrId]/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from "next";
+import { CreatorProfileClient } from "./creator-profile-client";
+import { getCreatorDisplayName } from "@/lib/utils/creator-profile";
+
+const GRAPHQL_URL =
+  process.env.NEXT_PUBLIC_GRAPHQL_URL || "http://localhost:3001/graphql";
+
+type PageProps = {
+  params: {
+    locale: string;
+    usernameOrId: string;
+  };
+};
+
+async function fetchCreatorMeta(identifier: string) {
+  const response = await fetch(GRAPHQL_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query: `
+        query PublicCreatorMeta($identifier: String!) {
+          publicCreator(identifier: $identifier) {
+            id
+            username
+            bio
+            avatarUrl
+            bannerUrl
+          }
+        }
+      `,
+      variables: { identifier },
+    }),
+    next: { revalidate: 120 },
+  });
+
+  if (!response.ok) return null;
+
+  const payload = (await response.json()) as {
+    data?: {
+      publicCreator?: {
+        id: string;
+        username?: string | null;
+        bio?: string | null;
+        avatarUrl?: string | null;
+        bannerUrl?: string | null;
+      };
+    };
+  };
+
+  return payload.data?.publicCreator ?? null;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const identifier = decodeURIComponent(params.usernameOrId);
+  const creator = await fetchCreatorMeta(identifier);
+
+  if (!creator) {
+    return {
+      title: "Creator | NFTopia",
+      description: "Explore creator profiles on NFTopia.",
+    };
+  }
+
+  const name = getCreatorDisplayName(creator.username, creator.id);
+  const description =
+    creator.bio?.slice(0, 160) || `View ${name}'s NFTs, collections, and activity on NFTopia.`;
+
+  return {
+    title: `${name} | NFTopia`,
+    description,
+    openGraph: {
+      title: `${name} | NFTopia`,
+      description,
+      images: creator.bannerUrl || creator.avatarUrl || undefined,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${name} | NFTopia`,
+      description,
+      images: creator.bannerUrl || creator.avatarUrl || undefined,
+    },
+  };
+}
+
+export default function CreatorProfilePage() {
+  return <CreatorProfileClient />;
+}

--- a/nftopia-frontend/app/[locale]/marketplace/[nftId]/page.tsx
+++ b/nftopia-frontend/app/[locale]/marketplace/[nftId]/page.tsx
@@ -174,6 +174,8 @@ export default function NFTDetailPage() {
 
   const isCreator = nft.creator?.id === nft.ownerId;
   const creatorAddress = nft.creator?.walletAddress || nft.creator?.id || "Unknown";
+  const creatorProfileSlug =
+    nft.creator?.username || nft.creator?.id || creatorAddress;
   const ownerAddress = nft.owner?.walletAddress || nft.owner?.id || "Unknown";
 
   return (
@@ -286,9 +288,12 @@ export default function NFTDetailPage() {
                     )}
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm text-white truncate">
-                      {formatAddress(creatorAddress)}
-                    </span>
+                    <Link
+                      href={`/creator/${encodeURIComponent(creatorProfileSlug)}`}
+                      className="font-mono text-sm text-white truncate hover:text-purple-300 transition-colors"
+                    >
+                      {nft.creator?.username || formatAddress(creatorAddress)}
+                    </Link>
                     <button
                       onClick={() => handleCopyAddress(creatorAddress)}
                       className="text-gray-500 hover:text-gray-300 transition-colors flex-shrink-0"

--- a/nftopia-frontend/components/creator/creator-activity-feed.tsx
+++ b/nftopia-frontend/components/creator/creator-activity-feed.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowUpRight, Gavel, Sparkles, Tag } from "lucide-react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type ActivityEdge = {
+  node: {
+    type: "MINT" | "SALE" | "LISTING";
+    occurredAt: string;
+    nftId?: string | null;
+    price?: string | null;
+    currency?: string | null;
+  };
+  cursor: string;
+};
+
+type CreatorActivityFeedProps = {
+  edges: ActivityEdge[];
+  hasNextPage: boolean;
+  onLoadMore?: () => void;
+  loadingMore?: boolean;
+};
+
+const activityIcons = {
+  MINT: Sparkles,
+  SALE: Gavel,
+  LISTING: Tag,
+} as const;
+
+export function CreatorActivityFeed({
+  edges,
+  hasNextPage,
+  onLoadMore,
+  loadingMore,
+}: CreatorActivityFeedProps) {
+  const { t } = useTranslation();
+
+  if (!edges.length) {
+    return (
+      <EmptyState
+        title={t("creatorProfile.emptyActivity")}
+        className="py-12"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <ul className="divide-y divide-gray-800/80 overflow-hidden rounded-xl border border-gray-800/60 bg-gray-900/30">
+        {edges.map(({ node, cursor }) => {
+          const Icon = activityIcons[node.type];
+          const labelKey =
+            node.type === "MINT"
+              ? "creatorProfile.activityMint"
+              : node.type === "SALE"
+                ? "creatorProfile.activitySale"
+                : "creatorProfile.activityListing";
+
+          return (
+            <li key={cursor} className="flex items-center gap-4 px-4 py-3">
+              <div
+                className={cn(
+                  "flex h-10 w-10 items-center justify-center rounded-full",
+                  node.type === "MINT" && "bg-emerald-500/10 text-emerald-300",
+                  node.type === "SALE" && "bg-purple-500/10 text-purple-300",
+                  node.type === "LISTING" && "bg-blue-500/10 text-blue-300",
+                )}
+              >
+                <Icon className="h-4 w-4" />
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-white">{t(labelKey)}</p>
+                <p className="text-xs text-gray-400">
+                  {new Date(node.occurredAt).toLocaleString()}
+                </p>
+              </div>
+
+              <div className="flex items-center gap-3 text-sm text-gray-300">
+                {node.price ? (
+                  <span>
+                    {Number(node.price).toFixed(2)}{" "}
+                    {node.currency || "XLM"}
+                  </span>
+                ) : null}
+                {node.nftId ? (
+                  <Link
+                    href={`/marketplace/${node.nftId}`}
+                    className="inline-flex items-center gap-1 text-purple-300 hover:text-purple-200"
+                  >
+                    <ArrowUpRight className="h-4 w-4" />
+                  </Link>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {hasNextPage && onLoadMore ? (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            className="border-gray-700 bg-transparent text-gray-200"
+          >
+            {loadingMore ? t("common.loading") : t("common.next")}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/nftopia-frontend/components/creator/creator-collection-grid.tsx
+++ b/nftopia-frontend/components/creator/creator-collection-grid.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useTranslation } from "@/hooks/useTranslation";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
+
+type CollectionEdge = {
+  node: {
+    id: string;
+    name: string;
+    image: string;
+    floorPrice?: string | null;
+    totalSupply?: number | null;
+  };
+  cursor: string;
+};
+
+type CreatorCollectionGridProps = {
+  edges: CollectionEdge[];
+  hasNextPage: boolean;
+  onLoadMore?: () => void;
+  loadingMore?: boolean;
+};
+
+export function CreatorCollectionGrid({
+  edges,
+  hasNextPage,
+  onLoadMore,
+  loadingMore,
+}: CreatorCollectionGridProps) {
+  const { t } = useTranslation();
+
+  if (!edges.length) {
+    return (
+      <EmptyState
+        title={t("creatorProfile.emptyCollections")}
+        className="py-12"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {edges.map(({ node }) => (
+          <Link
+            key={node.id}
+            href={`/collection/${node.id}`}
+            className="group overflow-hidden rounded-xl border border-gray-800/60 bg-gray-900/40 transition hover:-translate-y-0.5 hover:border-purple-500/40"
+          >
+            <div className="relative aspect-[4/3] bg-gray-800/50">
+              <Image
+                src={node.image}
+                alt={node.name}
+                fill
+                className="object-cover transition group-hover:scale-[1.02]"
+                unoptimized
+              />
+            </div>
+            <div className="space-y-1 p-4">
+              <p className="truncate text-base font-medium text-white">{node.name}</p>
+              <div className="flex items-center gap-3 text-xs text-gray-400">
+                {node.totalSupply != null ? (
+                  <span>{node.totalSupply} items</span>
+                ) : null}
+                {node.floorPrice ? (
+                  <span>{Number(node.floorPrice).toFixed(2)} XLM floor</span>
+                ) : null}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {hasNextPage && onLoadMore ? (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            className="border-gray-700 bg-transparent text-gray-200"
+          >
+            {loadingMore ? t("common.loading") : t("common.next")}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/nftopia-frontend/components/creator/creator-follow-button.tsx
+++ b/nftopia-frontend/components/creator/creator-follow-button.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@apollo/client";
+import { Loader2 } from "lucide-react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import { useStellarWallet } from "@/components/wallet/hooks/useStellarWallet";
+import { WalletModal } from "@/components/wallet/WalletModal";
+import {
+  FOLLOW_CREATOR_MUTATION,
+  UNFOLLOW_CREATOR_MUTATION,
+} from "@/lib/graphql/queries/creator.queries";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type CreatorFollowButtonProps = {
+  creatorId: string;
+  initialFollowing: boolean;
+  initialFollowerCount: number;
+  className?: string;
+};
+
+export function CreatorFollowButton({
+  creatorId,
+  initialFollowing,
+  initialFollowerCount,
+  className,
+}: CreatorFollowButtonProps) {
+  const { t } = useTranslation();
+  const authUser = useAuthStore((state) => state.user);
+  const { connected } = useStellarWallet();
+  const [walletModalOpen, setWalletModalOpen] = useState(false);
+  const [isFollowing, setIsFollowing] = useState(initialFollowing);
+  const [followerCount, setFollowerCount] = useState(initialFollowerCount);
+
+  const [followCreator, followState] = useMutation(FOLLOW_CREATOR_MUTATION, {
+    optimisticResponse: {
+      followCreator: {
+        __typename: "FollowResult",
+        success: true,
+        followerCount: followerCount + 1,
+        isFollowing: true,
+      },
+    },
+    onCompleted: (data) => {
+      setIsFollowing(data.followCreator.isFollowing);
+      setFollowerCount(data.followCreator.followerCount);
+    },
+    onError: () => {
+      setIsFollowing(initialFollowing);
+      setFollowerCount(initialFollowerCount);
+    },
+  });
+
+  const [unfollowCreator, unfollowState] = useMutation(
+    UNFOLLOW_CREATOR_MUTATION,
+    {
+      optimisticResponse: {
+        unfollowCreator: {
+          __typename: "FollowResult",
+          success: true,
+          followerCount: Math.max(0, followerCount - 1),
+          isFollowing: false,
+        },
+      },
+      onCompleted: (data) => {
+        setIsFollowing(data.unfollowCreator.isFollowing);
+        setFollowerCount(data.unfollowCreator.followerCount);
+      },
+      onError: () => {
+        setIsFollowing(initialFollowing);
+        setFollowerCount(initialFollowerCount);
+      },
+    },
+  );
+
+  const loading = followState.loading || unfollowState.loading;
+  const isAuthenticated = Boolean(authUser?.id);
+
+  const handleClick = async () => {
+    if (!isAuthenticated || !connected) {
+      setWalletModalOpen(true);
+      return;
+    }
+
+    if (isFollowing) {
+      setIsFollowing(false);
+      setFollowerCount((count) => Math.max(0, count - 1));
+      await unfollowCreator({ variables: { creatorId } });
+      return;
+    }
+
+    setIsFollowing(true);
+    setFollowerCount((count) => count + 1);
+    await followCreator({ variables: { creatorId } });
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        onClick={handleClick}
+        disabled={loading}
+        className={cn(
+          "min-w-[108px] bg-gradient-to-r from-[#4e3bff] to-[#9747ff] text-white hover:opacity-90",
+          isFollowing && "border border-gray-600 bg-transparent from-transparent to-transparent",
+          className,
+        )}
+        variant={isFollowing ? "outline" : "default"}
+      >
+        {loading ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : isFollowing ? (
+          t("common.unfollow")
+        ) : (
+          t("common.follow")
+        )}
+      </Button>
+
+      <WalletModal
+        open={walletModalOpen}
+        onClose={() => setWalletModalOpen(false)}
+      />
+    </>
+  );
+}

--- a/nftopia-frontend/components/creator/creator-nft-grid.tsx
+++ b/nftopia-frontend/components/creator/creator-nft-grid.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useTranslation } from "@/hooks/useTranslation";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
+
+type NftEdge = {
+  node: {
+    id: string;
+    name: string;
+    image?: string | null;
+    lastPrice?: string | null;
+  };
+  cursor: string;
+};
+
+type CreatorNftGridProps = {
+  edges: NftEdge[];
+  hasNextPage: boolean;
+  onLoadMore?: () => void;
+  loadingMore?: boolean;
+};
+
+export function CreatorNftGrid({
+  edges,
+  hasNextPage,
+  onLoadMore,
+  loadingMore,
+}: CreatorNftGridProps) {
+  const { t } = useTranslation();
+
+  if (!edges.length) {
+    return (
+      <EmptyState
+        title={t("creatorProfile.emptyNfts")}
+        className="py-12"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+        {edges.map(({ node }) => (
+          <Link
+            key={node.id}
+            href={`/marketplace/${node.id}`}
+            className="group overflow-hidden rounded-xl border border-gray-800/60 bg-gray-900/40 transition hover:-translate-y-0.5 hover:border-purple-500/40"
+          >
+            <div className="relative aspect-square bg-gray-800/50">
+              {node.image ? (
+                <Image
+                  src={node.image}
+                  alt={node.name}
+                  fill
+                  className="object-cover transition group-hover:scale-[1.02]"
+                  unoptimized
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-xs text-gray-500">
+                  {node.name}
+                </div>
+              )}
+            </div>
+            <div className="space-y-1 p-3">
+              <p className="truncate text-sm font-medium text-white">{node.name}</p>
+              {node.lastPrice ? (
+                <p className="text-xs text-gray-400">
+                  {Number(node.lastPrice).toFixed(2)} XLM
+                </p>
+              ) : null}
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {hasNextPage && onLoadMore ? (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            className="border-gray-700 bg-transparent text-gray-200"
+          >
+            {loadingMore ? t("common.loading") : t("common.next")}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/nftopia-frontend/components/creator/creator-profile-header.tsx
+++ b/nftopia-frontend/components/creator/creator-profile-header.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useMemo } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  BadgeCheck,
+  Calendar,
+  ExternalLink,
+  Globe,
+  Instagram,
+} from "lucide-react";
+import { useTranslation } from "@/hooks/useTranslation";
+import {
+  buildCreatorProfilePath,
+  buildInstagramUrl,
+  buildTwitterUrl,
+  getCreatorAvatarUrl,
+  getCreatorBannerUrl,
+  getCreatorDisplayName,
+  sanitizeExternalUrl,
+} from "@/lib/utils/creator-profile";
+import { CreatorFollowButton } from "./creator-follow-button";
+import { CreatorShareButton } from "./creator-share-button";
+
+type CreatorProfileHeaderProps = {
+  creator: {
+    id: string;
+    username?: string | null;
+    bio?: string | null;
+    avatarUrl?: string | null;
+    bannerUrl?: string | null;
+    website?: string | null;
+    twitterHandle?: string | null;
+    instagramHandle?: string | null;
+    isVerified: boolean;
+    followerCount: number;
+    totalNftsCreated: number;
+    totalSalesVolume: string;
+    createdAt: string;
+    isFollowing?: boolean | null;
+  };
+  profileSlug: string;
+  locale: string;
+};
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+      />
+    </svg>
+  );
+}
+
+export function CreatorProfileHeader({
+  creator,
+  profileSlug,
+  locale,
+}: CreatorProfileHeaderProps) {
+  const { t } = useTranslation();
+
+  const displayName = getCreatorDisplayName(creator.username, creator.id);
+  const avatarUrl = getCreatorAvatarUrl(creator.id, creator.avatarUrl);
+  const bannerUrl = getCreatorBannerUrl(creator.id, creator.bannerUrl);
+  const websiteUrl = sanitizeExternalUrl(creator.website);
+  const twitterUrl = buildTwitterUrl(creator.twitterHandle);
+  const instagramUrl = buildInstagramUrl(creator.instagramHandle);
+  const profilePath = buildCreatorProfilePath(profileSlug, locale);
+
+  const joinedLabel = useMemo(() => {
+    if (!creator.createdAt) return null;
+    return new Date(creator.createdAt).toLocaleDateString(undefined, {
+      month: "short",
+      year: "numeric",
+    });
+  }, [creator.createdAt]);
+
+  return (
+    <section className="overflow-hidden rounded-2xl border border-gray-800/60 bg-gray-900/40">
+      <div className="relative h-36 md:h-48">
+        {bannerUrl ? (
+          <Image
+            src={bannerUrl}
+            alt=""
+            fill
+            className="object-cover"
+            priority
+            unoptimized
+          />
+        ) : (
+          <div className="h-full w-full bg-gradient-to-r from-[#181359] via-[#2a1f7a] to-[#4e3bff]/40" />
+        )}
+      </div>
+
+      <div className="relative px-4 pb-5 pt-0 md:px-6">
+        <div className="-mt-10 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div className="flex items-end gap-4">
+            <div className="relative h-20 w-20 overflow-hidden rounded-2xl border-4 border-gray-900 bg-gray-900 md:h-24 md:w-24">
+              <Image
+                src={avatarUrl}
+                alt={displayName}
+                fill
+                className="object-cover"
+                unoptimized
+              />
+              {creator.isVerified ? (
+                <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
+                  <BadgeCheck className="h-5 w-5 text-emerald-400" />
+                </span>
+              ) : null}
+            </div>
+
+            <div className="min-w-0 pb-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="truncate text-2xl font-bold text-white md:text-3xl">
+                  {displayName}
+                </h1>
+                {creator.isVerified ? (
+                  <span className="rounded-full bg-emerald-400/10 px-2 py-0.5 text-xs text-emerald-300">
+                    {t("creatorProfile.verified")}
+                  </span>
+                ) : null}
+              </div>
+
+              {creator.bio ? (
+                <p className="mt-1 max-w-2xl text-sm text-gray-300 line-clamp-2">
+                  {creator.bio}
+                </p>
+              ) : null}
+
+              <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-gray-400">
+                {joinedLabel ? (
+                  <span className="inline-flex items-center gap-1">
+                    <Calendar className="h-3.5 w-3.5" />
+                    {joinedLabel}
+                  </span>
+                ) : null}
+                <span>
+                  {creator.followerCount.toLocaleString()}{" "}
+                  {t("creatorProfile.followers")}
+                </span>
+                <span>
+                  {creator.totalNftsCreated.toLocaleString()}{" "}
+                  {t("creatorProfile.nftsCreated")}
+                </span>
+                <span>
+                  {Number(creator.totalSalesVolume).toFixed(2)} XLM{" "}
+                  {t("creatorProfile.volume")}
+                </span>
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {twitterUrl ? (
+                  <SocialLink href={twitterUrl} label="Twitter">
+                    <XIcon className="h-4 w-4" />
+                  </SocialLink>
+                ) : null}
+                {instagramUrl ? (
+                  <SocialLink href={instagramUrl} label="Instagram">
+                    <Instagram className="h-4 w-4" />
+                  </SocialLink>
+                ) : null}
+                {websiteUrl ? (
+                  <SocialLink href={websiteUrl} label="Website">
+                    <Globe className="h-4 w-4" />
+                  </SocialLink>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <CreatorFollowButton
+              creatorId={creator.id}
+              initialFollowing={creator.isFollowing ?? false}
+              initialFollowerCount={creator.followerCount}
+            />
+            <CreatorShareButton
+              profileUrl={profilePath}
+              title={displayName}
+              text={creator.bio ?? undefined}
+              imageUrl={avatarUrl}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SocialLink({
+  href,
+  label,
+  children,
+}: {
+  href: string;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 rounded-lg border border-gray-700/80 px-2.5 py-1.5 text-gray-300 transition-colors hover:border-purple-400/50 hover:text-white"
+      aria-label={label}
+    >
+      {children}
+      <ExternalLink className="h-3 w-3 opacity-60" />
+    </a>
+  );
+}

--- a/nftopia-frontend/components/creator/creator-profile-skeleton.tsx
+++ b/nftopia-frontend/components/creator/creator-profile-skeleton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function CreatorProfileSkeleton() {
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-8">
+      <Skeleton className="h-44 w-full rounded-2xl" />
+      <div className="flex gap-4">
+        <Skeleton className="h-24 w-24 rounded-2xl" />
+        <div className="flex-1 space-y-3 pt-8">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-full max-w-xl" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+      </div>
+      <Skeleton className="h-10 w-72" />
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, index) => (
+          <Skeleton key={index} className="aspect-square rounded-xl" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/nftopia-frontend/components/creator/creator-profile-tabs.tsx
+++ b/nftopia-frontend/components/creator/creator-profile-tabs.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { cn } from "@/lib/utils";
+import { CreatorNftGrid } from "./creator-nft-grid";
+import { CreatorCollectionGrid } from "./creator-collection-grid";
+import { CreatorActivityFeed } from "./creator-activity-feed";
+
+type TabKey = "nfts" | "collections" | "activity";
+
+type CreatorProfileTabsProps = {
+  creator: {
+    nfts?: {
+      edges: Array<{
+        node: {
+          id: string;
+          name: string;
+          image?: string | null;
+          lastPrice?: string | null;
+        };
+        cursor: string;
+      }>;
+      pageInfo: { hasNextPage: boolean; endCursor?: string | null };
+    } | null;
+    collections?: {
+      edges: Array<{
+        node: {
+          id: string;
+          name: string;
+          image: string;
+          floorPrice?: string | null;
+          totalSupply?: number | null;
+        };
+        cursor: string;
+      }>;
+      pageInfo: { hasNextPage: boolean; endCursor?: string | null };
+    } | null;
+    activity?: {
+      edges: Array<{
+        node: {
+          type: "MINT" | "SALE" | "LISTING";
+          occurredAt: string;
+          nftId?: string | null;
+          price?: string | null;
+          currency?: string | null;
+        };
+        cursor: string;
+      }>;
+      totalCount: number;
+    } | null;
+  };
+  nftSort: "NEWEST" | "PRICE";
+  onNftSortChange: (sort: "NEWEST" | "PRICE") => void;
+  onLoadMoreNfts?: () => void;
+  onLoadMoreCollections?: () => void;
+  onLoadMoreActivity?: () => void;
+  loadingMoreNfts?: boolean;
+  loadingMoreCollections?: boolean;
+  loadingMoreActivity?: boolean;
+};
+
+export function CreatorProfileTabs({
+  creator,
+  nftSort,
+  onNftSortChange,
+  onLoadMoreNfts,
+  onLoadMoreCollections,
+  onLoadMoreActivity,
+  loadingMoreNfts,
+  loadingMoreCollections,
+  loadingMoreActivity,
+}: CreatorProfileTabsProps) {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<TabKey>("nfts");
+
+  const tabs: { key: TabKey; label: string }[] = [
+    { key: "nfts", label: t("creatorProfile.tabNfts") },
+    { key: "collections", label: t("creatorProfile.tabCollections") },
+    { key: "activity", label: t("creatorProfile.tabActivity") },
+  ];
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2 border-b border-gray-800/80 pb-3">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={cn(
+              "rounded-lg px-3 py-1.5 text-sm transition-colors",
+              activeTab === tab.key
+                ? "bg-purple-500/20 text-purple-200"
+                : "text-gray-400 hover:text-gray-200",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+
+        {activeTab === "nfts" ? (
+          <div className="ml-auto flex gap-2">
+            {(["NEWEST", "PRICE"] as const).map((sort) => (
+              <button
+                key={sort}
+                type="button"
+                onClick={() => onNftSortChange(sort)}
+                className={cn(
+                  "rounded-md border px-2 py-1 text-xs",
+                  nftSort === sort
+                    ? "border-purple-400/60 text-purple-200"
+                    : "border-gray-700 text-gray-400",
+                )}
+              >
+                {sort === "NEWEST"
+                  ? t("creatorProfile.sortNewest")
+                  : t("creatorProfile.sortPrice")}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {activeTab === "nfts" ? (
+        <CreatorNftGrid
+          edges={creator.nfts?.edges ?? []}
+          hasNextPage={creator.nfts?.pageInfo.hasNextPage ?? false}
+          onLoadMore={onLoadMoreNfts}
+          loadingMore={loadingMoreNfts}
+        />
+      ) : null}
+
+      {activeTab === "collections" ? (
+        <CreatorCollectionGrid
+          edges={creator.collections?.edges ?? []}
+          hasNextPage={creator.collections?.pageInfo.hasNextPage ?? false}
+          onLoadMore={onLoadMoreCollections}
+          loadingMore={loadingMoreCollections}
+        />
+      ) : null}
+
+      {activeTab === "activity" ? (
+        <CreatorActivityFeed
+          edges={creator.activity?.edges ?? []}
+          hasNextPage={
+            (creator.activity?.edges.length ?? 0) <
+            (creator.activity?.totalCount ?? 0)
+          }
+          onLoadMore={onLoadMoreActivity}
+          loadingMore={loadingMoreActivity}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/nftopia-frontend/components/creator/creator-share-button.tsx
+++ b/nftopia-frontend/components/creator/creator-share-button.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, Share2 } from "lucide-react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { shareCreatorProfile } from "@/lib/utils/share-profile";
+import { Button } from "@/components/ui/button";
+
+type CreatorShareButtonProps = {
+  profileUrl: string;
+  title: string;
+  text?: string;
+  imageUrl?: string | null;
+};
+
+export function CreatorShareButton({
+  profileUrl,
+  title,
+  text,
+  imageUrl,
+}: CreatorShareButtonProps) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const [shareUrl, setShareUrl] = useState(profileUrl);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setShareUrl(`${window.location.origin}${profileUrl}`);
+    }
+  }, [profileUrl]);
+
+  const handleShare = async () => {
+    const result = await shareCreatorProfile({
+      url: shareUrl,
+      title,
+      text,
+      imageUrl,
+    });
+
+    if (result.method === "clipboard") {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={handleShare}
+      className="border-gray-700 bg-transparent text-gray-200 hover:bg-gray-800/60"
+      aria-label={t("common.share")}
+    >
+      {copied ? (
+        <Check className="h-4 w-4 text-emerald-400" />
+      ) : (
+        <Share2 className="h-4 w-4" />
+      )}
+      <span className="ml-2">{copied ? t("common.copied") : t("common.share")}</span>
+    </Button>
+  );
+}

--- a/nftopia-frontend/components/ui/image-upload-field.tsx
+++ b/nftopia-frontend/components/ui/image-upload-field.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type DragEvent,
+} from "react";
+import { ImagePlus, Redo2, Undo2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const MAX_HISTORY = 5;
+const MAX_SIZE_MB = 5;
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+type HistoryEntry = {
+  previewUrl: string | null;
+  file: File | null;
+  remoteUrl: string | null;
+};
+
+export type ImageUploadFieldProps = {
+  label?: string;
+  value?: string;
+  fallbackSeed?: string;
+  aspect?: "square" | "banner";
+  className?: string;
+  onPendingFileChange?: (file: File | null) => void;
+};
+
+function isAcceptedImage(file: File): boolean {
+  return ACCEPTED_TYPES.includes(file.type);
+}
+
+export function ImageUploadField({
+  label,
+  value,
+  fallbackSeed,
+  aspect = "square",
+  className,
+  onPendingFileChange,
+}: ImageUploadFieldProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([
+    { previewUrl: value ?? null, file: null, remoteUrl: value ?? null },
+  ]);
+  const [historyIndex, setHistoryIndex] = useState(0);
+  const [isDragActive, setIsDragActive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const current = history[historyIndex];
+
+  useEffect(() => {
+    if (!value) return;
+    setHistory([{ previewUrl: value, file: null, remoteUrl: value }]);
+    setHistoryIndex(0);
+  }, [value]);
+
+  useEffect(() => {
+    return () => {
+      history.forEach((entry) => {
+        if (entry.previewUrl?.startsWith("blob:")) {
+          URL.revokeObjectURL(entry.previewUrl);
+        }
+      });
+    };
+  }, [history]);
+
+  const displayUrl = useMemo(() => {
+    if (current.previewUrl) return current.previewUrl;
+    if (fallbackSeed) {
+      return `https://api.dicebear.com/7.x/bottts-neutral/svg?seed=${encodeURIComponent(fallbackSeed)}`;
+    }
+    return null;
+  }, [current.previewUrl, fallbackSeed]);
+
+  const pushHistory = useCallback(
+    (entry: HistoryEntry) => {
+      setHistory((prev) => {
+        const trimmed = prev.slice(0, historyIndex + 1);
+        const next = [...trimmed, entry];
+        if (next.length > MAX_HISTORY) {
+          const removed = next.shift();
+          if (removed?.previewUrl?.startsWith("blob:")) {
+            URL.revokeObjectURL(removed.previewUrl);
+          }
+        }
+        setHistoryIndex(next.length - 1);
+        return next;
+      });
+    },
+    [historyIndex],
+  );
+
+  const applyFile = useCallback(
+    (file: File) => {
+      if (!isAcceptedImage(file)) {
+        setError("Use JPG, PNG, WebP, or GIF.");
+        return;
+      }
+
+      if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+        setError(`Max ${MAX_SIZE_MB}MB.`);
+        return;
+      }
+
+      setError(null);
+      const previewUrl = URL.createObjectURL(file);
+      pushHistory({ previewUrl, file, remoteUrl: null });
+      onPendingFileChange?.(file);
+    },
+    [onPendingFileChange, pushHistory],
+  );
+
+  const handleFiles = useCallback(
+    (files: FileList | null) => {
+      const file = files?.[0];
+      if (file) applyFile(file);
+    },
+    [applyFile],
+  );
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragActive(false);
+    handleFiles(event.dataTransfer.files);
+  };
+
+  const undo = () => {
+    if (historyIndex <= 0) return;
+    const nextIndex = historyIndex - 1;
+    setHistoryIndex(nextIndex);
+    onPendingFileChange?.(history[nextIndex]?.file ?? null);
+  };
+
+  const redo = () => {
+    if (historyIndex >= history.length - 1) return;
+    const nextIndex = historyIndex + 1;
+    setHistoryIndex(nextIndex);
+    onPendingFileChange?.(history[nextIndex]?.file ?? null);
+  };
+
+  const canUndo = historyIndex > 0;
+  const canRedo = historyIndex < history.length - 1;
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {label ? (
+        <span className="block text-sm font-medium text-card-foreground">
+          {label}
+        </span>
+      ) : null}
+
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        onDragEnter={(event) => {
+          event.preventDefault();
+          setIsDragActive(true);
+        }}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setIsDragActive(true);
+        }}
+        onDragLeave={(event) => {
+          event.preventDefault();
+          setIsDragActive(false);
+        }}
+        onDrop={handleDrop}
+        className={cn(
+          "group relative overflow-hidden rounded-xl border border-dashed border-border bg-muted/20 transition-colors",
+          aspect === "banner" ? "h-36 md:h-44" : "aspect-square max-w-[160px]",
+          isDragActive && "border-purple-400 bg-purple-500/10",
+          "cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400",
+        )}
+        aria-label={label || "Upload image"}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED_TYPES.join(",")}
+          className="hidden"
+          onChange={(event) => handleFiles(event.target.files)}
+        />
+
+        {displayUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={displayUrl}
+            alt=""
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center text-muted-foreground">
+            <ImagePlus className="h-6 w-6 text-purple-400" />
+            <p className="text-xs">Drop or click</p>
+          </div>
+        )}
+
+        <div className="pointer-events-none absolute inset-0 flex items-end justify-center bg-gradient-to-t from-black/50 to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100">
+          <span className="text-xs text-white">Change</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={undo}
+          disabled={!canUndo}
+          className="rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
+          aria-label="Undo image change"
+        >
+          <Undo2 className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={redo}
+          disabled={!canRedo}
+          className="rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
+          aria-label="Redo image change"
+        >
+          <Redo2 className="h-4 w-4" />
+        </button>
+      </div>
+
+      {error ? <p className="text-xs text-red-400">{error}</p> : null}
+    </div>
+  );
+}

--- a/nftopia-frontend/lib/graphql/queries/creator.queries.ts
+++ b/nftopia-frontend/lib/graphql/queries/creator.queries.ts
@@ -1,0 +1,116 @@
+import { gql } from "@apollo/client";
+import { NFT_FIELDS_FRAGMENT, COLLECTION_FIELDS_FRAGMENT } from "../fragments";
+
+export const PUBLIC_CREATOR_FIELDS_FRAGMENT = gql`
+  fragment PublicCreatorFields on PublicCreator {
+    id
+    username
+    bio
+    avatarUrl
+    bannerUrl
+    website
+    twitterHandle
+    instagramHandle
+    isVerified
+    followerCount
+    followingCount
+    totalNftsCreated
+    totalSalesVolume
+    createdAt
+    isFollowing
+  }
+`;
+
+export const GET_PUBLIC_CREATOR_QUERY = gql`
+  query GetPublicCreator(
+    $identifier: String!
+    $nftFirst: Int = 12
+    $nftAfter: String
+    $nftSort: CreatorNftSort
+    $collectionFirst: Int = 12
+    $collectionAfter: String
+    $activityFirst: Int = 10
+    $activityAfter: String
+  ) {
+    publicCreator(identifier: $identifier) {
+      ...PublicCreatorFields
+      nfts(pagination: { first: $nftFirst, after: $nftAfter }, sortBy: $nftSort) {
+        edges {
+          node {
+            ...NftFields
+            lastPrice
+          }
+          cursor
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
+      }
+      collections(pagination: { first: $collectionFirst, after: $collectionAfter }) {
+        edges {
+          node {
+            ...CollectionFields
+            floorPrice
+            totalSupply
+          }
+          cursor
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
+      }
+      activity(pagination: { first: $activityFirst, after: $activityAfter }) {
+        edges {
+          node {
+            type
+            occurredAt
+            nftId
+            price
+            currency
+          }
+          cursor
+        }
+        totalCount
+      }
+    }
+  }
+  ${PUBLIC_CREATOR_FIELDS_FRAGMENT}
+  ${NFT_FIELDS_FRAGMENT}
+  ${COLLECTION_FIELDS_FRAGMENT}
+`;
+
+export const GET_PUBLIC_CREATOR_META_QUERY = gql`
+  query GetPublicCreatorMeta($identifier: String!) {
+    publicCreator(identifier: $identifier) {
+      id
+      username
+      bio
+      avatarUrl
+      bannerUrl
+    }
+  }
+`;
+
+export const FOLLOW_CREATOR_MUTATION = gql`
+  mutation FollowCreator($creatorId: ID!) {
+    followCreator(creatorId: $creatorId) {
+      success
+      followerCount
+      isFollowing
+    }
+  }
+`;
+
+export const UNFOLLOW_CREATOR_MUTATION = gql`
+  mutation UnfollowCreator($creatorId: ID!) {
+    unfollowCreator(creatorId: $creatorId) {
+      success
+      followerCount
+      isFollowing
+    }
+  }
+`;

--- a/nftopia-frontend/lib/graphql/schema.graphql
+++ b/nftopia-frontend/lib/graphql/schema.graphql
@@ -199,6 +199,12 @@ type Mutation {
 
   """Execute NFT purchase against an active listing"""
   buyNFT(listingId: ID!): TransactionResult!
+
+  """Follow a creator"""
+  followCreator(creatorId: ID!): FollowResult!
+
+  """Unfollow a creator"""
+  unfollowCreator(creatorId: ID!): FollowResult!
 }
 
 type NFT {
@@ -373,6 +379,9 @@ type Query {
   """Fetch a user by Stellar address"""
   userByAddress(address: String!): User
 
+  """Fetch a public creator profile by id, username, or wallet address"""
+  publicCreator(identifier: String!): PublicCreator!
+
   """Fetch a single auction by ID"""
   auction(id: ID!): Auction!
 }
@@ -445,5 +454,61 @@ type User {
   auctions(pagination: PaginationInput): AuctionConnection
   purchases(pagination: PaginationInput): OrderConnection
   sales(pagination: PaginationInput): OrderConnection
+}
+
+type PublicCreator {
+  id: ID!
+  username: String
+  bio: String
+  avatarUrl: String
+  bannerUrl: String
+  website: String
+  twitterHandle: String
+  instagramHandle: String
+  isVerified: Boolean!
+  followerCount: Int!
+  followingCount: Int!
+  totalNftsCreated: Int!
+  totalSalesVolume: String!
+  createdAt: DateTime!
+  isFollowing: Boolean
+  nfts(pagination: PaginationInput, sortBy: CreatorNftSort): NFTConnection
+  collections(pagination: PaginationInput): CollectionConnection
+  activity(pagination: PaginationInput): CreatorActivityConnection
+}
+
+enum CreatorNftSort {
+  NEWEST
+  PRICE
+}
+
+enum CreatorActivityType {
+  MINT
+  SALE
+  LISTING
+}
+
+type CreatorActivityItem {
+  type: CreatorActivityType!
+  occurredAt: DateTime!
+  nftId: ID
+  price: String
+  currency: String
+}
+
+type CreatorActivityEdge {
+  node: CreatorActivityItem!
+  cursor: String!
+}
+
+type CreatorActivityConnection {
+  edges: [CreatorActivityEdge!]!
+  totalCount: Int!
+}
+
+type FollowResult {
+  success: Boolean!
+  followerCount: Int!
+  isFollowing: Boolean!
 }
 

--- a/nftopia-frontend/lib/utils/creator-profile.ts
+++ b/nftopia-frontend/lib/utils/creator-profile.ts
@@ -1,0 +1,75 @@
+export function getCreatorAvatarUrl(
+  userId: string,
+  avatarUrl?: string | null,
+): string {
+  if (avatarUrl?.trim()) {
+    return avatarUrl;
+  }
+
+  return `https://api.dicebear.com/7.x/bottts-neutral/svg?seed=${encodeURIComponent(userId)}`;
+}
+
+export function getCreatorBannerUrl(
+  userId: string,
+  bannerUrl?: string | null,
+): string | null {
+  if (bannerUrl?.trim()) {
+    return bannerUrl;
+  }
+
+  return null;
+}
+
+export function getCreatorDisplayName(
+  username?: string | null,
+  id?: string,
+): string {
+  if (username?.trim()) {
+    return username.trim();
+  }
+
+  if (id) {
+    return `${id.slice(0, 6)}…${id.slice(-4)}`;
+  }
+
+  return "Creator";
+}
+
+export function buildCreatorProfilePath(
+  usernameOrId: string,
+  locale?: string,
+): string {
+  const slug = encodeURIComponent(usernameOrId);
+  return locale ? `/${locale}/creator/${slug}` : `/creator/${slug}`;
+}
+
+export function normalizeSocialHandle(
+  handle?: string | null,
+): string | null {
+  if (!handle?.trim()) return null;
+  return handle.startsWith("@") ? handle.slice(1) : handle;
+}
+
+export function buildTwitterUrl(handle?: string | null): string | null {
+  const normalized = normalizeSocialHandle(handle);
+  return normalized ? `https://twitter.com/${normalized}` : null;
+}
+
+export function buildInstagramUrl(handle?: string | null): string | null {
+  const normalized = normalizeSocialHandle(handle);
+  return normalized ? `https://instagram.com/${normalized}` : null;
+}
+
+export function sanitizeExternalUrl(url?: string | null): string | null {
+  if (!url?.trim()) return null;
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}

--- a/nftopia-frontend/lib/utils/share-profile.ts
+++ b/nftopia-frontend/lib/utils/share-profile.ts
@@ -1,0 +1,62 @@
+type ShareCreatorProfileInput = {
+  url: string;
+  title: string;
+  text?: string;
+  imageUrl?: string | null;
+};
+
+export type ShareResult =
+  | { method: "native" }
+  | { method: "clipboard" }
+  | { method: "cancelled" };
+
+async function fetchShareImageFile(imageUrl: string): Promise<File | null> {
+  try {
+    const response = await fetch(imageUrl, { mode: "cors" });
+    if (!response.ok) return null;
+
+    const blob = await response.blob();
+    if (!blob.type.startsWith("image/")) return null;
+
+    const extension = blob.type.split("/")[1] || "png";
+    return new File([blob], `creator-profile.${extension}`, { type: blob.type });
+  } catch {
+    return null;
+  }
+}
+
+export async function shareCreatorProfile(
+  input: ShareCreatorProfileInput,
+): Promise<ShareResult> {
+  if (typeof navigator !== "undefined" && navigator.share) {
+    try {
+      const shareData: ShareData = {
+        title: input.title,
+        text: input.text,
+        url: input.url,
+      };
+
+      if (input.imageUrl && navigator.canShare) {
+        const imageFile = await fetchShareImageFile(input.imageUrl);
+        if (imageFile && navigator.canShare({ files: [imageFile] })) {
+          await navigator.share({ ...shareData, files: [imageFile] });
+          return { method: "native" };
+        }
+      }
+
+      await navigator.share(shareData);
+      return { method: "native" };
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return { method: "cancelled" };
+      }
+    }
+  }
+
+  await navigator.clipboard.writeText(input.url);
+  return { method: "clipboard" };
+}
+
+export async function copyCreatorProfileUrl(url: string): Promise<void> {
+  await navigator.clipboard.writeText(url);
+}

--- a/nftopia-frontend/locales/de/common.json
+++ b/nftopia-frontend/locales/de/common.json
@@ -101,6 +101,24 @@
       "royalties": "Lizenzgebühren",
       "mint": "NFT prägen"
     },
+    "creatorProfile": {
+      "verified": "Verifiziert",
+      "followers": "Follower",
+      "nftsCreated": "NFTs",
+      "volume": "Volumen",
+      "tabNfts": "NFTs",
+      "tabCollections": "Kollektionen",
+      "tabActivity": "Aktivität",
+      "sortNewest": "Neueste",
+      "sortPrice": "Preis",
+      "emptyNfts": "Noch keine NFTs",
+      "emptyCollections": "Noch keine Kollektionen",
+      "emptyActivity": "Noch keine Aktivität",
+      "notFound": "Creator nicht gefunden",
+      "activityMint": "Gemintet",
+      "activitySale": "Verkauft",
+      "activityListing": "Gelistet"
+    },
     "common": {
       "loading": "Wird geladen...",
       "error": "Fehler",

--- a/nftopia-frontend/locales/en/common.json
+++ b/nftopia-frontend/locales/en/common.json
@@ -101,6 +101,24 @@
     "royalties": "Royalties",
     "mint": "Mint NFT"
   },
+  "creatorProfile": {
+    "verified": "Verified",
+    "followers": "followers",
+    "nftsCreated": "NFTs",
+    "volume": "volume",
+    "tabNfts": "NFTs",
+    "tabCollections": "Collections",
+    "tabActivity": "Activity",
+    "sortNewest": "Newest",
+    "sortPrice": "Price",
+    "emptyNfts": "No NFTs yet",
+    "emptyCollections": "No collections yet",
+    "emptyActivity": "No activity yet",
+    "notFound": "Creator not found",
+    "activityMint": "Minted",
+    "activitySale": "Sold",
+    "activityListing": "Listed"
+  },
   "common": {
     "loading": "Loading...",
     "error": "Error",

--- a/nftopia-frontend/locales/es/common.json
+++ b/nftopia-frontend/locales/es/common.json
@@ -101,6 +101,24 @@
       "royalties": "Regalías",
       "mint": "Acuñar NFT"
     },
+    "creatorProfile": {
+      "verified": "Verificado",
+      "followers": "seguidores",
+      "nftsCreated": "NFTs",
+      "volume": "volumen",
+      "tabNfts": "NFTs",
+      "tabCollections": "Colecciones",
+      "tabActivity": "Actividad",
+      "sortNewest": "Más recientes",
+      "sortPrice": "Precio",
+      "emptyNfts": "Sin NFTs",
+      "emptyCollections": "Sin colecciones",
+      "emptyActivity": "Sin actividad",
+      "notFound": "Creador no encontrado",
+      "activityMint": "Acuñado",
+      "activitySale": "Vendido",
+      "activityListing": "Listado"
+    },
     "common": {
       "loading": "Cargando...",
       "error": "Error",

--- a/nftopia-frontend/locales/fr/common.json
+++ b/nftopia-frontend/locales/fr/common.json
@@ -101,6 +101,24 @@
     "royalties": "Revenus",
     "mint": "Minter le NFT"
   },
+  "creatorProfile": {
+    "verified": "Vérifié",
+    "followers": "abonnés",
+    "nftsCreated": "NFTs",
+    "volume": "volume",
+    "tabNfts": "NFTs",
+    "tabCollections": "Collections",
+    "tabActivity": "Activité",
+    "sortNewest": "Plus récents",
+    "sortPrice": "Prix",
+    "emptyNfts": "Aucun NFT",
+    "emptyCollections": "Aucune collection",
+    "emptyActivity": "Aucune activité",
+    "notFound": "Créateur introuvable",
+    "activityMint": "Minté",
+    "activitySale": "Vendu",
+    "activityListing": "Listé"
+  },
   "common": {
     "loading": "Chargement...",
     "error": "Erreur",


### PR DESCRIPTION
Summary
Adds public creator profiles at /[locale]/creator/[usernameOrId] so users can browse a creator's portfolio, collections, and activity outside the authenticated creator dashboard.

Backend: publicCreator GraphQL query (resolve by id, username, or Stellar address), followCreator / unfollowCreator mutations, NFT/collection/activity field resolvers, and user_follows migration
Frontend: Profile header (banner, avatar, verification badge, stats, social links), tabbed NFTs / Collections / Activity views, follow button with optimistic UI, share via Web Share API + clipboard fallback, SEO generateMetadata, loading/error states
Creator dashboard: Custom drag-and-drop image upload with undo/redo (max 5); uploads deferred until profile save
Security: Public responses exclude private fields; banned users hidden; follow requires auth; external URLs sanitized

Test plan
 Apply migration (see below) and start backend + frontend
 Visit /en/creator/{username} — profile loads with avatar, banner, bio, join date, social links

 Verified creator shows badge

 NFTs tab: grid loads, sort (Newest / Price), pagination works; cards link to NFT detail

 Collections tab: grid loads; cards link to collection detail

 Activity tab: mint / sale / listing events render

 Authenticated user can follow/unfollow; count updates optimistically

 Logged-out user sees follower count; follow opens wallet connect

 Share copies URL or opens native share sheet

 NFT detail page creator name links to public profile

 Creator dashboard: avatar/banner drag-and-drop, undo/redo, upload only on save

Apply the new migration against your Postgres instance (local or remote):
psql "$DATABASE_URL" -f nftopia-backend/migrations/20260701000000_user_follows_and_created_at.sql
The repo has SQL migrations under nftopia-backend/migrations/ but no db:migrate:deploy (or similar) script in package.json. Dev currently relies on TypeORM synchronize: true, which may create some schema changes automatically, but production/remote environments should run migrations explicitly. Worth adding a migrate script in a follow-up if the team moves off synchronize

GraphQL codegen: npm run graphql:codegen fails due to existing frontend/schema drift — lib/graphql/queries/auction.queries.ts references serverTime and auctions, which are not in lib/graphql/schema.graphql. That mismatch predates this PR; this work does not depend on codegen (the creator profile uses direct Apollo queries). fixing codegen/schema alignment can be a separate issue if the team wants generated hooks restored project wide

Closes #318 