### PR TITLE
feat(seo): add dynamic SEO meta tags for collection pages

### DIFF
--- a/nftopia-frontend/app/[locale]/collection/[id]/page.tsx
+++ b/nftopia-frontend/app/[locale]/collection/[id]/page.tsx
@@ -5,12 +5,35 @@ import { GET_COLLECTION_BY_ID_QUERY } from "@/lib/graphql/queries/collection.que
 import { isValidCollectionId } from "@/utils/id-validation";
 import { CollectionDetailClient } from "./CollectionDetailClient";
 
-const fallbacks: Record<string, { notFoundTitle: string; notFoundDesc: string }> = {
-  en: { notFoundTitle: "Collection Not Found | NFTopia Marketplace", notFoundDesc: "The requested collection could not be found or does not exist." },
-  fr: { notFoundTitle: "Collection introuvable | NFTopia Marketplace", notFoundDesc: "La collection demandée est introuvable ou n'existe pas." },
-  es: { notFoundTitle: "Colección no encontrada | NFTopia Marketplace", notFoundDesc: "La colección solicitada no se pudo encontrar o no existe." },
-  de: { notFoundTitle: "Sammlung nicht gefunden | NFTopia Marketplace", notFoundDesc: "Die angeforderte Sammlung konnte nicht gefunden werden oder existiert nicht." },
+const SUPPORTED_LOCALES = ["en", "fr", "es", "de"] as const;
+type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+const fallbacks: Record<Locale, { notFoundTitle: string; notFoundDesc: string; description: string }> = {
+  en: {
+    notFoundTitle: "Collection Not Found | NFTopia Marketplace",
+    notFoundDesc: "The requested collection could not be found or does not exist.",
+    description: "View this collection on NFTopia",
+  },
+  fr: {
+    notFoundTitle: "Collection introuvable | NFTopia Marketplace",
+    notFoundDesc: "La collection demandée est introuvable ou n'existe pas.",
+    description: "Voir cette collection sur NFTopia",
+  },
+  es: {
+    notFoundTitle: "Colección no encontrada | NFTopia Marketplace",
+    notFoundDesc: "La colección solicitada no se pudo encontrar o no existe.",
+    description: "Ver esta colección en NFTopia",
+  },
+  de: {
+    notFoundTitle: "Sammlung nicht gefunden | NFTopia Marketplace",
+    notFoundDesc: "Die angeforderte Sammlung konnte nicht gefunden werden oder existiert nicht.",
+    description: "Diese Sammlung auf NFTopia ansehen",
+  },
 };
+
+function getLocale(locale: string): Locale {
+  return SUPPORTED_LOCALES.includes(locale as Locale) ? (locale as Locale) : "en";
+}
 
 async function fetchCollection(collectionId: string) {
   const client = getApolloClient();
@@ -33,21 +56,72 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { id, locale } = params;
   const collection = await fetchCollection(id);
-  const localeKey = (Object.keys(fallbacks).includes(locale) ? locale : "en") as keyof typeof fallbacks;
-  const tFallback = fallbacks[localeKey];
+  const resolvedLocale = getLocale(locale);
+  const tFallback = fallbacks[resolvedLocale];
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const pageUrl = `${baseUrl}/${resolvedLocale}/collection/${id}`;
 
   if (!collection) {
     return {
       title: tFallback.notFoundTitle,
       description: tFallback.notFoundDesc,
       robots: { index: false, follow: false },
+      alternates: {
+        canonical: pageUrl,
+        languages: Object.fromEntries(
+          SUPPORTED_LOCALES.map((loc) => [loc, `${baseUrl}/${loc}/collection/${id}`])
+        ),
+      },
+      openGraph: {
+        title: tFallback.notFoundTitle,
+        description: tFallback.notFoundDesc,
+        url: pageUrl,
+        type: "website",
+      },
+      twitter: {
+        card: "summary",
+        title: tFallback.notFoundTitle,
+        description: tFallback.notFoundDesc,
+      },
     };
   }
 
+  const title = `${collection.name} | NFTopia Marketplace`;
+  const description = collection.description || tFallback.description;
+  const ogImage = collection.image || `${baseUrl}/nftopia-03.png`;
+
   return {
-    title: `${collection.name} | NFTopia Marketplace`,
-    description: collection.description || `Browse NFTs in the ${collection.name} collection`,
+    title,
+    description,
+    keywords: [`${collection.name}`, "NFT", "collection", "digital art", "NFTopia"],
     robots: { index: true, follow: true },
+    alternates: {
+      canonical: pageUrl,
+      languages: Object.fromEntries(
+        SUPPORTED_LOCALES.map((loc) => [loc, `${baseUrl}/${loc}/collection/${id}`])
+      ),
+    },
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      type: "website",
+      images: [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: collection.name,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImage],
+    },
   };
 }
 
@@ -68,5 +142,37 @@ export default async function CollectionDetailPage({
     notFound();
   }
 
-  return <CollectionDetailClient collection={collection} locale={locale} />;
+  // Structured Data (JSON-LD Collection Schema)
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Collection",
+    "name": collection.name,
+    "description": collection.description || undefined,
+    "image": collection.image || undefined,
+    "url": `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/${locale}/collection/${id}`,
+    ...(collection.creator
+      ? {
+          "creator": {
+            "@type": "Person",
+            "name": collection.creator.username || collection.creator.walletAddress,
+            "url": collection.creator.username
+              ? `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/${locale}/creator/${collection.creator.username}`
+              : undefined,
+          },
+        }
+      : {}),
+    ...(collection.totalSupply != null
+      ? { "size": collection.totalSupply }
+      : {}),
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <CollectionDetailClient collection={collection} locale={locale} />
+    </>
+  );
 }

--- a/nftopia-frontend/app/[locale]/layout.tsx
+++ b/nftopia-frontend/app/[locale]/layout.tsx
@@ -33,6 +33,8 @@ export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
   const isAuthPage = pathname?.includes("/auth/");
   const isCreatorDashboard = pathname?.includes("/creator-dashboard");
   const isNftDetailPage = pathname ? /^\/[a-z]{2}\/marketplace\/(?!auction$|auctions$|auction\/|auctions\/)[^/]+$/.test(pathname) : false;
+  const isCollectionDetailPage = pathname ? /^\/[a-z]{2}\/collection\/[^/]+$/.test(pathname) : false;
+  const isDynamicSeoPage = isNftDetailPage || isCollectionDetailPage;
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
   const currentPath = pathname?.replace(/^\/[a-z]{2}/, "") || "";
@@ -58,7 +60,7 @@ export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
         <meta name="msapplication-TileColor" content="#181359" />
         <meta name="msapplication-tap-highlight" content="no" />
 
-        {!isNftDetailPage && (
+        {!isDynamicSeoPage && (
           <>
             <title>{t("seo.title")}</title>
             <meta name="description" content={t("seo.description")} />
@@ -74,7 +76,7 @@ export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
 
         <link rel="icon" href="/nftopia-03.svg" id="favicon" />
 
-        {!isNftDetailPage && (
+        {!isDynamicSeoPage && (
           <>
             <meta property="og:title" content={t("seo.title")} />
             <meta property="og:description" content={t("seo.description")} />


### PR DESCRIPTION
## Overview

This PR adds dynamic SEO metadata for collection pages to improve search engine visibility and social sharing.

## Related Issue

Closes #349

## Changes

### SEO Metadata Enhancement

- Enhanced generateMetadata in collection/[id]/page.tsx with full Open Graph tags, Twitter Cards, canonical URLs with hreflang, and JSON-LD structured data
- Updated locale layout.tsx to prevent static SEO tags from conflicting with dynamic collection page metadata

### What was added:
- Open Graph tags: og:title, og:description, og:image, og:url, og:type
- Twitter Card: summary_large_image with title, description, and image
- Canonical URL with hreflang language variants (en, fr, es, de)
- JSON-LD structured data (schema.org/Collection) with creator info
- Dynamic keywords from collection names
- Localized fallback metadata for not-found states

## Verification

- TypeScript compilation: 0 errors
- Dynamic titles, OG tags, Twitter cards, canonical URLs, JSON-LD all implemented
- Locale layout properly skips static SEO on collection pages

Made with [Cursor](https://cursor.com)