### PR TITLE
Feat/dynamic seo meta tags

### DIFF
--- a/nftopia-frontend/__tests__/nft-detail-seo.test.tsx
+++ b/nftopia-frontend/__tests__/nft-detail-seo.test.tsx
@@ -72,7 +72,7 @@ describe("NFT Detail SEO & Server Wrapper", () => {
       expect(metadata.description).toBe("An NFT of a voyager traveling the Stellar universe.");
       expect(metadata.openGraph?.title).toBe("Stellar Voyager | NFTopia Marketplace");
       expect(metadata.openGraph?.images).toEqual(["https://example.com/voyager.png"]);
-      expect(metadata.twitter?.card).toBe("summary_large_image");
+      expect((metadata.twitter as any)?.card).toBe("summary_large_image");
       expect(metadata.alternates?.canonical).toBe("http://localhost:3000/en/marketplace/nft-1");
     });
 

--- a/nftopia-frontend/__tests__/nft-detail-seo.test.tsx
+++ b/nftopia-frontend/__tests__/nft-detail-seo.test.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import NFTDetailPage, { generateMetadata } from "../app/[locale]/marketplace/[nftId]/page";
+import NFTDetailClient from "../app/[locale]/marketplace/[nftId]/NFTDetailClient";
+import { getApolloClient } from "@/lib/graphql/client";
+
+// Mock next-intl
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+// Mock GraphQL queries hooks
+jest.mock("@/hooks/graphql/useNFTQueries", () => ({
+  useNFTByIdQuery: () => ({
+    data: null,
+    loading: false,
+    error: null,
+  }),
+  useNFTTransferHistoryQuery: () => ({
+    data: {
+      nftTransferHistory: {
+        edges: [],
+        totalCount: 0,
+        pageInfo: { hasNextPage: false },
+      },
+    },
+    loading: false,
+    refetch: jest.fn(),
+  }),
+}));
+
+// Mock getApolloClient
+jest.mock("@/lib/graphql/client", () => {
+  const queryMock = jest.fn();
+  return {
+    getApolloClient: () => ({
+      query: queryMock,
+    }),
+  };
+});
+
+const mockApolloClient = getApolloClient() as any;
+
+describe("NFT Detail SEO & Server Wrapper", () => {
+  const mockNft = {
+    id: "nft-1",
+    tokenId: "token-123",
+    name: "Stellar Voyager",
+    description: "An NFT of a voyager traveling the Stellar universe.",
+    image: "https://example.com/voyager.png",
+    lastPrice: "100",
+    creator: { id: "c1", username: "creator_one", walletAddress: "G123" },
+    owner: { id: "o1", username: "owner_one", walletAddress: "G456" },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("generateMetadata", () => {
+    it("generates correct metadata when NFT is found", async () => {
+      mockApolloClient.query.mockResolvedValueOnce({
+        data: { nft: mockNft },
+      });
+
+      const metadata = await generateMetadata({
+        params: { nftId: "nft-1", locale: "en" },
+      });
+
+      expect(metadata.title).toBe("Stellar Voyager | NFTopia Marketplace");
+      expect(metadata.description).toBe("An NFT of a voyager traveling the Stellar universe.");
+      expect(metadata.openGraph?.title).toBe("Stellar Voyager | NFTopia Marketplace");
+      expect(metadata.openGraph?.images).toEqual(["https://example.com/voyager.png"]);
+      expect(metadata.twitter?.card).toBe("summary_large_image");
+      expect(metadata.alternates?.canonical).toBe("http://localhost:3000/en/marketplace/nft-1");
+    });
+
+    it("generates correct fallback metadata when NFT is not found", async () => {
+      mockApolloClient.query.mockResolvedValueOnce({
+        data: { nft: null },
+      });
+
+      const metadata = await generateMetadata({
+        params: { nftId: "nft-nonexistent", locale: "en" },
+      });
+
+      expect(metadata.title).toBe("NFT Not Found | NFTopia Marketplace");
+      expect(metadata.description).toBe("The requested NFT could not be found or does not exist.");
+    });
+
+    it("uses localized fallback strings for French locale when NFT is not found", async () => {
+      mockApolloClient.query.mockResolvedValueOnce({
+        data: { nft: null },
+      });
+
+      const metadata = await generateMetadata({
+        params: { nftId: "nft-nonexistent", locale: "fr" },
+      });
+
+      expect(metadata.title).toBe("NFT introuvable | NFTopia Marketplace");
+      expect(metadata.description).toBe("L'NFT demandé est introuvable ou n'existe pas.");
+    });
+  });
+
+  describe("NFTDetailPage (Server Component)", () => {
+    it("renders page with correct JSON-LD Product Schema structured data", async () => {
+      mockApolloClient.query.mockResolvedValueOnce({
+        data: { nft: mockNft },
+      });
+
+      const element = await NFTDetailPage({
+        params: { nftId: "nft-1", locale: "en" },
+      });
+
+      render(element);
+
+      // Verify JSON-LD script is rendered
+      const script = document.querySelector("script[type='application/ld+json']");
+      expect(script).toBeInTheDocument();
+      const json = JSON.parse(script?.innerHTML || "{}");
+      expect(json["@type"]).toBe("Product");
+      expect(json.name).toBe("Stellar Voyager");
+      expect(json.sku).toBe("token-123");
+      expect(json.offers?.price).toBe("100");
+    });
+  });
+
+  describe("NFTDetailClient (Client Component)", () => {
+    it("renders NFT content immediately using initialNft without loading skeleton", () => {
+      render(<NFTDetailClient nftId="nft-1" initialNft={mockNft} />);
+
+      expect(screen.queryByTestId("skeleton")).not.toBeInTheDocument();
+      expect(screen.getByText("Stellar Voyager")).toBeInTheDocument();
+      expect(screen.getByText("An NFT of a voyager traveling the Stellar universe.")).toBeInTheDocument();
+    });
+  });
+});

--- a/nftopia-frontend/app/[locale]/layout.tsx
+++ b/nftopia-frontend/app/[locale]/layout.tsx
@@ -32,6 +32,7 @@ export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
   const { t, locales } = useTranslation();
   const isAuthPage = pathname?.includes("/auth/");
   const isCreatorDashboard = pathname?.includes("/creator-dashboard");
+  const isNftDetailPage = pathname ? /^\/[a-z]{2}\/marketplace\/(?!auction$|auctions$|auction\/|auctions\/)[^/]+$/.test(pathname) : false;
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
   const currentPath = pathname?.replace(/^\/[a-z]{2}/, "") || "";
@@ -57,30 +58,38 @@ export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
         <meta name="msapplication-TileColor" content="#181359" />
         <meta name="msapplication-tap-highlight" content="no" />
 
-        <title>{t("seo.title")}</title>
-        <meta name="description" content={t("seo.description")} />
-        <meta name="keywords" content={t("seo.keywords")} />
+        {!isNftDetailPage && (
+          <>
+            <title>{t("seo.title")}</title>
+            <meta name="description" content={t("seo.description")} />
+            <meta name="keywords" content={t("seo.keywords")} />
 
-        {/* Hreflang Tags */}
-        {Object.entries(hreflangUrls).map(([lang, url]) => (
-          <link key={lang} rel="alternate" hrefLang={lang} href={url} />
-        ))}
-        <link rel="alternate" hrefLang="x-default" href={hreflangUrls.en} />
+            {/* Hreflang Tags */}
+            {Object.entries(hreflangUrls).map(([lang, url]) => (
+              <link key={lang} rel="alternate" hrefLang={lang} href={url} />
+            ))}
+            <link rel="alternate" hrefLang="x-default" href={hreflangUrls.en} />
+          </>
+        )}
 
         <link rel="icon" href="/nftopia-03.svg" id="favicon" />
 
-        <meta property="og:title" content={t("seo.title")} />
-        <meta property="og:description" content={t("seo.description")} />
-        <meta property="og:type" content="website" />
-        <meta property="og:locale" content={params.locale} />
-        {locales
-          .filter((loc) => loc !== params.locale)
-          .map((alt) => (
-            <meta key={alt} property="og:locale:alternate" content={alt} />
-          ))}
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={t("seo.title")} />
-        <meta name="twitter:description" content={t("seo.description")} />
+        {!isNftDetailPage && (
+          <>
+            <meta property="og:title" content={t("seo.title")} />
+            <meta property="og:description" content={t("seo.description")} />
+            <meta property="og:type" content="website" />
+            <meta property="og:locale" content={params.locale} />
+            {locales
+              .filter((loc) => loc !== params.locale)
+              .map((alt) => (
+                <meta key={alt} property="og:locale:alternate" content={alt} />
+              ))}
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:title" content={t("seo.title")} />
+            <meta name="twitter:description" content={t("seo.description")} />
+          </>
+        )}
       </head>
       <body className={inter.className}>
         <StoreProvider>

--- a/nftopia-frontend/app/[locale]/marketplace/[nftId]/NFTDetailClient.tsx
+++ b/nftopia-frontend/app/[locale]/marketplace/[nftId]/NFTDetailClient.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { 
+  ArrowLeft, 
+  Copy, 
+  Check, 
+  User,
+  Wallet,
+  Award
+} from "lucide-react";
+import Link from "next/link";
+import Image from "next/image";
+
+import { CircuitBackground } from "@/components/circuit-background";
+import { Card, CardContent } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useNFTByIdQuery, useNFTTransferHistoryQuery } from "@/hooks/graphql/useNFTQueries";
+import TransferHistory from "@/components/nft/TransferHistory";
+
+// Helper function to format address
+function formatAddress(address: string | null | undefined): string {
+  if (!address) return "Unknown";
+  if (address === "0x0000000000000000000000000000000000000000") return "Zero Address";
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+// Helper function to format date
+function formatDate(date: string | Date | null | undefined): string {
+  if (!date) return "N/A";
+  const d = new Date(date);
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// Skeleton component for NFT detail
+function NftDetailSkeleton() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div className="space-y-4">
+          <Skeleton className="aspect-square w-full rounded-xl" />
+        </div>
+        <div className="space-y-6">
+          <Skeleton className="h-8 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-24 w-full" />
+          <div className="grid grid-cols-2 gap-4">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+          </div>
+          <Skeleton className="h-12 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Client NFT Detail Page Component
+export default function NFTDetailClient({
+  nftId,
+  initialNft,
+}: {
+  nftId: string;
+  initialNft: any;
+}) {
+  const t = useTranslations("common");
+
+  const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
+  const [transferHistoryPage, setTransferHistoryPage] = useState(1);
+
+  // Fetch NFT data
+  const {
+    data: nftData,
+    loading: nftLoading,
+    error: nftError,
+  } = useNFTByIdQuery({
+    id: nftId,
+  });
+
+  // Fetch transfer history
+  const {
+    data: historyData,
+    loading: historyLoading,
+    refetch: refetchHistory,
+  } = useNFTTransferHistoryQuery({
+    nftId,
+    page: transferHistoryPage,
+    limit: 10,
+  });
+
+  // Refetch when page changes
+  useEffect(() => {
+    if (nftId) {
+      refetchHistory({
+        nftId,
+        page: transferHistoryPage,
+        limit: 10,
+      });
+    }
+  }, [transferHistoryPage, nftId, refetchHistory]);
+
+  const nft = nftData?.nft || initialNft;
+  const transferEvents = historyData?.nftTransferHistory?.edges?.map((edge: any) => edge.node) || [];
+  const totalTransfers = historyData?.nftTransferHistory?.totalCount || 0;
+  const hasNextPage = historyData?.nftTransferHistory?.pageInfo?.hasNextPage || false;
+
+  const handleCopyAddress = useCallback(async (address: string) => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopiedAddress(address);
+      setTimeout(() => setCopiedAddress(null), 2000);
+    } catch (error) {
+      console.error("Failed to copy address:", error);
+    }
+  }, []);
+
+  const handleLoadMore = useCallback(() => {
+    if (hasNextPage) {
+      setTransferHistoryPage((prev) => prev + 1);
+    }
+  }, [hasNextPage]);
+
+  const handleViewTransaction = useCallback((transactionHash: string) => {
+    const horizonUrl = process.env.NEXT_PUBLIC_HORIZON_URL || "https://horizon-testnet.stellar.org";
+    const isTestnet = horizonUrl.includes("testnet");
+    const baseUrl = isTestnet ? "https://testnet.stellar.org" : "https://stellar.org";
+    window.open(`${baseUrl}/tx/${transactionHash}`, "_blank", "noopener,noreferrer");
+  }, []);
+
+  // Loading state
+  if (nftLoading && !initialNft) {
+    return (
+      <main className="min-h-screen relative text-white overflow-hidden">
+        <CircuitBackground />
+        <div className="relative z-10">
+          <NftDetailSkeleton />
+        </div>
+      </main>
+    );
+  }
+
+  // Error state
+  if ((nftError && !initialNft) || (!nft && !nftLoading)) {
+    return (
+      <main className="min-h-screen relative text-white overflow-hidden">
+        <CircuitBackground />
+        <div className="relative z-10 max-w-7xl mx-auto px-4 py-8">
+          <EmptyState
+            icon={<div className="text-4xl">🔍</div>}
+            title="NFT Not Found"
+            description={nftError?.message || "The NFT you're looking for doesn't exist or has been removed."}
+            actionLabel="Go Back"
+            onAction={() => window.history.back()}
+          />
+        </div>
+      </main>
+    );
+  }
+
+  const isCreator = nft.creator?.id === nft.ownerId;
+  const creatorAddress = nft.creator?.walletAddress || nft.creator?.id || "Unknown";
+  const creatorProfileSlug =
+    nft.creator?.username || nft.creator?.id || creatorAddress;
+  const ownerAddress = nft.owner?.walletAddress || nft.owner?.id || "Unknown";
+
+  return (
+    <main className="min-h-screen relative text-white overflow-hidden">
+      <CircuitBackground />
+
+      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Back Button */}
+        <Link
+          href="/marketplace"
+          className="inline-flex items-center gap-2 text-gray-400 hover:text-white transition-colors mb-6"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          <span>Back to Marketplace</span>
+        </Link>
+
+        {/* NFT Detail Grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          {/* Left Column - Image */}
+          <div className="space-y-4">
+            <div className="relative aspect-square w-full rounded-xl overflow-hidden bg-gray-900/50 border border-gray-800/50">
+              {nft.image ? (
+                <Image
+                  src={nft.image}
+                  alt={nft.name}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  priority
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-gray-600">
+                  <span className="text-6xl">🖼️</span>
+                </div>
+              )}
+            </div>
+
+            {/* Collection Info */}
+            {nft.collection && (
+              <div className="flex items-center gap-3 p-3 rounded-lg bg-gray-900/30 border border-gray-800/50">
+                <div className="w-10 h-10 rounded-full bg-purple-500/20 flex items-center justify-center">
+                  <span className="text-sm font-bold text-purple-400">
+                    {nft.collection.symbol?.slice(0, 3) || "C"}
+                  </span>
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-white">{nft.collection.name}</p>
+                  <p className="text-xs text-gray-400">{nft.collection.symbol}</p>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Right Column - Details */}
+          <div className="space-y-6">
+            {/* NFT Name & Token ID */}
+            <div>
+              <h1 className="text-3xl font-bold text-white mb-2">{nft.name}</h1>
+              <div className="flex items-center gap-3 text-sm text-gray-400">
+                <span>Token ID: <span className="font-mono text-gray-300">{nft.tokenId}</span></span>
+                <button
+                  onClick={() => handleCopyAddress(nft.tokenId)}
+                  className="text-gray-500 hover:text-gray-300 transition-colors"
+                  aria-label="Copy token ID"
+                >
+                  {copiedAddress === nft.tokenId ? (
+                    <Check className="h-3 w-3 text-emerald-400" />
+                  ) : (
+                    <Copy className="h-3 w-3" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* Description */}
+            {nft.description && (
+              <p className="text-gray-300 leading-relaxed">{nft.description}</p>
+            )}
+
+            {/* Attributes Grid */}
+            {nft.attributes && nft.attributes.length > 0 && (
+              <div>
+                <h3 className="text-sm font-semibold text-gray-400 mb-2">Attributes</h3>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                  {nft.attributes.map((attr: any, index: number) => (
+                    <div
+                      key={index}
+                      className="p-2 rounded-lg bg-gray-900/30 border border-gray-800/50 text-center"
+                    >
+                      <p className="text-xs text-gray-400">{attr.traitType}</p>
+                      <p className="text-sm font-medium text-white truncate">{attr.value}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Owner & Creator Info */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {/* Creator */}
+              <Card className="border-gray-800/50 bg-gray-900/30">
+                <CardContent className="p-4">
+                  <div className="flex items-center gap-2 text-sm text-gray-400 mb-1">
+                    <Award className="h-4 w-4 text-emerald-400" />
+                    <span>Creator</span>
+                    {isCreator && (
+                      <span className="ml-1 text-xs text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded-full">
+                        Owner
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Link
+                      href={`/creator/${encodeURIComponent(creatorProfileSlug)}`}
+                      className="font-mono text-sm text-white truncate hover:text-purple-300 transition-colors"
+                    >
+                      {nft.creator?.username || formatAddress(creatorAddress)}
+                    </Link>
+                    <button
+                      onClick={() => handleCopyAddress(creatorAddress)}
+                      className="text-gray-500 hover:text-gray-300 transition-colors flex-shrink-0"
+                      aria-label="Copy creator address"
+                    >
+                      {copiedAddress === creatorAddress ? (
+                        <Check className="h-3 w-3 text-emerald-400" />
+                      ) : (
+                        <Copy className="h-3 w-3" />
+                      )}
+                    </button>
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Minted {formatDate(nft.mintedAt)}
+                  </p>
+                </CardContent>
+              </Card>
+
+              {/* Owner */}
+              <Card className="border-gray-800/50 bg-gray-900/30">
+                <CardContent className="p-4">
+                  <div className="flex items-center gap-2 text-sm text-gray-400 mb-1">
+                    <User className="h-4 w-4 text-blue-400" />
+                    <span>Current Owner</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-sm text-white truncate">
+                      {formatAddress(ownerAddress)}
+                    </span>
+                    <button
+                      onClick={() => handleCopyAddress(ownerAddress)}
+                      className="text-gray-500 hover:text-gray-300 transition-colors flex-shrink-0"
+                      aria-label="Copy owner address"
+                    >
+                      {copiedAddress === ownerAddress ? (
+                        <Check className="h-3 w-3 text-emerald-400" />
+                      ) : (
+                        <Copy className="h-3 w-3" />
+                      )}
+                    </button>
+                  </div>
+                  {nft.lastPrice && (
+                    <p className="text-xs text-emerald-400 mt-1">
+                      Last Sale: {nft.lastPrice} XLM
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Contract Address */}
+            {nft.contractAddress && (
+              <div className="flex items-center gap-2 text-sm text-gray-400 p-3 rounded-lg bg-gray-900/20 border border-gray-800/30">
+                <Wallet className="h-4 w-4 flex-shrink-0" />
+                <span className="truncate">Contract: {nft.contractAddress}</span>
+                <button
+                  onClick={() => handleCopyAddress(nft.contractAddress)}
+                  className="text-gray-500 hover:text-gray-300 transition-colors flex-shrink-0 ml-auto"
+                  aria-label="Copy contract address"
+                >
+                  {copiedAddress === nft.contractAddress ? (
+                    <Check className="h-3 w-3 text-emerald-400" />
+                  ) : (
+                    <Copy className="h-3 w-3" />
+                  )}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Transfer History / Provenance Section */}
+        <div className="mt-12">
+          <TransferHistory
+            events={transferEvents.map((event: any) => ({
+              ...event,
+              blockExplorerUrl: event.blockExplorerUrl || undefined,
+            }))}
+            totalCount={totalTransfers}
+            loading={historyLoading}
+            hasNextPage={hasNextPage}
+            onLoadMore={handleLoadMore}
+            onViewTransaction={handleViewTransaction}
+            className="border-gray-800/50 bg-gray-900/30 backdrop-blur-sm"
+            showHeader={true}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/nftopia-frontend/app/[locale]/marketplace/[nftId]/page.tsx
+++ b/nftopia-frontend/app/[locale]/marketplace/[nftId]/page.tsx
@@ -1,387 +1,139 @@
-"use client";
+import { Metadata } from "next";
+import { getApolloClient } from "@/lib/graphql/client";
+import { GET_NFT_BY_ID_QUERY } from "@/lib/graphql/queries/nft.queries";
+import NFTDetailClient from "./NFTDetailClient";
 
-import React, { useState, useEffect, useCallback } from "react";
-import { useParams } from "next/navigation";
-import { useTranslations } from "next-intl";
-import { 
-  ArrowLeft, 
-  ExternalLink, 
-  Copy, 
-  Check, 
-  Calendar,
-  User,
-  Wallet,
-  Award,
-  TrendingUp,
-  Clock,
-  Loader2
-} from "lucide-react";
-import Link from "next/link";
-import Image from "next/image";
+// Localized fallbacks for metadata
+const fallbacks: Record<string, { description: string; notFoundTitle: string; notFoundDesc: string }> = {
+  en: {
+    description: "View this unique NFT on NFTopia",
+    notFoundTitle: "NFT Not Found | NFTopia Marketplace",
+    notFoundDesc: "The requested NFT could not be found or does not exist.",
+  },
+  fr: {
+    description: "Voir cet NFT unique sur NFTopia",
+    notFoundTitle: "NFT introuvable | NFTopia Marketplace",
+    notFoundDesc: "L'NFT demandé est introuvable ou n'existe pas.",
+  },
+  es: {
+    description: "Ver este NFT único en NFTopia",
+    notFoundTitle: "NFT no encontrado | NFTopia Marketplace",
+    notFoundDesc: "El NFT solicitado no se pudo encontrar o no existe.",
+  },
+  de: {
+    description: "Diesen einzigartigen NFT auf NFTopia ansehen",
+    notFoundTitle: "NFT nicht gefunden | NFTopia Marketplace",
+    notFoundDesc: "Der angeforderte NFT konnte nicht gefunden werden oder existiert nicht.",
+  },
+};
 
-import { CircuitBackground } from "@/components/circuit-background";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { EmptyState } from "@/components/ui/empty-state";
-import { Skeleton } from "@/components/ui/skeleton";
-import { useNFTByIdQuery, useNFTTransferHistoryQuery } from "@/hooks/graphql/useNFTQueries";
-import TransferHistory, { TransferEvent } from "@/components/nft/TransferHistory";
-import { cn } from "@/lib/utils";
-
-// Helper function to format address
-function formatAddress(address: string | null | undefined): string {
-  if (!address) return "Unknown";
-  if (address === "0x0000000000000000000000000000000000000000") return "Zero Address";
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+// Fetch NFT details on the server side
+async function fetchNFT(nftId: string) {
+  const client = getApolloClient();
+  try {
+    const { data } = await client.query({
+      query: GET_NFT_BY_ID_QUERY,
+      variables: { id: nftId },
+      fetchPolicy: "network-only",
+    });
+    return data?.nft;
+  } catch (error) {
+    console.error("Error fetching NFT on server:", error);
+    return null;
+  }
 }
 
-// Helper function to format date
-function formatDate(date: string | Date | null | undefined): string {
-  if (!date) return "N/A";
-  const d = new Date(date);
-  return d.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
+// Generate dynamic SEO metadata
+export async function generateMetadata({
+  params,
+}: {
+  params: { nftId: string; locale: string };
+}): Promise<Metadata> {
+  const { nftId, locale } = params;
+  const nft = await fetchNFT(nftId);
+  const localeKey = (Object.keys(fallbacks).includes(locale) ? locale : "en") as keyof typeof fallbacks;
+  const tFallback = fallbacks[localeKey];
 
-// Skeleton component for NFT detail
-function NftDetailSkeleton() {
-  return (
-    <div className="max-w-7xl mx-auto px-4 py-8">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        <div className="space-y-4">
-          <Skeleton className="aspect-square w-full rounded-xl" />
-        </div>
-        <div className="space-y-6">
-          <Skeleton className="h-8 w-3/4" />
-          <Skeleton className="h-4 w-1/2" />
-          <Skeleton className="h-24 w-full" />
-          <div className="grid grid-cols-2 gap-4">
-            <Skeleton className="h-20 w-full" />
-            <Skeleton className="h-20 w-full" />
-          </div>
-          <Skeleton className="h-12 w-full" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// Main NFT Detail Page Component
-export default function NFTDetailPage() {
-  const params = useParams();
-  const t = useTranslations("common");
-  const nftId = params.nftId as string;
-
-  const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
-  const [transferHistoryPage, setTransferHistoryPage] = useState(1);
-  const [showFullHistory, setShowFullHistory] = useState(false);
-
-  // Fetch NFT data
-  const {
-    data: nftData,
-    loading: nftLoading,
-    error: nftError,
-    refetch: refetchNft,
-  } = useNFTByIdQuery({
-    id: nftId,
-  });
-
-  // Fetch transfer history
-  const {
-    data: historyData,
-    loading: historyLoading,
-    error: historyError,
-    refetch: refetchHistory,
-  } = useNFTTransferHistoryQuery({
-    nftId,
-    page: transferHistoryPage,
-    limit: 10,
-  });
-
-  // Refetch when page changes
-  useEffect(() => {
-    if (nftId) {
-      refetchHistory({
-        nftId,
-        page: transferHistoryPage,
-        limit: 10,
-      });
-    }
-  }, [transferHistoryPage, nftId, refetchHistory]);
-
-  const nft = nftData?.nft;
-  const transferEvents = historyData?.nftTransferHistory?.edges?.map((edge: any) => edge.node) || [];
-  const totalTransfers = historyData?.nftTransferHistory?.totalCount || 0;
-  const hasNextPage = historyData?.nftTransferHistory?.pageInfo?.hasNextPage || false;
-
-  const handleCopyAddress = useCallback(async (address: string) => {
-    try {
-      await navigator.clipboard.writeText(address);
-      setCopiedAddress(address);
-      setTimeout(() => setCopiedAddress(null), 2000);
-    } catch (error) {
-      console.error("Failed to copy address:", error);
-    }
-  }, []);
-
-  const handleLoadMore = useCallback(() => {
-    if (hasNextPage) {
-      setTransferHistoryPage((prev) => prev + 1);
-    }
-  }, [hasNextPage]);
-
-  const handleViewTransaction = useCallback((transactionHash: string) => {
-    const horizonUrl = process.env.NEXT_PUBLIC_HORIZON_URL || "https://horizon-testnet.stellar.org";
-    const isTestnet = horizonUrl.includes("testnet");
-    const baseUrl = isTestnet ? "https://testnet.stellar.org" : "https://stellar.org";
-    window.open(`${baseUrl}/tx/${transactionHash}`, "_blank", "noopener,noreferrer");
-  }, []);
-
-  // Loading state
-  if (nftLoading) {
-    return (
-      <main className="min-h-screen relative text-white overflow-hidden">
-        <CircuitBackground />
-        <div className="relative z-10">
-          <NftDetailSkeleton />
-        </div>
-      </main>
-    );
+  if (!nft) {
+    return {
+      title: tFallback.notFoundTitle,
+      description: tFallback.notFoundDesc,
+    };
   }
 
-  // Error state
-  if (nftError || !nft) {
-    return (
-      <main className="min-h-screen relative text-white overflow-hidden">
-        <CircuitBackground />
-        <div className="relative z-10 max-w-7xl mx-auto px-4 py-8">
-          <EmptyState
-            icon={<div className="text-4xl">🔍</div>}
-            title="NFT Not Found"
-            description={nftError?.message || "The NFT you're looking for doesn't exist or has been removed."}
-            actionLabel="Go Back"
-            onAction={() => window.history.back()}
-          />
-        </div>
-      </main>
-    );
-  }
+  const title = `${nft.name} | NFTopia Marketplace`;
+  const description = nft.description || tFallback.description;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const pageUrl = `${baseUrl}/${locale}/marketplace/${nftId}`;
+  const images = nft.image ? [nft.image] : [`${baseUrl}/nftopia-03.png`];
 
-  const isCreator = nft.creator?.id === nft.ownerId;
-  const creatorAddress = nft.creator?.walletAddress || nft.creator?.id || "Unknown";
-  const creatorProfileSlug =
-    nft.creator?.username || nft.creator?.id || creatorAddress;
-  const ownerAddress = nft.owner?.walletAddress || nft.owner?.id || "Unknown";
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: pageUrl,
+      languages: {
+        en: `${baseUrl}/en/marketplace/${nftId}`,
+        fr: `${baseUrl}/fr/marketplace/${nftId}`,
+        es: `${baseUrl}/es/marketplace/${nftId}`,
+        de: `${baseUrl}/de/marketplace/${nftId}`,
+        "x-default": `${baseUrl}/en/marketplace/${nftId}`,
+      },
+    },
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      type: "website",
+      images,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images,
+    },
+  };
+}
+
+// Main Page entrypoint (Server Component)
+export default async function NFTDetailPage({
+  params,
+}: {
+  params: { nftId: string; locale: string };
+}) {
+  const { nftId, locale } = params;
+  const nft = await fetchNFT(nftId);
+
+  // Structured Data (JSON-LD Product Schema)
+  const jsonLd = nft
+    ? {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": nft.name,
+        "image": nft.image,
+        "description": nft.description || undefined,
+        "sku": nft.tokenId,
+        "offers": nft.lastPrice
+          ? {
+              "@type": "Offer",
+              "price": nft.lastPrice,
+              "priceCurrency": "XLM",
+              "availability": "https://schema.org/InStock",
+            }
+          : undefined,
+      }
+    : null;
 
   return (
-    <main className="min-h-screen relative text-white overflow-hidden">
-      <CircuitBackground />
-
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Back Button */}
-        <Link
-          href="/marketplace"
-          className="inline-flex items-center gap-2 text-gray-400 hover:text-white transition-colors mb-6"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          <span>Back to Marketplace</span>
-        </Link>
-
-        {/* NFT Detail Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          {/* Left Column - Image */}
-          <div className="space-y-4">
-            <div className="relative aspect-square w-full rounded-xl overflow-hidden bg-gray-900/50 border border-gray-800/50">
-              {nft.image ? (
-                <Image
-                  src={nft.image}
-                  alt={nft.name}
-                  fill
-                  className="object-cover"
-                  sizes="(max-width: 768px) 100vw, 50vw"
-                  priority
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-gray-600">
-                  <span className="text-6xl">🖼️</span>
-                </div>
-              )}
-            </div>
-
-            {/* Collection Info */}
-            {nft.collection && (
-              <div className="flex items-center gap-3 p-3 rounded-lg bg-gray-900/30 border border-gray-800/50">
-                <div className="w-10 h-10 rounded-full bg-purple-500/20 flex items-center justify-center">
-                  <span className="text-sm font-bold text-purple-400">
-                    {nft.collection.symbol?.slice(0, 3) || "C"}
-                  </span>
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-white">{nft.collection.name}</p>
-                  <p className="text-xs text-gray-400">{nft.collection.symbol}</p>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Right Column - Details */}
-          <div className="space-y-6">
-            {/* NFT Name & Token ID */}
-            <div>
-              <h1 className="text-3xl font-bold text-white mb-2">{nft.name}</h1>
-              <div className="flex items-center gap-3 text-sm text-gray-400">
-                <span>Token ID: <span className="font-mono text-gray-300">{nft.tokenId}</span></span>
-                <button
-                  onClick={() => handleCopyAddress(nft.tokenId)}
-                  className="text-gray-500 hover:text-gray-300 transition-colors"
-                  aria-label="Copy token ID"
-                >
-                  {copiedAddress === nft.tokenId ? (
-                    <Check className="h-3 w-3 text-emerald-400" />
-                  ) : (
-                    <Copy className="h-3 w-3" />
-                  )}
-                </button>
-              </div>
-            </div>
-
-            {/* Description */}
-            {nft.description && (
-              <p className="text-gray-300 leading-relaxed">{nft.description}</p>
-            )}
-
-            {/* Attributes Grid */}
-            {nft.attributes && nft.attributes.length > 0 && (
-              <div>
-                <h3 className="text-sm font-semibold text-gray-400 mb-2">Attributes</h3>
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                  {nft.attributes.map((attr: any, index: number) => (
-                    <div
-                      key={index}
-                      className="p-2 rounded-lg bg-gray-900/30 border border-gray-800/50 text-center"
-                    >
-                      <p className="text-xs text-gray-400">{attr.traitType}</p>
-                      <p className="text-sm font-medium text-white truncate">{attr.value}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Owner & Creator Info */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {/* Creator */}
-              <Card className="border-gray-800/50 bg-gray-900/30">
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-2 text-sm text-gray-400 mb-1">
-                    <Award className="h-4 w-4 text-emerald-400" />
-                    <span>Creator</span>
-                    {isCreator && (
-                      <span className="ml-1 text-xs text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded-full">
-                        Owner
-                      </span>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Link
-                      href={`/creator/${encodeURIComponent(creatorProfileSlug)}`}
-                      className="font-mono text-sm text-white truncate hover:text-purple-300 transition-colors"
-                    >
-                      {nft.creator?.username || formatAddress(creatorAddress)}
-                    </Link>
-                    <button
-                      onClick={() => handleCopyAddress(creatorAddress)}
-                      className="text-gray-500 hover:text-gray-300 transition-colors flex-shrink-0"
-                      aria-label="Copy creator address"
-                    >
-                      {copiedAddress === creatorAddress ? (
-                        <Check className="h-3 w-3 text-emerald-400" />
-                      ) : (
-                        <Copy className="h-3 w-3" />
-                      )}
-                    </button>
-                  </div>
-                  <p className="text-xs text-gray-500 mt-1">
-                    Minted {formatDate(nft.mintedAt)}
-                  </p>
-                </CardContent>
-              </Card>
-
-              {/* Owner */}
-              <Card className="border-gray-800/50 bg-gray-900/30">
-                <CardContent className="p-4">
-                  <div className="flex items-center gap-2 text-sm text-gray-400 mb-1">
-                    <User className="h-4 w-4 text-blue-400" />
-                    <span>Current Owner</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm text-white truncate">
-                      {formatAddress(ownerAddress)}
-                    </span>
-                    <button
-                      onClick={() => handleCopyAddress(ownerAddress)}
-                      className="text-gray-500 hover:text-gray-300 transition-colors flex-shrink-0"
-                      aria-label="Copy owner address"
-                    >
-                      {copiedAddress === ownerAddress ? (
-                        <Check className="h-3 w-3 text-emerald-400" />
-                      ) : (
-                        <Copy className="h-3 w-3" />
-                      )}
-                    </button>
-                  </div>
-                  {nft.lastPrice && (
-                    <p className="text-xs text-emerald-400 mt-1">
-                      Last Sale: {nft.lastPrice} XLM
-                    </p>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-
-            {/* Contract Address */}
-            {nft.contractAddress && (
-              <div className="flex items-center gap-2 text-sm text-gray-400 p-3 rounded-lg bg-gray-900/20 border border-gray-800/30">
-                <Wallet className="h-4 w-4 flex-shrink-0" />
-                <span className="truncate">Contract: {nft.contractAddress}</span>
-                <button
-                  onClick={() => handleCopyAddress(nft.contractAddress)}
-                  className="text-gray-500 hover:text-gray-300 transition-colors flex-shrink-0 ml-auto"
-                  aria-label="Copy contract address"
-                >
-                  {copiedAddress === nft.contractAddress ? (
-                    <Check className="h-3 w-3 text-emerald-400" />
-                  ) : (
-                    <Copy className="h-3 w-3" />
-                  )}
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Transfer History / Provenance Section */}
-        <div className="mt-12">
-          <TransferHistory
-            events={transferEvents.map((event: any) => ({
-              ...event,
-              blockExplorerUrl: event.blockExplorerUrl || undefined,
-            }))}
-            totalCount={totalTransfers}
-            loading={historyLoading}
-            hasNextPage={hasNextPage}
-            onLoadMore={handleLoadMore}
-            onViewTransaction={handleViewTransaction}
-            className="border-gray-800/50 bg-gray-900/30 backdrop-blur-sm"
-            showHeader={true}
-          />
-        </div>
-      </div>
-    </main>
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
+      <NFTDetailClient nftId={nftId} initialNft={nft} />
+    </>
   );
 }

--- a/nftopia-frontend/firebase.d.ts
+++ b/nftopia-frontend/firebase.d.ts
@@ -1,0 +1,2 @@
+declare module "firebase/app";
+declare module "firebase/storage";

--- a/nftopia-frontend/package-lock.json
+++ b/nftopia-frontend/package-lock.json
@@ -23935,7 +23935,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/nftopia-frontend/package-lock.json
+++ b/nftopia-frontend/package-lock.json
@@ -23935,7 +23935,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Closes #348 

### Summary

Adds dynamic SEO metadata, canonical alternate tags, Twitter cards, Open Graph metadata, and valid JSON-LD Product schema structured data to the NFT detail route.

### What Changed

* **Server Wrapper (`page.tsx`)**: Refactored the entrypoint under `app/[locale]/marketplace/[nftId]/page.tsx` from a client component into a Server Component. Added server-side data fetching via Apollo Client, dynamic metadata generation via `generateMetadata`, and JSON-LD `<script>` tag insertion.
* **Client Interactive Logic (`NFTDetailClient.tsx`)**: Created the client component to handle local user state, clipboard operations, and transfer history query/pagination, utilizing `initialNft` to eliminate initial loading skeletons and layout shifts.
* **Layout Bypass (`layout.tsx`)**: Updated `app/[locale]/layout.tsx` to conditionally bypass default head meta/title tags when rendering the NFT detail page, letting Next.js metadata take precedence and avoiding duplicate HTML tags.
* **Test Suite (`nft-detail-seo.test.tsx`)**: Added Jest unit and integration tests covering server-side queries, alternates, fallback localization, JSON-LD structure validation, and component hydration.

### Key Design Decisions

* Wrapped the server-side GraphQL fetch in a robust try/catch block. If the server cannot reach the API during SSR, it falls back to `null` and enables the client to fetch details, preserving page availability.
* Conditional render matchers exclude pages like `/marketplace/auction` and `/marketplace/auctions` from the NFT detail matching filter in `layout.tsx`.

### Acceptance Criteria Checklist

* [x] Unique title with NFT name
* [x] Description metadata reflecting NFT details or fallback
* [x] Open Graph tags with NFT image
* [x] Twitter Card preview tags (`summary_large_image`)
* [x] Canonical alternate link tags per locale
* [x] JSON-LD schema.org/Product structured metadata
* [x] Localized fallbacks for missing/error states
* [x] Server-side indexing verification

### Test Output & Coverage

```bash
PASS __tests__/nft-detail-seo.test.tsx
  NFT Detail SEO & Server Wrapper
    generateMetadata
      ✓ generates correct metadata when NFT is found (5 ms)
      ✓ generates correct fallback metadata when NFT is not found (2 ms)
      ✓ uses localized fallback strings for French locale when NFT is not found (1 ms)
    NFTDetailPage (Server Component)
      ✓ renders page with correct JSON-LD Product Schema structured data (443 ms)
    NFTDetailClient (Client Component)
      ✓ renders NFT content immediately using initialNft without loading skeleton (237 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        3.302 s

```