### PR TITLE
feat(marketplace_settlement): require explicit fee config at deployment, add one-time init guard

### DIFF
--- a/nftopia-stellar/contracts/marketplace_settlement/src/error.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/error.rs
@@ -58,6 +58,7 @@ pub enum SettlementError {
     FeeCalculationFailed = 700,
     InvalidFeeConfig = 701,
     FeeExemptionNotAllowed = 702,
+    FeeAlreadyInitialized = 703,
 
     // Admin errors
     NotAdmin = 800,

--- a/nftopia-stellar/contracts/marketplace_settlement/src/events.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/events.rs
@@ -262,6 +262,14 @@ pub struct EmergencyWithdrawalEvent {
 // Configuration Events
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeConfigInitializedEvent {
+    pub config: FeeConfig,
+    pub initialized_by: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FeeConfigUpdatedEvent {
     pub new_config: FeeConfig,
     pub updated_by: Address,
@@ -423,6 +431,12 @@ pub fn emit_rate_limit_exceeded(env: &Env, event: RateLimitExceededEvent) {
 pub fn emit_emergency_withdrawal(env: &Env, event: EmergencyWithdrawalEvent) {
     env.events()
         .publish(("MarketplaceSettlement", symbol_short!("emerg_wd")), event);
+}
+
+#[allow(deprecated)]
+pub fn emit_fee_config_initialized(env: &Env, event: FeeConfigInitializedEvent) {
+    env.events()
+        .publish(("MarketplaceSettlement", symbol_short!("fee_init")), event);
 }
 
 #[allow(deprecated)]

--- a/nftopia-stellar/contracts/marketplace_settlement/src/fee_manager.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/fee_manager.rs
@@ -163,9 +163,7 @@ impl FeeManager {
         Self::validate_fee_config(config)?;
 
         env.storage().instance().set(&FEE_CONFIG, config);
-        env.storage()
-            .instance()
-            .set(&FEE_CONFIG_INITIALIZED, &true);
+        env.storage().instance().set(&FEE_CONFIG_INITIALIZED, &true);
 
         emit_fee_config_initialized(
             env,
@@ -376,7 +374,6 @@ impl FeeManager {
         }
     }
 }
-
 
 /// Fee statistics structure
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/nftopia-stellar/contracts/marketplace_settlement/src/fee_manager.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/fee_manager.rs
@@ -1,11 +1,15 @@
 use crate::error::SettlementError;
-use crate::events::{emit_platform_fees_collected, PlatformFeesCollectedEvent};
+use crate::events::{
+    emit_fee_config_initialized, emit_platform_fees_collected, FeeConfigInitializedEvent,
+    PlatformFeesCollectedEvent,
+};
 use crate::types::{Asset, FeeConfig, VolumeTier};
 use crate::utils::math_utils;
 use soroban_sdk::{symbol_short, Address, Env, Map, Symbol, Vec};
 
 // Storage keys
 const FEE_CONFIG: Symbol = symbol_short!("fee_cfg");
+const FEE_CONFIG_INITIALIZED: Symbol = symbol_short!("fee_initd");
 const ACCUMULATED_FEES: Symbol = symbol_short!("acc_fees");
 const USER_VOLUMES: Symbol = symbol_short!("usr_vol");
 
@@ -143,6 +147,36 @@ impl FeeManager {
             .set(&ACCUMULATED_FEES, &accumulated_fees);
 
         Ok(amount)
+    }
+
+    /// Initialize fee configuration exactly once at deployment.
+    /// Subsequent calls return FeeAlreadyInitialized.
+    pub fn initialize_fee_config(
+        env: &Env,
+        config: &FeeConfig,
+        initializer: &Address,
+    ) -> Result<(), SettlementError> {
+        if env.storage().instance().has(&FEE_CONFIG_INITIALIZED) {
+            return Err(SettlementError::FeeAlreadyInitialized);
+        }
+
+        Self::validate_fee_config(config)?;
+
+        env.storage().instance().set(&FEE_CONFIG, config);
+        env.storage()
+            .instance()
+            .set(&FEE_CONFIG_INITIALIZED, &true);
+
+        emit_fee_config_initialized(
+            env,
+            FeeConfigInitializedEvent {
+                config: config.clone(),
+                initialized_by: initializer.clone(),
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
     }
 
     /// Update fee configuration
@@ -343,31 +377,6 @@ impl FeeManager {
     }
 }
 
-impl FeeConfig {
-    /// Create a new fee configuration
-    pub fn new(fee_recipient: Address, env: &Env) -> Self {
-        Self {
-            platform_fee_bps: 250, // 2.5%
-            minimum_fee: 1000,     // Minimum 1000 units
-            maximum_fee: 1000000,  // Maximum 1M units
-            fee_recipient,
-            dynamic_fee_enabled: true,
-            volume_discounts: {
-                let mut discounts = Vec::new(env);
-                discounts.push_back(VolumeTier {
-                    min_volume: 1000000,  // 1M volume
-                    fee_discount_bps: 50, // 0.5% discount
-                });
-                discounts.push_back(VolumeTier {
-                    min_volume: 10000000,  // 10M volume
-                    fee_discount_bps: 100, // 1% discount
-                });
-                discounts
-            },
-            vip_exemptions: Vec::new(env),
-        }
-    }
-}
 
 /// Fee statistics structure
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/nftopia-stellar/contracts/marketplace_settlement/src/settlement_core.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/settlement_core.rs
@@ -30,7 +30,11 @@ impl MarketplaceSettlement {
     /// `fee_config` must be provided with deployment-appropriate values; there
     /// are no hardcoded defaults. This function can be called exactly once —
     /// any subsequent call returns `FeeAlreadyInitialized`.
-    pub fn initialize(env: Env, admin: Address, fee_config: FeeConfig) -> Result<(), SettlementError> {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        fee_config: FeeConfig,
+    ) -> Result<(), SettlementError> {
         let admin_config = AdminConfig {
             admin: admin.clone(),
             emergency_withdrawal_enabled: true,

--- a/nftopia-stellar/contracts/marketplace_settlement/src/settlement_core.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/settlement_core.rs
@@ -12,7 +12,7 @@ use crate::storage::{
 };
 use crate::types::{
     AdminConfig, Asset, AuctionTransaction, AuctionType, BundleTransaction, ExecutionResult,
-    FeeConfig, SaleTransaction, TradeTransaction, VolumeTier,
+    FeeConfig, SaleTransaction, TradeTransaction,
 };
 use crate::utils::{asset_utils, time_utils};
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, Env, Symbol, Vec};
@@ -25,9 +25,12 @@ pub struct MarketplaceSettlement;
 #[allow(clippy::too_many_arguments)]
 #[contractimpl]
 impl MarketplaceSettlement {
-    /// Initialize the contract with admin configuration
-    pub fn initialize(env: Env, admin: Address) -> Result<(), SettlementError> {
-        // Set default configurations
+    /// Initialize the contract with admin configuration and explicit fee parameters.
+    ///
+    /// `fee_config` must be provided with deployment-appropriate values; there
+    /// are no hardcoded defaults. This function can be called exactly once —
+    /// any subsequent call returns `FeeAlreadyInitialized`.
+    pub fn initialize(env: Env, admin: Address, fee_config: FeeConfig) -> Result<(), SettlementError> {
         let admin_config = AdminConfig {
             admin: admin.clone(),
             emergency_withdrawal_enabled: true,
@@ -43,28 +46,8 @@ impl MarketplaceSettlement {
             .instance()
             .set(&symbol_short!("admin_cfg"), &admin_config);
 
-        // Set default fee config
-        let fee_config = FeeConfig {
-            platform_fee_bps: 250,        // 2.5%
-            minimum_fee: 1000,            // Minimum 1000 units
-            maximum_fee: 1000000,         // Maximum 1M units
-            fee_recipient: admin.clone(), // Fee recipient defaults to admin
-            dynamic_fee_enabled: true,
-            volume_discounts: {
-                let mut discounts = Vec::new(&env);
-                discounts.push_back(VolumeTier {
-                    min_volume: 1000000,  // 1M volume
-                    fee_discount_bps: 50, // 0.5% discount
-                });
-                discounts.push_back(VolumeTier {
-                    min_volume: 10000000,  // 10M volume
-                    fee_discount_bps: 100, // 1% discount
-                });
-                discounts
-            },
-            vip_exemptions: Vec::new(&env),
-        };
-        FeeManager::update_fee_config(&env, &fee_config, &admin)?;
+        // Validate and store the caller-supplied fee configuration exactly once.
+        FeeManager::initialize_fee_config(&env, &fee_config, &admin)?;
 
         // Set default auction config
         let auction_config = crate::auction_engine::AuctionConfig::default();

--- a/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
+++ b/nftopia-stellar/contracts/marketplace_settlement/src/test.rs
@@ -4,7 +4,7 @@ use crate::{
     error::SettlementError,
     royalty_distributor::RoyaltyDistributor,
     settlement_core::{MarketplaceSettlement, MarketplaceSettlementClient},
-    types::{Asset, AuctionType},
+    types::{Asset, AuctionType, FeeConfig},
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
@@ -56,13 +56,26 @@ fn mk_asset(env: &Env) -> Asset {
     }
 }
 
+fn default_fee_config(env: &Env, fee_recipient: Address) -> FeeConfig {
+    FeeConfig {
+        platform_fee_bps: 250,
+        minimum_fee: 1000,
+        maximum_fee: 1_000_000,
+        fee_recipient,
+        dynamic_fee_enabled: true,
+        volume_discounts: soroban_sdk::Vec::new(env),
+        vip_exemptions: soroban_sdk::Vec::new(env),
+    }
+}
+
 fn new_env() -> (Env, Address, MarketplaceSettlementClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
     let cid = env.register(MarketplaceSettlement, ());
     let client = MarketplaceSettlementClient::new(&env, &cid);
     let admin = Address::generate(&env);
-    client.initialize(&admin);
+    let fee_config = default_fee_config(&env, admin.clone());
+    client.initialize(&admin, &fee_config);
     let client: MarketplaceSettlementClient<'static> = unsafe { core::mem::transmute(client) };
     (env, cid, client, admin)
 }
@@ -82,6 +95,15 @@ fn reg(env: &Env, cid: &Address, nft: &Address, creator: &Address, admin: &Addre
 #[test]
 fn test_initialize_success() {
     new_env();
+}
+
+#[test]
+fn test_reinitialize_fee_config_fails() {
+    let (env, _cid, client, admin) = new_env();
+    let fee_config = default_fee_config(&env, admin.clone());
+    // A second initialize on the same contract must fail with FeeAlreadyInitialized.
+    let result = client.try_initialize(&admin, &fee_config);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -299,7 +321,6 @@ fn test_get_nonexistent_auction_fails() {
 
 #[test]
 fn test_update_fee_config_by_admin() {
-    use crate::types::FeeConfig;
     let (env, _cid, _client, _admin) = new_env();
     let admin = Address::generate(&env);
     let cfg = FeeConfig {
@@ -314,7 +335,8 @@ fn test_update_fee_config_by_admin() {
     // re-initialize with known admin so we can update
     let cid2 = env.register(MarketplaceSettlement, ());
     let c2 = MarketplaceSettlementClient::new(&env, &cid2);
-    c2.initialize(&admin);
+    let init_cfg = default_fee_config(&env, admin.clone());
+    c2.initialize(&admin, &init_cfg);
     c2.update_fee_config(&cfg, &admin);
 }
 
@@ -684,7 +706,8 @@ fn test_rate_limiter_admin_update_config() {
     // Setup known admin (using second client initialized with admin)
     let cid2 = env.register(MarketplaceSettlement, ());
     let c2 = MarketplaceSettlementClient::new(&env, &cid2);
-    c2.initialize(&admin);
+    let init_cfg = default_fee_config(&env, admin.clone());
+    c2.initialize(&admin, &init_cfg);
 
     let bidder = Address::generate(&env);
     let seller = Address::generate(&env);


### PR DESCRIPTION


## Description

### Problem
`FeeConfig::new()` in `fee_manager.rs` contained hardcoded values (250 bps, min 1000, max 1 000 000,
preset volume tiers) that became the live configuration if the deployer forgot to call
`update_fee_config` as a separate post-deployment transaction. This risked running mainnet with
testnet fee structures and provided no protection against accidental re-initialization.

### Changes

**fee infrastructure**
- `error.rs`: new `FeeAlreadyInitialized (703)` variant
- `events.rs`: new `FeeConfigInitializedEvent` + `emit_fee_config_initialized()` to separate
  deployment-time configuration from subsequent admin updates in off-chain event streams
- `fee_manager.rs`:
  - New `FeeManager::initialize_fee_config()` — validates the supplied `FeeConfig` (fee ≤ 10 000 bps,
    min < max, volume tiers in ascending order), writes a `FEE_CONFIG_INITIALIZED` storage flag,
    stores the config, and emits `FeeConfigInitializedEvent`; returns `FeeAlreadyInitialized` if
    called a second time
  - **Removed** `FeeConfig::new()` — no more hardcoded defaults anywhere in the fee layer

**Integration & tests**
- `settlement_core.rs`: `initialize()` now requires a `FeeConfig` argument; internally it calls
  `initialize_fee_config` instead of `update_fee_config`, so the one-time guard and event are
  enforced at contract deployment
- `test.rs`: `default_fee_config()` helper for tests; all `initialize()` call sites updated;
  new `test_reinitialize_fee_config_fails()` asserts the guard prevents a second initialization

### Acceptance criteria coverage
- ✅ No hardcoded fee values remain — `FeeConfig::new()` is gone
- ✅ Deployment tx must supply all fee parameters as arguments
- ✅ Config is validated before storage (bps ≤ 10 000, min < max, tiers ascending)
- ✅ Re-initialization blocked by `FEE_CONFIG_INITIALIZED` flag (`FeeAlreadyInitialized`)
- ✅ `FeeConfigInitializedEvent` emitted on first setup, distinct from `FeeConfigUpdatedEvent`


## Related Issue
Closes #283 