### PR TITLE
feat(marketplace): add loading skeletons for NFT detail and marketplace pages

### DIFF
--- a/nftopia-frontend/app/[locale]/marketplace/[nftId]/NFTDetailClient.tsx
+++ b/nftopia-frontend/app/[locale]/marketplace/[nftId]/NFTDetailClient.tsx
@@ -17,6 +17,9 @@ import { CircuitBackground } from "@/components/circuit-background";
 import { Card, CardContent } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import CreatorCardSkeleton from "@/components/Skeleton/CreatorCardSkeleton";
+import OwnerCardSkeleton from "@/components/Skeleton/OwnerCardSkeleton";
+import TransferHistorySkeleton from "@/components/nft/TransferHistorySkeleton";
 import { useNFTByIdQuery, useNFTTransferHistoryQuery } from "@/hooks/graphql/useNFTQueries";
 import TransferHistory from "@/components/nft/TransferHistory";
 
@@ -40,24 +43,74 @@ function formatDate(date: string | Date | null | undefined): string {
   });
 }
 
-// Skeleton component for NFT detail
-function NftDetailSkeleton() {
+// Comprehensive Skeleton component for NFT detail page
+export function NftDetailSkeleton() {
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8">
+    <div
+      role="status"
+      aria-label="Loading NFT details"
+      className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8"
+    >
+      <span className="sr-only">Loading NFT details...</span>
+      {/* Back button skeleton */}
+      <Skeleton className="h-4 w-36 mb-6" />
+
+      {/* Main Grid */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* Left Column - Image & Collection Info */}
         <div className="space-y-4">
           <Skeleton className="aspect-square w-full rounded-xl" />
-        </div>
-        <div className="space-y-6">
-          <Skeleton className="h-8 w-3/4" />
-          <Skeleton className="h-4 w-1/2" />
-          <Skeleton className="h-24 w-full" />
-          <div className="grid grid-cols-2 gap-4">
-            <Skeleton className="h-20 w-full" />
-            <Skeleton className="h-20 w-full" />
+          {/* Collection info card skeleton */}
+          <div className="flex items-center gap-3 p-3 rounded-lg bg-gray-900/30 border border-gray-800/50">
+            <Skeleton className="w-10 h-10 rounded-full" />
+            <div className="space-y-1 flex-1">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-16" />
+            </div>
           </div>
-          <Skeleton className="h-12 w-full" />
         </div>
+
+        {/* Right Column - Title, Token ID, Description, Attributes, Creator/Owner Cards, Contract */}
+        <div className="space-y-6">
+          <div>
+            <Skeleton className="h-8 w-3/4 mb-2" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+          <Skeleton className="h-20 w-full" />
+
+          {/* Attributes Grid (6 placeholder attribute pills) */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="p-2 rounded-lg bg-gray-900/30 border border-gray-800/50 space-y-1.5 text-center"
+                >
+                  <Skeleton className="h-3 w-16 mx-auto" />
+                  <Skeleton className="h-4 w-20 mx-auto" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Owner & Creator Cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <CreatorCardSkeleton />
+            <OwnerCardSkeleton />
+          </div>
+
+          {/* Contract Address */}
+          <div className="p-3 rounded-lg bg-gray-900/20 border border-gray-800/30 flex items-center justify-between">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-4 w-6" />
+          </div>
+        </div>
+      </div>
+
+      {/* Transfer History / Provenance Section Skeleton */}
+      <div className="mt-12">
+        <TransferHistorySkeleton count={5} />
       </div>
     </div>
   );

--- a/nftopia-frontend/app/[locale]/marketplace/[nftId]/loading.tsx
+++ b/nftopia-frontend/app/[locale]/marketplace/[nftId]/loading.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { CircuitBackground } from "@/components/circuit-background";
+import { NftDetailSkeleton } from "./NFTDetailClient";
+
+export default function NFTDetailLoading() {
+  return (
+    <main className="min-h-screen relative text-white overflow-hidden">
+      <CircuitBackground />
+      <div className="relative z-10">
+        <NftDetailSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/nftopia-frontend/app/[locale]/marketplace/loading.tsx
+++ b/nftopia-frontend/app/[locale]/marketplace/loading.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { CircuitBackground } from "@/components/circuit-background";
+import { MarketplaceSkeleton } from "@/components/Skeleton/MarketplaceSkeleton";
+
+export default function MarketplaceLoading() {
+  return (
+    <main className="min-h-[100svh] relative text-white overflow-hidden contain-layout">
+      <CircuitBackground />
+      <div className="relative z-10 max-w-screen-xl mx-auto px-2 sm:px-4 md:px-8 lg:px-12 pt-12">
+        <MarketplaceSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/nftopia-frontend/app/[locale]/marketplace/page.tsx
+++ b/nftopia-frontend/app/[locale]/marketplace/page.tsx
@@ -1,10 +1,10 @@
-// import { MarketplaceHero } from "@/components/marketplace-hero";
+import { Suspense } from "react";
 import { CircuitBackground } from "@/components/circuit-background";
 import { LiveAuctions } from "@/components/live-auctions";
 import { TopSellers } from "@/components/top-sellers";
 import { TodaysPicks } from "@/components/todays-picks";
 import PopularCollection from "@/components/PopularCollection";
-// import { CreateAndSell } from "@/components/create-and-sell";
+import { MarketplaceSkeleton } from "@/components/Skeleton/MarketplaceSkeleton";
 
 export default function MarketplacePage() {
   return (
@@ -14,12 +14,12 @@ export default function MarketplacePage() {
 
       {/* Main Content */}
       <div className="relative z-10 max-w-screen-xl mx-auto px-2 sm:px-4 md:px-8 lg:px-12 pt-12 space-y-16">
-        {/* <MarketplaceHero /> */}
-        <LiveAuctions />
-        <TopSellers />
-        <TodaysPicks />
-        <PopularCollection />
-        {/* <CreateAndSell /> */}
+        <Suspense fallback={<MarketplaceSkeleton />}>
+          <LiveAuctions />
+          <TopSellers />
+          <TodaysPicks />
+          <PopularCollection />
+        </Suspense>
       </div>
     </main>
   );

--- a/nftopia-frontend/components/PopularCollection.tsx
+++ b/nftopia-frontend/components/PopularCollection.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from "react";
 import Link from "next/link";
 import { emitCtaClicked, CTA_IDS, CTA_PLACEMENTS, normalizeRoute } from "@/lib/telemetry/navigation-instrumentation";
 import CollectionCard from "./CollectionCard";
+import { CollectionGridSkeleton } from "./Skeleton/CollectionGridSkeleton";
 import { Collection } from "@/types";
 import { ChevronRight, RefreshCw, Package } from "lucide-react";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -76,22 +77,7 @@ const PopularCollection: React.FC<PopularCollectionProps> = ({ title }) => {
           </div>
         ) : loading && !data ? (
           // Loading Skeleton
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-6 md:gap-8">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="animate-pulse bg-[#1E1A45] rounded-xl h-[400px] border border-purple-900/30">
-                <div className="h-48 bg-purple-900/20 rounded-t-xl mb-4" />
-                <div className="px-4 pb-4">
-                  <div className="h-6 bg-purple-900/20 rounded-md w-3/4 mb-3" />
-                  <div className="h-4 bg-purple-900/20 rounded-md w-1/2 mb-6" />
-                  <div className="flex gap-2">
-                    <div className="h-16 w-16 bg-purple-900/20 rounded-lg" />
-                    <div className="h-16 w-16 bg-purple-900/20 rounded-lg" />
-                    <div className="h-16 w-16 bg-purple-900/20 rounded-lg" />
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+          <CollectionGridSkeleton count={3} />
         ) : collections.length === 0 ? (
           <EmptyState
             icon={<Package className="h-12 w-12" />}

--- a/nftopia-frontend/components/Skeleton/CollectionGridSkeleton.tsx
+++ b/nftopia-frontend/components/Skeleton/CollectionGridSkeleton.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface CollectionGridSkeletonProps {
+  count?: number;
+  className?: string;
+}
+
+export function CollectionCardSkeleton() {
+  return (
+    <div className="bg-[#1E1A45] rounded-xl overflow-hidden border border-purple-900/30 p-4 space-y-4">
+      {/* Banner / Main Image */}
+      <Skeleton className="h-48 w-full rounded-lg" />
+
+      {/* Info Section */}
+      <div className="space-y-3">
+        <Skeleton className="h-6 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        
+        {/* Preview Thumbnails */}
+        <div className="flex gap-2 pt-2">
+          <Skeleton className="h-16 w-16 rounded-lg" />
+          <Skeleton className="h-16 w-16 rounded-lg" />
+          <Skeleton className="h-16 w-16 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CollectionGridSkeleton({
+  count = 3,
+  className,
+}: CollectionGridSkeletonProps) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading collections"
+      className={cn(
+        "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8",
+        className
+      )}
+    >
+      <span className="sr-only">Loading collections...</span>
+      {Array.from({ length: count }).map((_, index) => (
+        <CollectionCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+}
+
+export default CollectionGridSkeleton;

--- a/nftopia-frontend/components/Skeleton/CreatorCardSkeleton.tsx
+++ b/nftopia-frontend/components/Skeleton/CreatorCardSkeleton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface CreatorCardSkeletonProps {
+  className?: string;
+}
+
+export function CreatorCardSkeleton({ className }: CreatorCardSkeletonProps) {
+  return (
+    <Card className={cn("border-gray-800/50 bg-gray-900/30", className)} role="status" aria-label="Loading creator info">
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-4 rounded-full" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <Skeleton className="h-5 w-32" />
+        </div>
+        <Skeleton className="h-3 w-28" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default CreatorCardSkeleton;

--- a/nftopia-frontend/components/Skeleton/MarketplaceSkeleton.tsx
+++ b/nftopia-frontend/components/Skeleton/MarketplaceSkeleton.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CollectionGridSkeleton } from "./CollectionGridSkeleton";
+import { cn } from "@/lib/utils";
+
+interface MarketplaceSkeletonProps {
+  className?: string;
+}
+
+export function MarketplaceSkeleton({ className }: MarketplaceSkeletonProps) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading marketplace page"
+      className={cn("space-y-16 py-8", className)}
+    >
+      <span className="sr-only">Loading marketplace...</span>
+
+      {/* Live Auctions Section Skeleton */}
+      <section className="py-8 space-y-6">
+        <div className="flex justify-between items-center">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-[#1E1A45] rounded-2xl overflow-hidden border border-purple-900/30 p-4 space-y-3"
+            >
+              <Skeleton className="h-[240px] w-full rounded-xl" />
+              <Skeleton className="h-6 w-3/4" />
+              <div className="flex justify-between items-center">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-6 w-6 rounded-full" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+                <Skeleton className="h-4 w-16" />
+              </div>
+              <div className="pt-2 border-t border-purple-900/30 flex justify-between items-center">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-7 w-20 rounded-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Top Sellers Section Skeleton */}
+      <section className="py-8 space-y-6">
+        <div className="flex flex-col items-center mb-8">
+          <Skeleton className="h-10 w-48 mb-2" />
+          <Skeleton className="h-1 w-32" />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl p-4 bg-gray-900/80 border border-gray-800/50 flex items-center gap-3"
+            >
+              <Skeleton className="w-12 h-12 rounded-full flex-shrink-0" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Today's Picks Section Skeleton */}
+      <section className="py-8 space-y-6">
+        {/* Filter bar placeholder */}
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-4 bg-gray-900/40 p-4 rounded-xl border border-gray-800/50">
+          <Skeleton className="h-10 w-full sm:w-64 rounded-lg" />
+          <div className="flex gap-2 w-full sm:w-auto">
+            <Skeleton className="h-10 w-28 rounded-lg" />
+            <Skeleton className="h-10 w-28 rounded-lg" />
+          </div>
+        </div>
+
+        {/* 8 NFT Grid Items */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-[#1E1A45] rounded-2xl overflow-hidden border border-purple-900/30 p-4 space-y-3"
+            >
+              <Skeleton className="h-[240px] w-full rounded-xl" />
+              <Skeleton className="h-6 w-3/4" />
+              <div className="flex justify-between items-center">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-6 w-6 rounded-full" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+                <Skeleton className="h-4 w-16" />
+              </div>
+              <div className="pt-2 border-t border-purple-900/30 flex justify-between items-center">
+                <Skeleton className="h-7 w-20 rounded-full" />
+                <Skeleton className="h-7 w-20 rounded-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Popular Collections Section Skeleton */}
+      <section className="py-8 space-y-6">
+        <div className="flex justify-between items-center">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+        <CollectionGridSkeleton count={3} />
+      </section>
+    </div>
+  );
+}
+
+export default MarketplaceSkeleton;

--- a/nftopia-frontend/components/Skeleton/OwnerCardSkeleton.tsx
+++ b/nftopia-frontend/components/Skeleton/OwnerCardSkeleton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface OwnerCardSkeletonProps {
+  className?: string;
+}
+
+export function OwnerCardSkeleton({ className }: OwnerCardSkeletonProps) {
+  return (
+    <Card className={cn("border-gray-800/50 bg-gray-900/30", className)} role="status" aria-label="Loading owner info">
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-4 rounded-full" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <Skeleton className="h-5 w-32" />
+        </div>
+        <Skeleton className="h-3 w-24" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default OwnerCardSkeleton;

--- a/nftopia-frontend/components/Skeleton/__tests__/SkeletonComponents.test.tsx
+++ b/nftopia-frontend/components/Skeleton/__tests__/SkeletonComponents.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { MarketplaceSkeleton } from "../MarketplaceSkeleton";
+import { CollectionGridSkeleton, CollectionCardSkeleton } from "../CollectionGridSkeleton";
+import { CreatorCardSkeleton } from "../CreatorCardSkeleton";
+import { OwnerCardSkeleton } from "../OwnerCardSkeleton";
+import { TransferHistorySkeleton, EventRowSkeleton } from "../../nft/TransferHistorySkeleton";
+import { NftDetailSkeleton } from "../../../app/[locale]/marketplace/[nftId]/NFTDetailClient";
+
+// Mock next/navigation & next-intl if needed
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => "/en/marketplace",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("Skeleton Components", () => {
+  describe("CollectionGridSkeleton", () => {
+    it("renders with status role and default 3 item cards", () => {
+      render(<CollectionGridSkeleton />);
+      const statusEl = screen.getByRole("status", { name: /loading collections/i });
+      expect(statusEl).toBeInTheDocument();
+    });
+
+    it("renders specified count of collection cards", () => {
+      const { container } = render(<CollectionGridSkeleton count={5} />);
+      const cards = container.querySelectorAll(".bg-\\[\\#1E1A45\\]");
+      expect(cards.length).toBe(5);
+    });
+
+    it("renders single CollectionCardSkeleton", () => {
+      const { container } = render(<CollectionCardSkeleton />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe("CreatorCardSkeleton", () => {
+    it("renders creator card skeleton with status role", () => {
+      render(<CreatorCardSkeleton />);
+      const el = screen.getByRole("status", { name: /loading creator info/i });
+      expect(el).toBeInTheDocument();
+    });
+  });
+
+  describe("OwnerCardSkeleton", () => {
+    it("renders owner card skeleton with status role", () => {
+      render(<OwnerCardSkeleton />);
+      const el = screen.getByRole("status", { name: /loading owner info/i });
+      expect(el).toBeInTheDocument();
+    });
+  });
+
+  describe("TransferHistorySkeleton", () => {
+    it("renders transfer history skeleton with status role and header", () => {
+      render(<TransferHistorySkeleton />);
+      const el = screen.getByRole("status", { name: /loading transfer history/i });
+      expect(el).toBeInTheDocument();
+    });
+
+    it("renders correct number of event rows", () => {
+      const { container } = render(<TransferHistorySkeleton count={4} />);
+      const rows = container.querySelectorAll(".border-b");
+      expect(rows.length).toBe(4);
+    });
+
+    it("renders without header when showHeader is false", () => {
+      const { container } = render(<TransferHistorySkeleton showHeader={false} />);
+      const header = container.querySelector(".flex.items-center.justify-between");
+      expect(header).not.toBeInTheDocument();
+    });
+
+    it("renders standalone EventRowSkeleton", () => {
+      const { container } = render(<EventRowSkeleton />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe("MarketplaceSkeleton", () => {
+    it("renders marketplace skeleton with accessible status role", () => {
+      render(<MarketplaceSkeleton />);
+      const el = screen.getByRole("status", { name: /loading marketplace page/i });
+      expect(el).toBeInTheDocument();
+    });
+  });
+
+  describe("NftDetailSkeleton", () => {
+    it("renders complete NFT detail skeleton covering all sections", () => {
+      render(<NftDetailSkeleton />);
+      const statusEl = screen.getByRole("status", { name: /loading nft details/i });
+      expect(statusEl).toBeInTheDocument();
+      
+      // Verify sub-skeletons (Creator, Owner, Transfer History) are rendered
+      expect(screen.getByRole("status", { name: /loading creator info/i })).toBeInTheDocument();
+      expect(screen.getByRole("status", { name: /loading owner info/i })).toBeInTheDocument();
+      expect(screen.getByRole("status", { name: /loading transfer history/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/nftopia-frontend/components/nft/TransferHistory.tsx
+++ b/nftopia-frontend/components/nft/TransferHistory.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TransferHistorySkeleton } from "./TransferHistorySkeleton";
 
 export interface TransferEvent {
   id: string;
@@ -229,23 +230,11 @@ export function TransferHistory({
   // Loading state
   if (loading && events.length === 0) {
     return (
-      <Card className={cn("border-gray-800/50 bg-gray-900/30 backdrop-blur-sm", className)}>
-        {showHeader && (
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between text-lg">
-              <span>Ownership History</span>
-              <span className="text-sm font-normal text-gray-400">
-                Loading...
-              </span>
-            </CardTitle>
-          </CardHeader>
-        )}
-        <CardContent className="p-0 divide-y divide-gray-800/50">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <EventSkeleton key={i} />
-          ))}
-        </CardContent>
-      </Card>
+      <TransferHistorySkeleton
+        count={5}
+        showHeader={showHeader}
+        className={className}
+      />
     );
   }
 

--- a/nftopia-frontend/components/nft/TransferHistorySkeleton.tsx
+++ b/nftopia-frontend/components/nft/TransferHistorySkeleton.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface TransferHistorySkeletonProps {
+  count?: number;
+  showHeader?: boolean;
+  className?: string;
+}
+
+export function EventRowSkeleton() {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 py-3 px-4 border-b border-gray-800/50 last:border-0 overflow-hidden">
+      {/* Event Badge */}
+      <div className="sm:w-28 flex-shrink-0">
+        <Skeleton className="h-6 w-20 rounded-full" />
+      </div>
+
+      {/* From / To Addresses */}
+      <div className="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-center gap-2 overflow-hidden">
+        <Skeleton className="h-4 w-28 max-w-[120px] sm:max-w-none flex-shrink" />
+        <Skeleton className="h-3 w-3 hidden sm:block rounded-full flex-shrink-0" />
+        <Skeleton className="h-4 w-28 max-w-[120px] sm:max-w-none flex-shrink" />
+      </div>
+
+      {/* Price, Timestamp & Tx */}
+      <div className="flex items-center gap-3 flex-shrink-0">
+        <Skeleton className="h-4 w-12 sm:w-16" />
+        <Skeleton className="h-3 w-12 sm:w-16" />
+        <Skeleton className="h-4 w-12 sm:w-14" />
+      </div>
+    </div>
+  );
+}
+
+export function TransferHistorySkeleton({
+  count = 5,
+  showHeader = true,
+  className,
+}: TransferHistorySkeletonProps) {
+  return (
+    <Card
+      role="status"
+      aria-label="Loading transfer history"
+      className={cn(
+        "border-gray-800/50 bg-gray-900/30 backdrop-blur-sm overflow-hidden w-full",
+        className
+      )}
+    >
+      <span className="sr-only">Loading transfer history...</span>
+      {showHeader && (
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-6 w-40" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </CardHeader>
+      )}
+      <CardContent className="p-0 divide-y divide-gray-800/50">
+        {Array.from({ length: count }).map((_, index) => (
+          <EventRowSkeleton key={index} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default TransferHistorySkeleton;


### PR DESCRIPTION
- Closes #345

## Description
Adds coordinated loading skeleton screens for the Marketplace and NFT Detail pages to eliminate jarring layout shifts, unify loading design patterns using `@/components/ui/skeleton` (`bg-gray-800/50`), and ensure accessible loading feedback.

## Key Changes
- **New Skeletons**: Created `MarketplaceSkeleton`, `CollectionGridSkeleton`, `CreatorCardSkeleton`, `OwnerCardSkeleton`, and `TransferHistorySkeleton`.
- **Marketplace Page**: Added `<MarketplaceSkeleton />` with Suspense boundaries and Next.js App Router `loading.tsx`. Updated `PopularCollection` to use `CollectionGridSkeleton`.
- **NFT Detail Page**: Enhanced `NftDetailSkeleton` covering main image, collection card, 6 attribute pills, creator/owner cards, contract bar, and transfer history. Added `loading.tsx` route handler.
- **Transfer History**: Integrated `TransferHistorySkeleton` with responsive card bounds and `overflow-hidden` layout fixes.
- **Accessibility**: Added `role="status"`, `aria-label`, and screen-reader accessible text across all skeleton components.
- **Unit Tests**: Created `SkeletonComponents.test.tsx` covering all skeleton components (11/11 tests passing).

## Screeshots
1. **Marketplace Page Skeleton**

<img width="1905" height="967" alt="Screenshot 2026-07-29 032846" src="https://github.com/user-attachments/assets/a2fe964a-d7f0-475e-8429-bb287d535606" />
<img width="1917" height="971" alt="Screenshot 2026-07-29 032913" src="https://github.com/user-attachments/assets/ecc34102-b998-403f-ba89-d6b5d0a0cbab" />
<img width="1919" height="1033" alt="Screenshot 2026-07-29 032937" src="https://github.com/user-attachments/assets/1f585e20-d2e0-41da-b695-47aed0af7bfe" />



3. **NFT Detail Page Skeleton**

<img width="1915" height="976" alt="Screenshot 2026-07-29 034140" src="https://github.com/user-attachments/assets/0034340f-57e4-4045-8720-bd4ca0731add" />

<img width="1915" height="972" alt="Screenshot 2026-07-29 034204" src="https://github.com/user-attachments/assets/fe5684d0-e189-4ed9-9dfc-095473be3071" />



