### PR TITLE
feat(marketplace): connect creator List-for-Sale and Sales pages to shared listings/auctions data

### DIFF
--- a/nftopia-frontend/__tests__/list-for-sale-page.test.tsx
+++ b/nftopia-frontend/__tests__/list-for-sale-page.test.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import ListNFTsForSale from "../app/[locale]/creator-dashboard/list-nfts-for-sale/page";
+import { useCreatorListings } from "@/hooks/useCreatorListings";
+import type { MarketplaceNft } from "@/types/marketplace";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img alt="" {...props} />;
+  },
+}));
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+jest.mock("@/lib/stores", () => ({
+  useToast: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}));
+
+jest.mock("@/hooks/useCreatorListings", () => ({
+  useCreatorListings: jest.fn(),
+}));
+
+const mockedHook = useCreatorListings as jest.MockedFunction<
+  typeof useCreatorListings
+>;
+
+function makeNft(overrides: Partial<MarketplaceNft> = {}): MarketplaceNft {
+  return {
+    id: "n1",
+    contractId: "C1",
+    tokenId: "t1",
+    name: "Cosmic Cat",
+    nftKey: "C1:t1",
+    state: "NOT_LISTED",
+    listing: null,
+    ...overrides,
+  };
+}
+
+function setHook(partial: Partial<ReturnType<typeof useCreatorListings>>) {
+  mockedHook.mockReturnValue({
+    nfts: [],
+    loading: false,
+    error: null,
+    isAuthReady: true,
+    refetch: jest.fn(),
+    createListing: jest.fn().mockResolvedValue(undefined),
+    cancelListing: jest.fn().mockResolvedValue(undefined),
+    ...partial,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ListNFTsForSale page", () => {
+  it("does not render the grid or empty state while loading", () => {
+    setHook({ loading: true });
+    render(<ListNFTsForSale />);
+    expect(screen.queryByTestId("nft-grid")).not.toBeInTheDocument();
+    expect(screen.queryByText("No NFTs to list")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when the creator owns no NFTs", () => {
+    setHook({ nfts: [] });
+    render(<ListNFTsForSale />);
+    expect(screen.getByText("No NFTs to list")).toBeInTheDocument();
+  });
+
+  it("renders an error with a working retry button", () => {
+    const refetch = jest.fn();
+    setHook({ error: "Network down", refetch });
+    render(<ListNFTsForSale />);
+    expect(screen.getByText("Network down")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders owned NFTs with their market status", () => {
+    setHook({
+      nfts: [
+        makeNft(),
+        makeNft({ id: "n2", nftKey: "C2:t2", name: "Listed One", state: "ACTIVE" }),
+      ],
+    });
+    render(<ListNFTsForSale />);
+    expect(screen.getByText("Cosmic Cat")).toBeInTheDocument();
+    expect(screen.getByText("Not listed")).toBeInTheDocument();
+    expect(screen.getByText("Active listing")).toBeInTheDocument();
+  });
+
+  it("creates a listing through the inline form", async () => {
+    const createListing = jest.fn().mockResolvedValue(undefined);
+    setHook({ nfts: [makeNft()], createListing });
+    render(<ListNFTsForSale />);
+
+    fireEvent.click(screen.getByRole("button", { name: /list for sale/i }));
+    fireEvent.change(screen.getByLabelText(/price/i), {
+      target: { value: "25" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() =>
+      expect(createListing).toHaveBeenCalledWith(
+        expect.objectContaining({ nftKey: "C1:t1" }),
+        { price: 25, currency: "XLM" },
+      ),
+    );
+    await waitFor(() => expect(mockShowSuccess).toHaveBeenCalled());
+  });
+
+  it("cancels an active listing", async () => {
+    const cancelListing = jest.fn().mockResolvedValue(undefined);
+    const nft = makeNft({
+      state: "ACTIVE",
+      listing: {
+        id: "l1",
+        nftContractId: "C1",
+        nftTokenId: "t1",
+        sellerId: "creator-1",
+        price: 10,
+        currency: "XLM",
+        status: "ACTIVE",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    setHook({ nfts: [nft], cancelListing });
+    render(<ListNFTsForSale />);
+
+    const grid = screen.getByTestId("nft-grid");
+    fireEvent.click(
+      within(grid).getByRole("button", { name: /cancel listing/i }),
+    );
+
+    await waitFor(() => expect(cancelListing).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockShowSuccess).toHaveBeenCalled());
+  });
+});

--- a/nftopia-frontend/__tests__/marketplace-mapper.test.ts
+++ b/nftopia-frontend/__tests__/marketplace-mapper.test.ts
@@ -1,0 +1,136 @@
+import {
+  auctionToActivity,
+  buildActivityFeed,
+  deriveSalesSummary,
+  listingToActivity,
+  toMarketplaceNft,
+} from "@/lib/services/marketplace-mapper";
+import type { Auction, Listing, OwnedNft } from "@/types/marketplace";
+
+const CREATOR = "creator-1";
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+  return {
+    id: "l1",
+    nftContractId: "C1",
+    nftTokenId: "t1",
+    sellerId: CREATOR,
+    price: 10,
+    currency: "XLM",
+    status: "ACTIVE",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeAuction(overrides: Partial<Auction> = {}): Auction {
+  return {
+    id: "a1",
+    nftContractId: "C2",
+    nftTokenId: "t2",
+    sellerId: CREATOR,
+    startPrice: 5,
+    currentPrice: 8,
+    startTime: "2026-01-01T00:00:00.000Z",
+    endTime: "2026-02-01T00:00:00.000Z",
+    status: "ACTIVE",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const ownedNft: OwnedNft = { id: "n1", contractId: "C1", tokenId: "t1" };
+
+describe("toMarketplaceNft", () => {
+  it("marks an NFT as not listed when there is no listing", () => {
+    const result = toMarketplaceNft(ownedNft, null);
+    expect(result.state).toBe("NOT_LISTED");
+    expect(result.listing).toBeNull();
+    expect(result.nftKey).toBe("C1:t1");
+  });
+
+  it("exposes an active listing and ACTIVE state", () => {
+    const listing = makeListing({ status: "ACTIVE" });
+    const result = toMarketplaceNft(ownedNft, listing);
+    expect(result.state).toBe("ACTIVE");
+    expect(result.listing).toEqual(listing);
+  });
+
+  it("treats a cancelled listing as not listed and clears the listing", () => {
+    const result = toMarketplaceNft(ownedNft, makeListing({ status: "CANCELLED" }));
+    expect(result.state).toBe("NOT_LISTED");
+    expect(result.listing).toBeNull();
+  });
+
+  it("reflects a sold listing without exposing it as active", () => {
+    const result = toMarketplaceNft(ownedNft, makeListing({ status: "SOLD" }));
+    expect(result.state).toBe("SOLD");
+    expect(result.listing).toBeNull();
+  });
+});
+
+describe("activity normalization", () => {
+  it("normalizes a listing into a LISTING activity entry", () => {
+    const activity = listingToActivity(makeListing({ price: 12 }));
+    expect(activity).toMatchObject({
+      kind: "LISTING",
+      nftKey: "C1:t1",
+      amount: 12,
+      currency: "XLM",
+    });
+  });
+
+  it("uses the auction current price for the activity amount", () => {
+    const activity = auctionToActivity(makeAuction({ currentPrice: 9 }));
+    expect(activity).toMatchObject({ kind: "AUCTION", amount: 9 });
+  });
+
+  it("builds a recency-sorted feed of only the creator's events", () => {
+    const listings = [
+      makeListing({ id: "mine", updatedAt: "2026-03-01T00:00:00.000Z" }),
+      makeListing({ id: "other", sellerId: "someone-else" }),
+    ];
+    const auctions = [
+      makeAuction({ id: "auc", updatedAt: "2026-04-01T00:00:00.000Z" }),
+    ];
+
+    const feed = buildActivityFeed(listings, auctions, CREATOR);
+
+    expect(feed).toHaveLength(2);
+    // Most recent first: the auction (April) precedes the listing (March).
+    expect(feed[0].id).toBe("auction:auc");
+    expect(feed[1].id).toBe("listing:mine");
+  });
+});
+
+describe("deriveSalesSummary", () => {
+  it("derives counts and gross volume deterministically", () => {
+    const listings = [
+      makeListing({ id: "active", status: "ACTIVE" }),
+      makeListing({ id: "sold", status: "SOLD", price: 30 }),
+      makeListing({ id: "notmine", status: "SOLD", price: 999, sellerId: "x" }),
+    ];
+    const auctions = [
+      makeAuction({ id: "settled", status: "SETTLED", currentPrice: 20 }),
+      makeAuction({ id: "live", status: "ACTIVE", currentPrice: 7 }),
+    ];
+
+    const summary = deriveSalesSummary(listings, auctions, CREATOR);
+
+    expect(summary.activeListings).toBe(1);
+    expect(summary.itemsSold).toBe(2); // 1 sold listing + 1 settled auction
+    expect(summary.grossVolume).toBe(50); // 30 + 20
+    expect(summary.currency).toBe("XLM");
+  });
+
+  it("returns zeroes when the creator has no marketplace data", () => {
+    expect(deriveSalesSummary([], [], CREATOR)).toEqual({
+      activeListings: 0,
+      itemsSold: 0,
+      grossVolume: 0,
+      currency: "XLM",
+    });
+  });
+});

--- a/nftopia-frontend/__tests__/sales-page.test.tsx
+++ b/nftopia-frontend/__tests__/sales-page.test.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import SalesPage from "../app/[locale]/creator-dashboard/sales/page";
+import { useCreatorSales } from "@/hooks/useCreatorSales";
+import type { MarketplaceActivity, SalesSummary } from "@/types/marketplace";
+
+jest.mock("@/hooks/useCreatorSales", () => ({
+  useCreatorSales: jest.fn(),
+}));
+
+const mockedHook = useCreatorSales as jest.MockedFunction<
+  typeof useCreatorSales
+>;
+
+const summary: SalesSummary = {
+  activeListings: 3,
+  itemsSold: 2,
+  grossVolume: 150,
+  currency: "XLM",
+};
+
+const activity: MarketplaceActivity[] = [
+  {
+    id: "auction:a1",
+    kind: "AUCTION",
+    nftKey: "C2:t2",
+    status: "SETTLED",
+    amount: 100,
+    currency: "XLM",
+    timestamp: "2026-04-01T00:00:00.000Z",
+  },
+  {
+    id: "listing:l1",
+    kind: "LISTING",
+    nftKey: "C1:t1",
+    status: "SOLD",
+    amount: 50,
+    currency: "XLM",
+    timestamp: "2026-03-01T00:00:00.000Z",
+  },
+];
+
+function setHook(partial: Partial<ReturnType<typeof useCreatorSales>>) {
+  mockedHook.mockReturnValue({
+    summary: null,
+    activity: [],
+    loading: false,
+    error: null,
+    refetch: jest.fn(),
+    ...partial,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SalesPage", () => {
+  it("hides summary and feed while loading", () => {
+    setHook({ loading: true });
+    render(<SalesPage />);
+    expect(screen.queryByTestId("sales-summary")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("activity-feed")).not.toBeInTheDocument();
+  });
+
+  it("renders derived summary tiles from real data", () => {
+    setHook({ summary, activity });
+    render(<SalesPage />);
+
+    const tiles = screen.getByTestId("sales-summary");
+    expect(within(tiles).getByText("Active listings")).toBeInTheDocument();
+    expect(within(tiles).getByText("3")).toBeInTheDocument();
+    expect(within(tiles).getByText("2")).toBeInTheDocument();
+    expect(within(tiles).getByText("150 XLM")).toBeInTheDocument();
+  });
+
+  it("renders the combined activity feed", () => {
+    setHook({ summary, activity });
+    render(<SalesPage />);
+
+    const feed = screen.getByTestId("activity-feed");
+    expect(within(feed).getByText(/Auction · C2:t2/)).toBeInTheDocument();
+    expect(within(feed).getByText(/Listing · C1:t1/)).toBeInTheDocument();
+    expect(within(feed).getByText("100 XLM")).toBeInTheDocument();
+    expect(within(feed).getByText("50 XLM")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there is no activity", () => {
+    setHook({ summary, activity: [] });
+    render(<SalesPage />);
+    expect(
+      screen.getByText("No marketplace activity yet"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error with a working retry button", () => {
+    const refetch = jest.fn();
+    setHook({ error: "boom", refetch });
+    render(<SalesPage />);
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/nftopia-frontend/app/[locale]/creator-dashboard/list-nfts-for-sale/page.tsx
+++ b/nftopia-frontend/app/[locale]/creator-dashboard/list-nfts-for-sale/page.tsx
@@ -1,10 +1,245 @@
-export default function ListNFTsForSale() {
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Package, Tag, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardFooter } from "@/components/ui/card";
+import { useToast } from "@/lib/stores";
+import { useCreatorListings } from "@/hooks/useCreatorListings";
+import { MarketStateBadge } from "@/components/marketplace/MarketStateBadge";
+import { formatAmount } from "@/components/marketplace/format";
+import type { MarketplaceNft } from "@/types/marketplace";
+
+const FALLBACK_IMAGE = "/images/fallbacks/nft-fallback.svg";
+
+/**
+ * A single owned-NFT card: shows the NFT, its resolved market state, and the
+ * contextual action (create listing for an unlisted NFT, cancel for an active
+ * one). The create form is revealed inline to keep the action close to the item.
+ */
+function NftListingCard({
+  nft,
+  onCreate,
+  onCancel,
+}: {
+  nft: MarketplaceNft;
+  onCreate: (
+    nft: MarketplaceNft,
+    input: { price: number; currency: string },
+  ) => Promise<void>;
+  onCancel: (nft: MarketplaceNft) => Promise<void>;
+}) {
+  const [showForm, setShowForm] = useState(false);
+  const [price, setPrice] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    const parsed = Number(price);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+    setBusy(true);
+    try {
+      await onCreate(nft, { price: parsed, currency: "XLM" });
+      setShowForm(false);
+      setPrice("");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cancel = async () => {
+    setBusy(true);
+    try {
+      await onCancel(nft);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
-    <div className="flex items-center justify-center min-h-[60vh]">
-      <div className="text-center">
-        <h1 className="text-3xl font-bold text-nftopia-text mb-4">List NFTs For Sale</h1>
-        <p className="text-nftopia-subtext text-lg">Coming Soon</p>
+    <Card className="overflow-hidden">
+      <div className="relative aspect-square w-full bg-zinc-900">
+        <Image
+          src={nft.imageUrl || FALLBACK_IMAGE}
+          alt={nft.name || "NFT"}
+          fill
+          sizes="(max-width: 768px) 100vw, 33vw"
+          className="object-cover"
+        />
       </div>
+      <CardContent className="space-y-2 pt-4">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="truncate font-semibold text-nftopia-text">
+            {nft.name || `Token #${nft.tokenId}`}
+          </h3>
+          <MarketStateBadge state={nft.state} />
+        </div>
+        {nft.listing && (
+          <p className="text-sm text-nftopia-subtext">
+            Listed at {formatAmount(nft.listing.price, nft.listing.currency)}
+          </p>
+        )}
+        {showForm && (
+          <div className="space-y-2 pt-2">
+            <Label htmlFor={`price-${nft.nftKey}`}>Price (XLM)</Label>
+            <Input
+              id={`price-${nft.nftKey}`}
+              type="number"
+              min="0"
+              step="0.0000001"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              placeholder="25.0"
+            />
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="gap-2">
+        {nft.state === "ACTIVE" ? (
+          <Button
+            variant="danger-ghost"
+            loading={busy}
+            onClick={cancel}
+            className="w-full"
+          >
+            <X className="size-4" /> Cancel listing
+          </Button>
+        ) : nft.state === "NOT_LISTED" ? (
+          showForm ? (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => setShowForm(false)}
+                disabled={busy}
+                className="flex-1"
+              >
+                Cancel
+              </Button>
+              <Button
+                loading={busy}
+                onClick={submit}
+                disabled={!price}
+                className="flex-1"
+              >
+                Confirm
+              </Button>
+            </>
+          ) : (
+            <Button onClick={() => setShowForm(true)} className="w-full">
+              <Tag className="size-4" /> List for sale
+            </Button>
+          )
+        ) : (
+          <span className="w-full py-2 text-center text-sm text-nftopia-subtext">
+            {nft.state === "SOLD" ? "Already sold" : "Listing expired"}
+          </span>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}
+
+/** Loading placeholder grid shown while owned NFTs resolve. */
+function LoadingGrid() {
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="space-y-3">
+          <Skeleton className="aspect-square w-full rounded-lg" />
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-9 w-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * "List NFTs for Sale" — the creator's inventory management view. Loads owned
+ * NFTs, resolves each one's listing status, and lets the creator create or
+ * cancel listings with immediate per-item feedback.
+ */
+export default function ListNFTsForSale() {
+  const { nfts, loading, error, refetch, createListing, cancelListing } =
+    useCreatorListings();
+  const { showSuccess, showError } = useToast();
+
+  const handleCreate = async (
+    nft: MarketplaceNft,
+    input: { price: number; currency: string },
+  ) => {
+    try {
+      await createListing(nft, input);
+      showSuccess("Listing created.");
+    } catch (err) {
+      showError(
+        err instanceof Error ? err.message : "Could not create listing.",
+      );
+    }
+  };
+
+  const handleCancel = async (nft: MarketplaceNft) => {
+    try {
+      await cancelListing(nft);
+      showSuccess("Listing cancelled.");
+    } catch (err) {
+      showError(
+        err instanceof Error ? err.message : "Could not cancel listing.",
+      );
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-3xl font-bold text-nftopia-text">
+          List NFTs For Sale
+        </h1>
+        <p className="text-nftopia-subtext">
+          Create or cancel listings for the NFTs you own.
+        </p>
+      </header>
+
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertTitle>Couldn&apos;t load your NFTs</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-4">
+            <span>{error}</span>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {loading ? (
+        <LoadingGrid />
+      ) : nfts.length === 0 && !error ? (
+        <EmptyState
+          icon={<Package className="size-10 text-nftopia-subtext" />}
+          title="No NFTs to list"
+          description="Once you own or mint NFTs, they'll appear here ready to list for sale."
+        />
+      ) : (
+        <div
+          data-testid="nft-grid"
+          className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {nfts.map((nft) => (
+            <NftListingCard
+              key={nft.nftKey}
+              nft={nft}
+              onCreate={handleCreate}
+              onCancel={handleCancel}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/nftopia-frontend/app/[locale]/creator-dashboard/sales/page.tsx
+++ b/nftopia-frontend/app/[locale]/creator-dashboard/sales/page.tsx
@@ -1,10 +1,154 @@
-export default function SalesPage() {
+"use client";
+
+import { Activity, DollarSign, ShoppingBag, Tag } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent } from "@/components/ui/card";
+import { useCreatorSales } from "@/hooks/useCreatorSales";
+import { formatAmount, formatDate } from "@/components/marketplace/format";
+import type { MarketplaceActivity, SalesSummary } from "@/types/marketplace";
+
+/** A single summary tile (active listings, items sold, gross volume). */
+function SummaryTile({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
   return (
-    <div className="flex items-center justify-center min-h-[60vh]">
-      <div className="text-center">
-        <h1 className="text-3xl font-bold text-nftopia-text mb-4">Sales & Earnings</h1>
-        <p className="text-nftopia-subtext text-lg">Coming Soon</p>
+    <Card>
+      <CardContent className="flex items-center gap-4 p-5">
+        <span className="flex size-11 items-center justify-center rounded-xl bg-nftopia-purple/10 text-nftopia-purple">
+          {icon}
+        </span>
+        <div>
+          <p className="text-sm text-nftopia-subtext">{label}</p>
+          <p className="text-xl font-bold text-nftopia-text">{value}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Renders the three derived summary tiles from the sales summary model. */
+function SummaryTiles({ summary }: { summary: SalesSummary }) {
+  return (
+    <div
+      data-testid="sales-summary"
+      className="grid grid-cols-1 gap-4 sm:grid-cols-3"
+    >
+      <SummaryTile
+        icon={<Tag className="size-5" />}
+        label="Active listings"
+        value={String(summary.activeListings)}
+      />
+      <SummaryTile
+        icon={<ShoppingBag className="size-5" />}
+        label="Items sold"
+        value={String(summary.itemsSold)}
+      />
+      <SummaryTile
+        icon={<DollarSign className="size-5" />}
+        label="Gross volume"
+        value={formatAmount(summary.grossVolume, summary.currency)}
+      />
+    </div>
+  );
+}
+
+/** A single row in the recent-activity feed. */
+function ActivityRow({ item }: { item: MarketplaceActivity }) {
+  return (
+    <li className="flex items-center justify-between gap-4 border-b border-white/5 py-3 last:border-0">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-nftopia-text">
+          {item.kind === "AUCTION" ? "Auction" : "Listing"} · {item.nftKey}
+        </p>
+        <p className="text-xs text-nftopia-subtext">
+          {item.status} · {formatDate(item.timestamp)}
+        </p>
       </div>
+      <span className="shrink-0 text-sm font-semibold text-nftopia-text">
+        {formatAmount(item.amount, item.currency)}
+      </span>
+    </li>
+  );
+}
+
+/** Skeleton shown while summary + activity load. */
+function LoadingState() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 w-full rounded-lg" />
+        ))}
+      </div>
+      <Skeleton className="h-64 w-full rounded-lg" />
+    </div>
+  );
+}
+
+/**
+ * "Sales" — the creator's marketplace performance view. Aggregates listings and
+ * auctions through the shared mapper into summary tiles and a unified
+ * recent-activity feed, so it stays consistent with the List-for-Sale page.
+ */
+export default function SalesPage() {
+  const { summary, activity, loading, error, refetch } = useCreatorSales();
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-3xl font-bold text-nftopia-text">Sales &amp; Earnings</h1>
+        <p className="text-nftopia-subtext">
+          Track your listings, sales, and auction activity.
+        </p>
+      </header>
+
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertTitle>Couldn&apos;t load sales data</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-4">
+            <span>{error}</span>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {loading ? (
+        <LoadingState />
+      ) : (
+        <div className="space-y-8">
+          {summary && <SummaryTiles summary={summary} />}
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-nftopia-text">
+              Recent activity
+            </h2>
+            {activity.length === 0 ? (
+              <EmptyState
+                icon={<Activity className="size-10 text-nftopia-subtext" />}
+                title="No marketplace activity yet"
+                description="Your listings and auction outcomes will show up here."
+              />
+            ) : (
+              <ul data-testid="activity-feed">
+                {activity.map((item) => (
+                  <ActivityRow key={item.id} item={item} />
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      )}
     </div>
   );
 }

--- a/nftopia-frontend/components/marketplace/MarketStateBadge.tsx
+++ b/nftopia-frontend/components/marketplace/MarketStateBadge.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/lib/utils";
+import type { NftMarketState } from "@/types/marketplace";
+
+/** Human-readable label + color treatment for each NFT market state. */
+const STATE_CONFIG: Record<
+  NftMarketState,
+  { label: string; className: string }
+> = {
+  NOT_LISTED: {
+    label: "Not listed",
+    className: "bg-zinc-500/15 text-zinc-300",
+  },
+  ACTIVE: {
+    label: "Active listing",
+    className: "bg-emerald-500/15 text-emerald-400",
+  },
+  SOLD: { label: "Sold", className: "bg-blue-500/15 text-blue-400" },
+  EXPIRED: { label: "Expired", className: "bg-amber-500/15 text-amber-400" },
+};
+
+/**
+ * A small status pill that communicates an NFT's marketplace state on the
+ * "List NFTs for Sale" page. Shared so the same vocabulary is reused everywhere.
+ */
+export function MarketStateBadge({
+  state,
+  className,
+}: {
+  state: NftMarketState;
+  className?: string;
+}) {
+  const config = STATE_CONFIG[state];
+  return (
+    <span
+      data-testid="market-state-badge"
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        config.className,
+        className,
+      )}
+    >
+      {config.label}
+    </span>
+  );
+}

--- a/nftopia-frontend/components/marketplace/format.ts
+++ b/nftopia-frontend/components/marketplace/format.ts
@@ -2,13 +2,14 @@
 
 /**
  * Formats a numeric amount with its currency for display, e.g. `25 XLM`.
- * Trims trailing zeros while keeping up to 7 decimals (Stellar precision).
+ * Keeps up to 7 decimals (Stellar precision); `toLocaleString` already drops
+ * insignificant trailing zeros, so integers render without a decimal part.
  */
 export function formatAmount(amount: number, currency = "XLM"): string {
   const value = Number.isFinite(amount) ? amount : 0;
-  const formatted = value
-    .toLocaleString(undefined, { maximumFractionDigits: 7 })
-    .replace(/\.?0+$/, "");
+  const formatted = value.toLocaleString(undefined, {
+    maximumFractionDigits: 7,
+  });
   return `${formatted} ${currency}`;
 }
 

--- a/nftopia-frontend/components/marketplace/format.ts
+++ b/nftopia-frontend/components/marketplace/format.ts
@@ -1,0 +1,24 @@
+/** Formatting helpers shared by the creator marketplace pages. */
+
+/**
+ * Formats a numeric amount with its currency for display, e.g. `25 XLM`.
+ * Trims trailing zeros while keeping up to 7 decimals (Stellar precision).
+ */
+export function formatAmount(amount: number, currency = "XLM"): string {
+  const value = Number.isFinite(amount) ? amount : 0;
+  const formatted = value
+    .toLocaleString(undefined, { maximumFractionDigits: 7 })
+    .replace(/\.?0+$/, "");
+  return `${formatted} ${currency}`;
+}
+
+/** Formats an ISO timestamp into a short, locale-aware date string. */
+export function formatDate(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/nftopia-frontend/hooks/useCreatorListings.ts
+++ b/nftopia-frontend/hooks/useCreatorListings.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/lib/stores/auth-store";
+import {
+  cancelListing as cancelListingRequest,
+  createListing as createListingRequest,
+  getListingByNft,
+  getOwnedNfts,
+} from "@/lib/services/marketplace";
+import { toMarketplaceNft } from "@/lib/services/marketplace-mapper";
+import type { CreateListingDto, MarketplaceNft } from "@/types/marketplace";
+
+interface UseCreatorListingsResult {
+  nfts: MarketplaceNft[];
+  loading: boolean;
+  error: string | null;
+  /** True while the underlying creator id is still resolving. */
+  isAuthReady: boolean;
+  refetch: () => Promise<void>;
+  createListing: (
+    nft: MarketplaceNft,
+    input: { price: number; currency: string; expiresAt?: string },
+  ) => Promise<void>;
+  cancelListing: (nft: MarketplaceNft) => Promise<void>;
+}
+
+/**
+ * Loads the authenticated creator's owned NFTs and resolves each one's listing
+ * state, then exposes create/cancel actions that keep the in-memory list in
+ * sync via optimistic updates backed by a confirming refetch.
+ *
+ * Powers the "List NFTs for Sale" page.
+ */
+export function useCreatorListings(): UseCreatorListingsResult {
+  const { user } = useAuth();
+  const creatorId = user?.id ?? null;
+
+  const [nfts, setNfts] = useState<MarketplaceNft[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!creatorId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const owned = await getOwnedNfts(creatorId);
+      // Resolve listing state per NFT in parallel; a failed lookup degrades to
+      // "not listed" rather than failing the whole page.
+      const enriched = await Promise.all(
+        owned.map(async (nft) => {
+          try {
+            const listing = await getListingByNft(nft.contractId, nft.tokenId);
+            return toMarketplaceNft(nft, listing);
+          } catch {
+            return toMarketplaceNft(nft, null);
+          }
+        }),
+      );
+      setNfts(enriched);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load NFTs.");
+    } finally {
+      setLoading(false);
+    }
+  }, [creatorId]);
+
+  useEffect(() => {
+    if (creatorId) {
+      void load();
+    }
+  }, [creatorId, load]);
+
+  const createListing = useCallback(
+    async (
+      nft: MarketplaceNft,
+      input: { price: number; currency: string; expiresAt?: string },
+    ) => {
+      const payload: CreateListingDto = {
+        nftContractId: nft.contractId,
+        nftTokenId: nft.tokenId,
+        price: input.price,
+        currency: input.currency,
+        expiresAt: input.expiresAt,
+      };
+      const listing = await createListingRequest(payload);
+      // Optimistically reflect the new active listing, then refetch to confirm.
+      setNfts((prev) =>
+        prev.map((item) =>
+          item.nftKey === nft.nftKey
+            ? { ...item, state: "ACTIVE", listing }
+            : item,
+        ),
+      );
+      await load();
+    },
+    [load],
+  );
+
+  const cancelListing = useCallback(
+    async (nft: MarketplaceNft) => {
+      if (!nft.listing) return;
+      await cancelListingRequest(nft.listing.id);
+      setNfts((prev) =>
+        prev.map((item) =>
+          item.nftKey === nft.nftKey
+            ? { ...item, state: "NOT_LISTED", listing: null }
+            : item,
+        ),
+      );
+      await load();
+    },
+    [load],
+  );
+
+  return {
+    nfts,
+    loading,
+    error,
+    isAuthReady: creatorId !== null,
+    refetch: load,
+    createListing,
+    cancelListing,
+  };
+}

--- a/nftopia-frontend/hooks/useCreatorSales.ts
+++ b/nftopia-frontend/hooks/useCreatorSales.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/lib/stores/auth-store";
+import {
+  getAllAuctions,
+  getAllListings,
+} from "@/lib/services/marketplace";
+import {
+  buildActivityFeed,
+  deriveSalesSummary,
+} from "@/lib/services/marketplace-mapper";
+import type { MarketplaceActivity, SalesSummary } from "@/types/marketplace";
+
+interface UseCreatorSalesResult {
+  summary: SalesSummary | null;
+  activity: MarketplaceActivity[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Loads the creator's listings and auctions, then derives the Sales-page view
+ * model — summary tiles and a unified recent-activity feed — using the shared
+ * mapper. All metrics are deterministically derived; see
+ * `deriveSalesSummary` for the documented derivations.
+ *
+ * Powers the "Sales" page.
+ */
+export function useCreatorSales(): UseCreatorSalesResult {
+  const { user } = useAuth();
+  const creatorId = user?.id ?? null;
+
+  const [summary, setSummary] = useState<SalesSummary | null>(null);
+  const [activity, setActivity] = useState<MarketplaceActivity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!creatorId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [listings, auctions] = await Promise.all([
+        getAllListings(),
+        getAllAuctions(),
+      ]);
+      setSummary(deriveSalesSummary(listings, auctions, creatorId));
+      setActivity(buildActivityFeed(listings, auctions, creatorId));
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load sales data.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [creatorId]);
+
+  useEffect(() => {
+    if (creatorId) {
+      void load();
+    }
+  }, [creatorId, load]);
+
+  return { summary, activity, loading, error, refetch: load };
+}

--- a/nftopia-frontend/lib/services/marketplace-mapper.ts
+++ b/nftopia-frontend/lib/services/marketplace-mapper.ts
@@ -1,0 +1,148 @@
+import type {
+  Auction,
+  Listing,
+  MarketplaceActivity,
+  MarketplaceNft,
+  NftMarketState,
+  OwnedNft,
+  SalesSummary,
+} from "@/types/marketplace";
+import { toNftKey } from "@/lib/services/marketplace";
+
+/**
+ * Pure normalization layer shared by the "List NFTs for Sale" and "Sales"
+ * pages. Keeping all listing/auction → UI-model logic here (instead of in the
+ * page components) is what prevents the two views from drifting apart.
+ *
+ * Every function is deterministic and side-effect free, which also makes the
+ * derivations trivial to unit test.
+ */
+
+/** Default currency used when a record omits one (the marketplace is XLM-first). */
+const DEFAULT_CURRENCY = "XLM";
+
+/** Maps a raw listing status onto the UI-facing NFT market state. */
+function listingStatusToState(listing: Listing): NftMarketState {
+  switch (listing.status) {
+    case "ACTIVE":
+      return "ACTIVE";
+    case "SOLD":
+      return "SOLD";
+    case "EXPIRED":
+      return "EXPIRED";
+    // A CANCELLED listing leaves the NFT available again.
+    case "CANCELLED":
+    default:
+      return "NOT_LISTED";
+  }
+}
+
+/**
+ * Enriches an owned NFT with its resolved listing state.
+ *
+ * @param nft - The owned NFT.
+ * @param listing - The listing resolved via `GET /listings/nft/:nftId`, or null.
+ */
+export function toMarketplaceNft(
+  nft: OwnedNft,
+  listing: Listing | null,
+): MarketplaceNft {
+  const state: NftMarketState = listing
+    ? listingStatusToState(listing)
+    : "NOT_LISTED";
+  // Only an ACTIVE listing should be treated as the NFT's live listing.
+  const activeListing = listing && listing.status === "ACTIVE" ? listing : null;
+  return {
+    ...nft,
+    nftKey: toNftKey(nft.contractId, nft.tokenId),
+    state,
+    listing: activeListing,
+  };
+}
+
+/** Normalizes a listing into a unified activity-feed entry. */
+export function listingToActivity(listing: Listing): MarketplaceActivity {
+  return {
+    id: `listing:${listing.id}`,
+    kind: "LISTING",
+    nftKey: toNftKey(listing.nftContractId, listing.nftTokenId),
+    status: listing.status,
+    amount: Number(listing.price) || 0,
+    currency: listing.currency || DEFAULT_CURRENCY,
+    timestamp: listing.updatedAt || listing.createdAt,
+  };
+}
+
+/** Normalizes an auction into a unified activity-feed entry. */
+export function auctionToActivity(auction: Auction): MarketplaceActivity {
+  return {
+    id: `auction:${auction.id}`,
+    kind: "AUCTION",
+    nftKey: toNftKey(auction.nftContractId, auction.nftTokenId),
+    status: auction.status,
+    // currentPrice reflects the latest/settled bid; fall back to the start price.
+    amount: Number(auction.currentPrice ?? auction.startPrice) || 0,
+    currency: DEFAULT_CURRENCY,
+    timestamp: auction.updatedAt || auction.createdAt,
+  };
+}
+
+/**
+ * Builds the combined, recency-sorted activity feed for a creator.
+ * Only the creator's own listings/auctions are included.
+ */
+export function buildActivityFeed(
+  listings: Listing[],
+  auctions: Auction[],
+  creatorId: string,
+): MarketplaceActivity[] {
+  const mine = (sellerId: string) => sellerId === creatorId;
+  const entries: MarketplaceActivity[] = [
+    ...listings.filter((l) => mine(l.sellerId)).map(listingToActivity),
+    ...auctions.filter((a) => mine(a.sellerId)).map(auctionToActivity),
+  ];
+  return entries.sort(
+    (a, b) =>
+      new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+  );
+}
+
+/**
+ * Derives the creator's sales summary tiles from raw listing/auction data.
+ *
+ * Derivations (documented because the API exposes no single summary endpoint):
+ * - `activeListings`: count of the creator's listings with status ACTIVE.
+ * - `itemsSold`: count of SOLD listings + COMPLETED/SETTLED auctions.
+ * - `grossVolume`: sum of SOLD listing prices + settled auction current prices.
+ */
+export function deriveSalesSummary(
+  listings: Listing[],
+  auctions: Auction[],
+  creatorId: string,
+): SalesSummary {
+  const myListings = listings.filter((l) => l.sellerId === creatorId);
+  const myAuctions = auctions.filter((a) => a.sellerId === creatorId);
+
+  const activeListings = myListings.filter((l) => l.status === "ACTIVE").length;
+
+  const soldListings = myListings.filter((l) => l.status === "SOLD");
+  const settledAuctions = myAuctions.filter(
+    (a) => a.status === "COMPLETED" || a.status === "SETTLED",
+  );
+
+  const itemsSold = soldListings.length + settledAuctions.length;
+
+  const grossVolume =
+    soldListings.reduce((sum, l) => sum + (Number(l.price) || 0), 0) +
+    settledAuctions.reduce(
+      (sum, a) => sum + (Number(a.currentPrice ?? a.startPrice) || 0),
+      0,
+    );
+
+  return {
+    activeListings,
+    itemsSold,
+    grossVolume,
+    currency: DEFAULT_CURRENCY,
+  };
+}

--- a/nftopia-frontend/lib/services/marketplace.ts
+++ b/nftopia-frontend/lib/services/marketplace.ts
@@ -1,0 +1,141 @@
+import { fetchWithAuth } from "@/lib/api/fetchWithAuth";
+import { API_CONFIG } from "@/lib/config";
+import type {
+  Auction,
+  Bid,
+  CreateListingDto,
+  Listing,
+  OwnedNft,
+} from "@/types/marketplace";
+
+/**
+ * Typed client for the marketplace endpoints (listings, auctions, owned NFTs).
+ *
+ * Every call goes through {@link fetchWithAuth}, which transparently attaches
+ * the creator's JWT and refreshes it on expiry, so callers never deal with auth
+ * headers directly. Responses are unwrapped through {@link unwrapData} /
+ * {@link unwrapArray} because the API inconsistently nests payloads under
+ * `data` / `data.data`.
+ *
+ * This module is the single network layer shared by both the
+ * "List NFTs for Sale" and "Sales" pages.
+ */
+
+const jsonHeaders = { "Content-Type": "application/json" };
+
+/** Unwraps a single object that may be nested under `data` / `data.data`. */
+function unwrapData<T>(payload: unknown): T {
+  const typed = payload as { data?: { data?: T } | T };
+  if (typed?.data && typeof typed.data === "object" && "data" in typed.data) {
+    return (typed.data as { data: T }).data;
+  }
+  if (typed && typeof typed === "object" && "data" in typed) {
+    return typed.data as T;
+  }
+  return payload as T;
+}
+
+/**
+ * Unwraps an array that may arrive bare, under `data`, under `data.data`, or
+ * keyed by a collection name (`nfts`, `listings`, `auctions`, `bids`).
+ */
+function unwrapArray<T>(payload: unknown): T[] {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload as T[];
+  const obj = payload as Record<string, unknown>;
+  for (const key of ["data", "nfts", "listings", "auctions", "bids", "items"]) {
+    if (Array.isArray(obj[key])) return obj[key] as T[];
+  }
+  if (obj.data && typeof obj.data === "object") {
+    return unwrapArray<T>(obj.data);
+  }
+  return [];
+}
+
+async function getJson(url: string, init?: RequestInit): Promise<unknown> {
+  const res = await fetchWithAuth(url, init);
+  return res.json();
+}
+
+/** Builds the composite NFT key used by `GET /listings/nft/:nftId`. */
+export function toNftKey(contractId: string, tokenId: string): string {
+  return `${contractId}:${tokenId}`;
+}
+
+/** Loads the NFTs an authenticated creator owns and can list for sale. */
+export async function getOwnedNfts(
+  ownerId: string,
+  page = 1,
+  limit = 20,
+): Promise<OwnedNft[]> {
+  const url = `${API_CONFIG.baseUrl}/nfts?ownerId=${encodeURIComponent(
+    ownerId,
+  )}&page=${page}&limit=${limit}`;
+  return unwrapArray<OwnedNft>(await getJson(url));
+}
+
+/** Resolves the listing (if any) for a single NFT via its composite key. */
+export async function getListingByNft(
+  contractId: string,
+  tokenId: string,
+): Promise<Listing | null> {
+  const key = toNftKey(contractId, tokenId);
+  const url = `${API_CONFIG.baseUrl}/listings/nft/${encodeURIComponent(key)}`;
+  const data = unwrapData<Listing | null>(await getJson(url));
+  // The endpoint may return an array, a single object, or nothing.
+  if (Array.isArray(data)) return (data[0] as Listing) ?? null;
+  return data && (data as Listing).id ? (data as Listing) : null;
+}
+
+/** Loads all active listings. */
+export async function getActiveListings(): Promise<Listing[]> {
+  return unwrapArray<Listing>(
+    await getJson(`${API_CONFIG.baseUrl}/listings/active`),
+  );
+}
+
+/** Loads every listing (any status). */
+export async function getAllListings(): Promise<Listing[]> {
+  return unwrapArray<Listing>(await getJson(`${API_CONFIG.baseUrl}/listings`));
+}
+
+/** Creates a fixed-price listing (JWT required). */
+export async function createListing(
+  payload: CreateListingDto,
+): Promise<Listing> {
+  const data = await getJson(`${API_CONFIG.baseUrl}/listings`, {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+  return unwrapData<Listing>(data);
+}
+
+/** Cancels an active listing by id (JWT required). */
+export async function cancelListing(listingId: string): Promise<void> {
+  await fetchWithAuth(
+    `${API_CONFIG.baseUrl}/listings/${encodeURIComponent(listingId)}`,
+    { method: "DELETE" },
+  );
+}
+
+/** Loads active auctions. */
+export async function getActiveAuctions(): Promise<Auction[]> {
+  return unwrapArray<Auction>(
+    await getJson(`${API_CONFIG.baseUrl}/auctions/active`),
+  );
+}
+
+/** Loads every auction (any status). */
+export async function getAllAuctions(): Promise<Auction[]> {
+  return unwrapArray<Auction>(await getJson(`${API_CONFIG.baseUrl}/auctions`));
+}
+
+/** Loads the bids for a given auction. */
+export async function getAuctionBids(auctionId: string): Promise<Bid[]> {
+  return unwrapArray<Bid>(
+    await getJson(
+      `${API_CONFIG.baseUrl}/auctions/${encodeURIComponent(auctionId)}/bids`,
+    ),
+  );
+}

--- a/nftopia-frontend/types/marketplace.ts
+++ b/nftopia-frontend/types/marketplace.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared marketplace domain types for the creator dashboard.
+ *
+ * These mirror the backend contracts consumed by both the
+ * "List NFTs for Sale" and "Sales" creator pages. They are intentionally the
+ * single source of truth for listing/auction shapes on the frontend so the two
+ * pages stay consistent (see `lib/services/marketplace.ts`).
+ */
+
+/** Lifecycle status of a listing, mirroring the backend `ListingStatus` enum. */
+export type ListingStatus = "ACTIVE" | "SOLD" | "CANCELLED" | "EXPIRED";
+
+/** Lifecycle status of an auction, mirroring the backend `AuctionStatus` enum. */
+export type AuctionStatus = "ACTIVE" | "COMPLETED" | "CANCELLED" | "SETTLED";
+
+/** A fixed-price listing as returned by `GET /listings`. */
+export interface Listing {
+  id: string;
+  nftContractId: string;
+  nftTokenId: string;
+  sellerId: string;
+  price: number;
+  currency: string;
+  status: ListingStatus;
+  expiresAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** An auction as returned by `GET /auctions`. */
+export interface Auction {
+  id: string;
+  nftContractId: string;
+  nftTokenId: string;
+  sellerId: string;
+  startPrice: number;
+  currentPrice: number;
+  reservePrice?: number | null;
+  startTime: string;
+  endTime: string;
+  status: AuctionStatus;
+  winnerId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A single bid on an auction, returned by `GET /auctions/:id/bids`. */
+export interface Bid {
+  id: string;
+  auctionId: string;
+  bidderId: string;
+  amount: number;
+  amountXlm?: string | null;
+  createdAt: string;
+}
+
+/**
+ * Payload accepted by `POST /listings` (`CreateListingDto`).
+ * The composite NFT identity is split into contract + token id.
+ */
+export interface CreateListingDto {
+  nftContractId: string;
+  nftTokenId: string;
+  price: number;
+  currency: string;
+  /** ISO-8601 timestamp; optional — omit for a listing that never expires. */
+  expiresAt?: string;
+}
+
+/** A creator-owned NFT as returned by `GET /nfts?ownerId=<creatorId>`. */
+export interface OwnedNft {
+  id: string;
+  contractId: string;
+  tokenId: string;
+  name?: string;
+  description?: string;
+  imageUrl?: string;
+  ownerId?: string;
+  creatorId?: string;
+}
+
+/**
+ * The normalized, UI-facing listing state for a single owned NFT.
+ * Produced by the shared mapper and rendered as a status badge on the
+ * "List NFTs for Sale" page.
+ */
+export type NftMarketState = "NOT_LISTED" | "ACTIVE" | "SOLD" | "EXPIRED";
+
+/** An owned NFT enriched with its resolved marketplace state. */
+export interface MarketplaceNft extends OwnedNft {
+  /** The composite id used by `GET /listings/nft/:nftId` (`contractId:tokenId`). */
+  nftKey: string;
+  state: NftMarketState;
+  /** The active listing for this NFT, when one exists. */
+  listing: Listing | null;
+}
+
+/** The kind of marketplace event surfaced in the Sales activity feed. */
+export type MarketplaceActivityKind = "LISTING" | "AUCTION";
+
+/**
+ * A normalized marketplace event combining listings and auctions into a single
+ * shape so the Sales page can render a unified activity feed.
+ */
+export interface MarketplaceActivity {
+  id: string;
+  kind: MarketplaceActivityKind;
+  nftKey: string;
+  status: ListingStatus | AuctionStatus;
+  /** Settled/current amount for the event, in the listing/auction currency. */
+  amount: number;
+  currency: string;
+  /** ISO-8601 timestamp used for sorting the feed (most recent first). */
+  timestamp: string;
+}
+
+/** Aggregated, creator-facing metrics rendered as summary tiles on the Sales page. */
+export interface SalesSummary {
+  activeListings: number;
+  itemsSold: number;
+  /** Gross volume across sold listings + settled auctions, in XLM. */
+  grossVolume: number;
+  currency: string;
+}


### PR DESCRIPTION
Closes #220

## 📌 Summary

Implements the grouped **creator marketplace flow**: the "List NFTs for Sale" and "Sales" pages (previously placeholders) are now wired to the shared listings/auctions data through a single, reusable marketplace layer — so inventory management and sales visibility stay consistent.

**Frontend only — no backend files touched.**

## ✅ What changed

**Shared marketplace layer (reused by both pages)**
- `types/marketplace.ts` — single source of truth for listing/auction/NFT shapes (mirrors backend `ListingStatus`/`AuctionStatus`).
- `lib/services/marketplace.ts` — typed client over the existing `fetchWithAuth` (JWT handled automatically): owned NFTs, listing-by-NFT, create/cancel listing, listings + auctions + bids.
- `lib/services/marketplace-mapper.ts` — pure, deterministic normalization: `toMarketplaceNft`, `buildActivityFeed`, and `deriveSalesSummary` (derivations documented in code).
- `hooks/useCreatorListings.ts` / `hooks/useCreatorSales.ts` — data hooks with loading/error and refetch + optimistic updates.
- `components/marketplace/*` — shared status badge + amount/date formatting.

**List NFTs for Sale** (`app/[locale]/creator-dashboard/list-nfts-for-sale/page.tsx`)
- Loads owned NFTs via `GET /nfts?ownerId=<creatorId>`, resolves each one's listing via `GET /listings/nft/:contractId:tokenId`.
- Per-NFT status badge (Not listed / Active / Sold / Expired).
- Create listing (`POST /listings`, valid `CreateListingDto`) and cancel (`DELETE /listings/:id`) with per-item feedback and immediate UI refresh.
- Loading / empty / error (with retry) states.

**Sales** (`app/[locale]/creator-dashboard/sales/page.tsx`)
- Summary tiles (active listings, items sold, gross volume) derived from real listing/auction data.
- Unified recent-activity feed combining listings + auctions, recency-sorted.
- Loading / empty / error (with retry) states.

Both pages preserve locale-aware routing and use the authenticated creator id for ownership/filtering.

## 🧪 Tests

`npx jest __tests__/marketplace-mapper.test.ts __tests__/list-for-sale-page.test.tsx __tests__/sales-page.test.tsx`
```
Test Suites: 3 passed, 3 total
Tests:       20 passed, 20 total
```
- `marketplace-mapper.test.ts` — deterministic derivations (states, activity feed ordering, summary counts/volume).
- `list-for-sale-page.test.tsx` — loading, empty, error+retry, status rendering, create, cancel.
- `sales-page.test.tsx` — loading, summary tiles, activity feed, empty, error+retry.

`npx tsc --noEmit` — clean on all new files.

## 🔒 Notes
- All JWT-authenticated calls go through the existing `fetchWithAuth` client.
- Metrics with no single backing endpoint are derived deterministically from existing responses and documented in `marketplace-mapper.ts`.
- Scope strictly limited to this grouped issue; no backend changes.
