### PR TITLE
Build NFT media optimization pipeline

### DIFF
--- a/nftopia-backend/package-lock.json
+++ b/nftopia-backend/package-lock.json
@@ -31,6 +31,7 @@
         "class-validator": "^0.14.3",
         "dataloader": "^2.2.3",
         "dotenv": "^17.2.3",
+        "express": "^5.0.0",
         "graphql": "^16.13.2",
         "ioredis": "^5.3.2",
         "jsonwebtoken": "^9.0.3",
@@ -46,6 +47,7 @@
         "rate-limiter-flexible": "^2.3.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "sharp": "^0.35.3",
         "socket.io": "^4.8.3",
         "stellar-sdk": "^13.3.0",
         "swagger-ui-express": "^5.0.1",
@@ -1682,6 +1684,516 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -6521,6 +7033,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -11212,9 +11733,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11309,6 +11830,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {

--- a/nftopia-backend/package.json
+++ b/nftopia-backend/package.json
@@ -59,6 +59,7 @@
     "rate-limiter-flexible": "^2.3.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "sharp": "^0.35.3",
     "socket.io": "^4.8.3",
     "stellar-sdk": "^13.3.0",
     "swagger-ui-express": "^5.0.1",

--- a/nftopia-backend/src/common/metrics/prometheus.ts
+++ b/nftopia-backend/src/common/metrics/prometheus.ts
@@ -67,6 +67,24 @@ const businessTransactionsSettledTotal = new Counter({
   registers: [registry],
 });
 
+const nftImageOptimizationBytes = new Histogram({
+  name: 'nft_image_optimization_bytes',
+  help: 'Original and optimized NFT image byte sizes',
+  labelNames: ['format', 'stage'],
+  buckets: [
+    1_000, 5_000, 10_000, 25_000, 50_000, 100_000, 250_000, 500_000, 1_000_000,
+    5_000_000, 10_000_000,
+  ],
+  registers: [registry],
+});
+
+const nftImageOptimizationFallbacksTotal = new Counter({
+  name: 'nft_image_optimization_fallbacks_total',
+  help: 'Total NFT image optimization requests that fell back to originals',
+  labelNames: ['format'],
+  registers: [registry],
+});
+
 @Injectable()
 export class PrometheusService {
   private readonly logger = new Logger(PrometheusService.name);
@@ -163,6 +181,35 @@ export class PrometheusService {
     } catch (error) {
       this.logger.warn(
         `Failed to increment transactions_settled_total: ${error}`,
+      );
+    }
+  }
+
+  observeNftImageOptimization(
+    format: string,
+    originalBytes: number,
+    optimizedBytes: number,
+  ): void {
+    try {
+      nftImageOptimizationBytes.observe(
+        { format, stage: 'original' },
+        originalBytes,
+      );
+      nftImageOptimizationBytes.observe(
+        { format, stage: 'optimized' },
+        optimizedBytes,
+      );
+    } catch (error) {
+      this.logger.warn(`Failed to observe NFT image optimization: ${error}`);
+    }
+  }
+
+  incrementNftImageOptimizationFallback(format: string): void {
+    try {
+      nftImageOptimizationFallbacksTotal.inc({ format });
+    } catch (error) {
+      this.logger.warn(
+        `Failed to increment nft_image_optimization_fallbacks_total: ${error}`,
       );
     }
   }

--- a/nftopia-backend/src/modules/nft/dto/nft-image-query.dto.ts
+++ b/nftopia-backend/src/modules/nft/dto/nft-image-query.dto.ts
@@ -1,0 +1,43 @@
+import { Type } from 'class-transformer';
+import { IsBoolean, IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class NftImageQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(2000)
+  width?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(2000)
+  height?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  quality?: number;
+
+  @IsOptional()
+  @IsIn(['auto', 'webp', 'avif', 'jpeg', 'png', 'original'])
+  format?: 'auto' | 'webp' | 'avif' | 'jpeg' | 'png' | 'original';
+
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  signed?: boolean;
+
+  @IsOptional()
+  expires?: string;
+
+  @IsOptional()
+  signature?: string;
+
+  @IsOptional()
+  v?: string;
+}

--- a/nftopia-backend/src/modules/nft/nft-media.service.ts
+++ b/nftopia-backend/src/modules/nft/nft-media.service.ts
@@ -1,0 +1,405 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import sharp from 'sharp';
+import { Repository } from 'typeorm';
+import { PrometheusService } from '../../common/metrics/prometheus';
+import { Nft } from './entities/nft.entity';
+import { NftImageQueryDto } from './dto/nft-image-query.dto';
+
+type OutputFormat = 'webp' | 'avif' | 'jpeg' | 'png';
+
+interface ImageTransformOptions {
+  width?: number;
+  height?: number;
+  quality: number;
+  format: OutputFormat;
+}
+
+export interface OptimizedImageResult {
+  buffer: Buffer;
+  contentType: string;
+  cacheControl: string;
+  originalBytes: number;
+  optimizedBytes: number;
+}
+
+export interface ImageFallbackResult {
+  redirectUrl: string;
+  cacheControl: string;
+}
+
+export type NftImageResult = OptimizedImageResult | ImageFallbackResult;
+
+interface MediaVariant {
+  url: string | null;
+  width: number;
+  height: number;
+  format: 'auto';
+}
+
+interface NftMediaPayload {
+  originalUrl: string | null;
+  thumbnailUrl: string | null;
+  previewUrl: string | null;
+  detailUrl: string | null;
+  placeholder: string;
+  width: number;
+  height: number;
+  srcSet: string;
+  sizes: string;
+  variants: {
+    thumbnail: MediaVariant;
+    preview: MediaVariant;
+    detail: MediaVariant;
+  };
+}
+
+const VARIANTS = {
+  thumbnail: { width: 100, height: 100 },
+  preview: { width: 400, height: 400 },
+  detail: { width: 1200, height: 1200 },
+} as const;
+
+@Injectable()
+export class NftMediaService {
+  private readonly logger = new Logger(NftMediaService.name);
+
+  constructor(
+    @InjectRepository(Nft)
+    private readonly nftRepository: Repository<Nft>,
+    private readonly configService: ConfigService,
+    private readonly prometheusService: PrometheusService,
+  ) {}
+
+  enrichQueryResult<T extends { data: Nft[] }>(result: T): T {
+    return {
+      ...result,
+      data: result.data.map((nft) => this.enrichNft(nft)),
+    };
+  }
+
+  enrichNft<T extends Nft>(
+    nft: T,
+  ): T & {
+    media: NftMediaPayload;
+    thumbnailUrl: string | null;
+    responsiveSrcSet: string;
+  } {
+    const media = this.buildMediaPayload(nft);
+
+    return {
+      ...nft,
+      media,
+      thumbnailUrl: media.thumbnailUrl,
+      responsiveSrcSet: media.srcSet,
+    };
+  }
+
+  async getOptimizedImage(
+    nftId: string,
+    query: NftImageQueryDto,
+    acceptHeader = '',
+  ): Promise<NftImageResult> {
+    const nft = await this.nftRepository.findOne({ where: { id: nftId } });
+    if (!nft) {
+      throw new NotFoundException('NFT not found');
+    }
+
+    if (!nft.imageUrl) {
+      throw new NotFoundException('NFT image not found');
+    }
+
+    this.validateSignature(nftId, query);
+
+    if (query.format === 'original') {
+      return this.fallbackToOriginal(nft.imageUrl);
+    }
+
+    const options = this.normalizeTransformOptions(query, acceptHeader);
+
+    try {
+      const original = await this.fetchOriginalImage(nft.imageUrl);
+      const optimized = await this.transformImage(original, options);
+      this.prometheusService.observeNftImageOptimization(
+        options.format,
+        original.length,
+        optimized.length,
+      );
+
+      return {
+        buffer: optimized,
+        contentType: `image/${options.format}`,
+        cacheControl: this.getProcessedCacheControl(),
+        originalBytes: original.length,
+        optimizedBytes: optimized.length,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Image optimization failed for nft=${nftId}; falling back to original: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+      this.prometheusService.incrementNftImageOptimizationFallback(
+        options.format,
+      );
+      return this.fallbackToOriginal(nft.imageUrl);
+    }
+  }
+
+  pregenerateVariants(nft: Nft): void {
+    if (!nft.imageUrl) {
+      return;
+    }
+
+    setImmediate(() => {
+      void Promise.allSettled(
+        Object.values(VARIANTS).map((variant) =>
+          this.getOptimizedImage(
+            nft.id,
+            { ...variant, quality: 82, format: 'auto' },
+            'image/avif,image/webp,image/*',
+          ),
+        ),
+      );
+    });
+  }
+
+  private buildMediaPayload(nft: Nft): NftMediaPayload {
+    const thumbnailUrl = this.buildVariantUrl(nft, VARIANTS.thumbnail);
+    const previewUrl = this.buildVariantUrl(nft, VARIANTS.preview);
+    const detailUrl = this.buildVariantUrl(nft, VARIANTS.detail);
+
+    return {
+      originalUrl: nft.imageUrl ?? null,
+      thumbnailUrl,
+      previewUrl,
+      detailUrl,
+      placeholder: this.buildPlaceholder(nft.id),
+      width: VARIANTS.detail.width,
+      height: VARIANTS.detail.height,
+      srcSet: [thumbnailUrl, previewUrl, detailUrl]
+        .filter((url): url is string => Boolean(url))
+        .map((url, index) => {
+          const width = Object.values(VARIANTS)[index].width;
+          return `${url} ${width}w`;
+        })
+        .join(', '),
+      sizes: '(max-width: 640px) 100vw, (max-width: 1024px) 400px, 1200px',
+      variants: {
+        thumbnail: {
+          url: thumbnailUrl,
+          width: VARIANTS.thumbnail.width,
+          height: VARIANTS.thumbnail.height,
+          format: 'auto',
+        },
+        preview: {
+          url: previewUrl,
+          width: VARIANTS.preview.width,
+          height: VARIANTS.preview.height,
+          format: 'auto',
+        },
+        detail: {
+          url: detailUrl,
+          width: VARIANTS.detail.width,
+          height: VARIANTS.detail.height,
+          format: 'auto',
+        },
+      },
+    };
+  }
+
+  private buildVariantUrl(
+    nft: Nft,
+    variant: { width: number; height: number },
+  ): string | null {
+    if (!nft.imageUrl) {
+      return null;
+    }
+
+    const baseUrl =
+      this.configService.get<string>('NFT_MEDIA_CDN_BASE_URL') ??
+      this.configService.get<string>('APP_PUBLIC_URL') ??
+      '';
+    const path = `/nfts/${nft.id}/image`;
+    const params = new URLSearchParams({
+      width: String(variant.width),
+      height: String(variant.height),
+      quality: '82',
+      format: 'auto',
+      v: String(
+        (
+          nft.updatedAt ??
+          nft.mintedAt ??
+          nft.createdAt ??
+          new Date()
+        ).getTime(),
+      ),
+    });
+
+    const secret = this.configService.get<string>('NFT_MEDIA_SIGNING_SECRET');
+    if (secret) {
+      const expires = String(
+        Math.floor(Date.now() / 1000) +
+          Number(this.configService.get('NFT_MEDIA_SIGNED_TTL_SECONDS') ?? 900),
+      );
+      params.set('expires', expires);
+      params.set(
+        'signature',
+        this.signPath(`${path}?${params.toString()}`, secret),
+      );
+    }
+
+    return `${baseUrl}${path}?${params.toString()}`;
+  }
+
+  private normalizeTransformOptions(
+    query: NftImageQueryDto,
+    acceptHeader: string,
+  ): ImageTransformOptions {
+    return {
+      width: query.width,
+      height: query.height,
+      quality: query.quality ?? 82,
+      format: this.selectFormat(query.format, acceptHeader),
+    };
+  }
+
+  private selectFormat(
+    requestedFormat: NftImageQueryDto['format'],
+    acceptHeader: string,
+  ): OutputFormat {
+    if (
+      requestedFormat &&
+      requestedFormat !== 'auto' &&
+      requestedFormat !== 'original'
+    ) {
+      return requestedFormat;
+    }
+
+    if (acceptHeader.includes('image/avif')) {
+      return 'avif';
+    }
+
+    if (acceptHeader.includes('image/webp')) {
+      return 'webp';
+    }
+
+    return 'jpeg';
+  }
+
+  private async fetchOriginalImage(imageUrl: string): Promise<Buffer> {
+    const response = await fetch(imageUrl);
+    if (!response.ok) {
+      throw new ServiceUnavailableException(
+        `Original image request failed with ${response.status}`,
+      );
+    }
+
+    const bytes = await response.arrayBuffer();
+    return Buffer.from(bytes);
+  }
+
+  private async transformImage(
+    original: Buffer,
+    options: ImageTransformOptions,
+  ): Promise<Buffer> {
+    let pipeline = sharp(original, { animated: false }).rotate();
+
+    if (options.width || options.height) {
+      pipeline = pipeline.resize({
+        width: options.width,
+        height: options.height,
+        fit: 'inside',
+        withoutEnlargement: true,
+      });
+    }
+
+    switch (options.format) {
+      case 'avif':
+        return pipeline.avif({ quality: options.quality }).toBuffer();
+      case 'webp':
+        return pipeline.webp({ quality: options.quality }).toBuffer();
+      case 'png':
+        return pipeline.png({ quality: options.quality }).toBuffer();
+      case 'jpeg':
+        return pipeline.jpeg({ quality: options.quality }).toBuffer();
+    }
+  }
+
+  private validateSignature(nftId: string, query: NftImageQueryDto): void {
+    const secret = this.configService.get<string>('NFT_MEDIA_SIGNING_SECRET');
+    if (!secret) {
+      return;
+    }
+
+    if (!query.expires || !query.signature) {
+      throw new BadRequestException('Signed NFT image URL is required');
+    }
+
+    const expires = Number(query.expires);
+    if (!Number.isFinite(expires) || expires < Math.floor(Date.now() / 1000)) {
+      throw new BadRequestException('Signed NFT image URL has expired');
+    }
+
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (
+        value !== undefined &&
+        value !== null &&
+        key !== 'signature' &&
+        key !== 'signed'
+      ) {
+        params.set(key, String(value));
+      }
+    }
+
+    const expected = this.signPath(`/nfts/${nftId}/image?${params}`, secret);
+    const expectedBytes = Buffer.from(expected);
+    const actualBytes = Buffer.from(query.signature);
+
+    if (
+      expectedBytes.length !== actualBytes.length ||
+      !timingSafeEqual(expectedBytes, actualBytes)
+    ) {
+      throw new BadRequestException('Signed NFT image URL is invalid');
+    }
+  }
+
+  private signPath(value: string, secret: string): string {
+    return createHmac('sha256', secret).update(value).digest('hex');
+  }
+
+  private fallbackToOriginal(imageUrl: string): ImageFallbackResult {
+    return {
+      redirectUrl: imageUrl,
+      cacheControl:
+        this.configService.get<string>('NFT_MEDIA_ORIGINAL_CACHE_CONTROL') ??
+        'public, max-age=300',
+    };
+  }
+
+  private getProcessedCacheControl(): string {
+    return (
+      this.configService.get<string>('NFT_MEDIA_CACHE_CONTROL') ??
+      'public, max-age=31536000, immutable'
+    );
+  }
+
+  private buildPlaceholder(seed: string): string {
+    const hash = createHmac('sha1', 'nftopia-media-placeholder')
+      .update(seed)
+      .digest('hex');
+    const color = `#${hash.slice(0, 6)}`;
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><rect width="20" height="20" fill="${color}"/></svg>`;
+
+    return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+  }
+}

--- a/nftopia-backend/src/modules/nft/nft.controller.spec.ts
+++ b/nftopia-backend/src/modules/nft/nft.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NftController } from './nft.controller';
+import { NftMediaService } from './nft-media.service';
 import { NftService } from './nft.service';
 import type { Request as ExpressRequest } from 'express';
 
@@ -30,6 +31,26 @@ const mockNftService = {
   getAttributes: jest.fn().mockResolvedValue([]),
 };
 
+const mockNftMediaService = {
+  getOptimizedImage: jest.fn().mockResolvedValue({
+    buffer: Buffer.from('optimized'),
+    contentType: 'image/webp',
+    cacheControl: 'public, max-age=31536000, immutable',
+    originalBytes: 1000,
+    optimizedBytes: 100,
+  }),
+};
+
+const createMockResponse = () => {
+  const res = {
+    setHeader: jest.fn(),
+    redirect: jest.fn(),
+    send: jest.fn(),
+  };
+
+  return res;
+};
+
 describe('NftController', () => {
   let controller: NftController;
 
@@ -40,6 +61,10 @@ describe('NftController', () => {
         {
           provide: NftService,
           useValue: mockNftService,
+        },
+        {
+          provide: NftMediaService,
+          useValue: mockNftMediaService,
         },
       ],
     }).compile();
@@ -72,6 +97,25 @@ describe('NftController', () => {
   it('gets nft attributes', async () => {
     await controller.getAttributes('nft-1');
     expect(mockNftService.getAttributes).toHaveBeenCalledWith('nft-1');
+  });
+
+  it('streams optimized nft image', async () => {
+    const res = createMockResponse();
+
+    await controller.getImage(
+      'nft-1',
+      { width: 100, height: 100, format: 'webp' },
+      { headers: { accept: 'image/webp' } } as ExpressRequest,
+      res as never,
+    );
+
+    expect(mockNftMediaService.getOptimizedImage).toHaveBeenCalledWith(
+      'nft-1',
+      { width: 100, height: 100, format: 'webp' },
+      'image/webp',
+    );
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/webp');
+    expect(res.send).toHaveBeenCalledWith(Buffer.from('optimized'));
   });
 
   it('mints nft for authenticated caller', async () => {

--- a/nftopia-backend/src/modules/nft/nft.controller.ts
+++ b/nftopia-backend/src/modules/nft/nft.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
   Query,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -18,16 +19,22 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import type { Request as ExpressRequest } from 'express';
+import type { Response as ExpressResponse } from 'express';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { CreateNftDto } from './dto/create-nft.dto';
+import { NftImageQueryDto } from './dto/nft-image-query.dto';
 import { NftQueryDto } from './dto/nft-query.dto';
 import { UpdateNftDto } from './dto/update-nft.dto';
+import { NftMediaService } from './nft-media.service';
 import { NftService } from './nft.service';
 
 @ApiTags('nft')
 @Controller('nfts')
 export class NftController {
-  constructor(private readonly nftService: NftService) {}
+  constructor(
+    private readonly nftService: NftService,
+    private readonly nftMediaService: NftMediaService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'List NFTs with pagination and filters' })
@@ -67,6 +74,42 @@ export class NftController {
   @ApiParam({ name: 'id', description: 'NFT ID' })
   async getAttributes(@Param('id') id: string) {
     return this.nftService.getAttributes(id);
+  }
+
+  @Get(':id/image')
+  @ApiOperation({ summary: 'Get optimized NFT image variant' })
+  @ApiParam({ name: 'id', description: 'NFT ID' })
+  @ApiQuery({ name: 'width', required: false, example: 400 })
+  @ApiQuery({ name: 'height', required: false, example: 400 })
+  @ApiQuery({ name: 'quality', required: false, example: 82 })
+  @ApiQuery({
+    name: 'format',
+    required: false,
+    enum: ['auto', 'webp', 'avif', 'jpeg', 'png', 'original'],
+  })
+  async getImage(
+    @Param('id') id: string,
+    @Query() query: NftImageQueryDto,
+    @Req() req: ExpressRequest,
+    @Res() res: ExpressResponse,
+  ) {
+    const result = await this.nftMediaService.getOptimizedImage(
+      id,
+      query,
+      req.headers.accept,
+    );
+
+    res.setHeader('Cache-Control', result.cacheControl);
+
+    if ('redirectUrl' in result) {
+      return res.redirect(302, result.redirectUrl);
+    }
+
+    res.setHeader('Content-Type', result.contentType);
+    res.setHeader('Content-Length', result.buffer.length);
+    res.setHeader('X-Original-Bytes', result.originalBytes);
+    res.setHeader('X-Optimized-Bytes', result.optimizedBytes);
+    return res.send(result.buffer);
   }
 
   @Get(':id')

--- a/nftopia-backend/src/modules/nft/nft.module.ts
+++ b/nftopia-backend/src/modules/nft/nft.module.ts
@@ -9,6 +9,7 @@ import { User } from '../../users/user.entity';
 import { SorobanService } from '../../nft/soroban.service';
 import { NftTransferEvent } from '../../jobs/entities/nft-transfer-event.entity';
 import { MetricsModule } from '../../common/metrics/metrics.module';
+import { NftMediaService } from './nft-media.service';
 
 @Module({
   imports: [
@@ -17,7 +18,7 @@ import { MetricsModule } from '../../common/metrics/metrics.module';
     MetricsModule,
   ],
   controllers: [NftController],
-  providers: [NftService, SorobanService],
+  providers: [NftService, NftMediaService, SorobanService],
   exports: [NftService],
 })
 export class NftModule {}

--- a/nftopia-backend/src/modules/nft/nft.service.spec.ts
+++ b/nftopia-backend/src/modules/nft/nft.service.spec.ts
@@ -9,6 +9,7 @@ import { SorobanService } from '../../nft/soroban.service';
 import { User } from '../../users/user.entity';
 import { NftTransferEvent } from '../../jobs/entities/nft-transfer-event.entity';
 import { PrometheusService } from '../../common/metrics/prometheus';
+import { NftMediaService } from './nft-media.service';
 
 // Mock PrometheusService
 const mockPrometheusService = {
@@ -90,6 +91,12 @@ const mockEventEmitter = {
   emit: jest.fn(),
 };
 
+const mockNftMediaService = {
+  enrichQueryResult: jest.fn((result) => result),
+  enrichNft: jest.fn((nft) => nft),
+  pregenerateVariants: jest.fn(),
+};
+
 describe('NftService', () => {
   let service: NftService;
 
@@ -110,6 +117,7 @@ describe('NftService', () => {
         { provide: SorobanService, useValue: mockSorobanService },
         { provide: EventEmitter2, useValue: mockEventEmitter },
         { provide: PrometheusService, useValue: mockPrometheusService },
+        { provide: NftMediaService, useValue: mockNftMediaService },
       ],
     }).compile();
 
@@ -148,6 +156,7 @@ describe('NftService', () => {
     expect(mockMetadataRepo.save).toHaveBeenCalled();
     expect(mockSorobanService.getLatestLedger).toHaveBeenCalled();
     expect(mockPrometheusService.incrementNftMint).toHaveBeenCalled();
+    expect(mockNftMediaService.pregenerateVariants).toHaveBeenCalled();
   });
 
   it('rejects mint when caller is not owner or creator', async () => {

--- a/nftopia-backend/src/modules/nft/nft.service.spec.ts
+++ b/nftopia-backend/src/modules/nft/nft.service.spec.ts
@@ -10,6 +10,7 @@ import { User } from '../../users/user.entity';
 import { NftTransferEvent } from '../../jobs/entities/nft-transfer-event.entity';
 import { PrometheusService } from '../../common/metrics/prometheus';
 import { NftMediaService } from './nft-media.service';
+import type { NftQueryResult } from './interfaces/nft.interface';
 
 // Mock PrometheusService
 const mockPrometheusService = {
@@ -92,8 +93,10 @@ const mockEventEmitter = {
 };
 
 const mockNftMediaService = {
-  enrichQueryResult: jest.fn((result) => result),
-  enrichNft: jest.fn((nft) => nft),
+  enrichQueryResult: jest.fn(
+    (result: NftQueryResult<Nft>): NftQueryResult<Nft> => result,
+  ),
+  enrichNft: jest.fn((nft: Nft): Nft => nft),
   pregenerateVariants: jest.fn(),
 };
 

--- a/nftopia-backend/src/modules/nft/nft.service.ts
+++ b/nftopia-backend/src/modules/nft/nft.service.ts
@@ -25,6 +25,7 @@ import { SorobanService } from '../../nft/soroban.service';
 import { User } from '../../users/user.entity';
 import { PrometheusService } from '../../common/metrics/prometheus';
 import { NftTransferEvent } from '../../jobs/entities/nft-transfer-event.entity';
+import { NftMediaService } from './nft-media.service';
 
 @Injectable()
 export class NftService {
@@ -40,6 +41,7 @@ export class NftService {
     private readonly sorobanService: SorobanService,
     private readonly eventEmitter: EventEmitter2,
     private readonly prometheusService: PrometheusService,
+    private readonly nftMediaService: NftMediaService,
     @InjectRepository(NftTransferEvent)
     private readonly transferEventRepo: Repository<NftTransferEvent>,
   ) {}
@@ -55,13 +57,13 @@ export class NftService {
 
     const [data, total] = await qb.getManyAndCount();
 
-    return {
+    return this.nftMediaService.enrichQueryResult({
       data,
       page,
       limit,
       total,
       totalPages: Math.ceil(total / limit),
-    };
+    });
   }
 
   async findConnection(
@@ -75,7 +77,9 @@ export class NftService {
     ]);
 
     return {
-      data: rows.slice(0, first),
+      data: rows
+        .slice(0, first)
+        .map((nft) => this.nftMediaService.enrichNft(nft)),
       total,
       hasNextPage: rows.length > first,
     };
@@ -91,7 +95,7 @@ export class NftService {
       throw new NotFoundException('NFT not found');
     }
 
-    return nft;
+    return this.nftMediaService.enrichNft(nft);
   }
 
   async findByIds(ids: string[]): Promise<Nft[]> {
@@ -143,7 +147,7 @@ export class NftService {
       throw new NotFoundException('NFT not found');
     }
 
-    return nft;
+    return this.nftMediaService.enrichNft(nft);
   }
 
   async findByOwner(
@@ -215,6 +219,7 @@ export class NftService {
     const indexedNft = await this.findById(savedNft.id);
     this.emitSearchEvent('search.nft.upsert', { nftId: indexedNft.id });
     this.prometheusService.incrementNftMint(dto.collectionId);
+    this.nftMediaService.pregenerateVariants(savedNft);
     return indexedNft;
   }
 
@@ -270,6 +275,7 @@ export class NftService {
 
     const indexedNft = await this.findById(nft.id);
     this.emitSearchEvent('search.nft.upsert', { nftId: indexedNft.id });
+    this.nftMediaService.pregenerateVariants(nft);
     return indexedNft;
   }
 
@@ -320,7 +326,7 @@ export class NftService {
 
     const saved = await this.nftRepository.save(nft);
     this.emitSearchEvent('search.nft.upsert', { nftId: saved.id });
-    return saved;
+    return this.nftMediaService.enrichNft(saved);
   }
 
   async getAttributes(id: string): Promise<NftMetadata[]> {


### PR DESCRIPTION
## Summary
- Added Sharp-based NFT image optimization with resize, quality, and format conversion support.
- Added `GET /nfts/:id/image` for CDN-cacheable image variants.
- Enriched NFT responses with `thumbnailUrl`, `responsiveSrcSet`, and `media` metadata.
- Added background variant warming and fail-open fallback to original media.
- Added Prometheus metrics for optimization byte sizes and fallback counts.

## Issue
Closes #388

## Testing
- `npm run build`
- `npm test -- src/modules/nft --runInBand`

## Notes
- Processed image responses use `Cache-Control: public, max-age=31536000, immutable`.
- Existing `imageUrl` fields remain unchanged for backward compatibility.
- CDN/base URL can be configured with `NFT_MEDIA_CDN_BASE_URL`.
- Signed media URLs are enabled when `NFT_MEDIA_SIGNING_SECRET` is configured.