### PR TITLE
feat: implement NFT detail screen with transfer history

### DIFF
--- a/nftopia-mobile-app/components/wallet/TransferHistory.tsx
+++ b/nftopia-mobile-app/components/wallet/TransferHistory.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Linking, ActivityIndicator } from 'react-native';
+import { colors, spacing, borderRadius } from '@/constants/theme';
+import { TransferEvent } from '@/screens/Marketplace/MarketplaceScreen';
+
+interface TransferHistoryProps {
+  events: TransferEvent[];
+  isLoading: boolean;
+}
+
+export default function TransferHistory({ events, isLoading }: TransferHistoryProps) {
+  
+  const openExplorer = (txHash: string) => {
+    // For Stellar, typically it's stellar.expert
+    const url = `https://stellar.expert/explorer/public/tx/${txHash}`;
+    Linking.openURL(url).catch(err => console.error("Couldn't load page", err));
+  };
+
+  const renderSkeleton = () => (
+    <View style={styles.skeletonContainer}>
+      {[1, 2, 3].map((key) => (
+        <View key={key} style={styles.skeletonRow}>
+          <View style={styles.skeletonIcon} />
+          <View style={styles.skeletonContent}>
+            <View style={styles.skeletonTextLong} />
+            <View style={styles.skeletonTextShort} />
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+
+  const renderEmptyState = () => (
+    <View style={styles.emptyState}>
+      <Text style={styles.emptyStateIcon}>📜</Text>
+      <Text style={styles.emptyStateText}>No transfer history found</Text>
+    </View>
+  );
+
+  const getEventIcon = (type: string) => {
+    switch (type) {
+      case 'mint': return '✨';
+      case 'sale': return '💰';
+      case 'transfer': return '🔄';
+      default: return '📄';
+    }
+  };
+
+  const formatAddress = (address: string) => {
+    if (!address) return '';
+    return `${address.substring(0, 5)}...${address.substring(address.length - 4)}`;
+  };
+
+  const renderItem = ({ item }: { item: TransferEvent }) => (
+    <View style={styles.eventItem}>
+      <View style={styles.eventIconContainer}>
+        <Text style={styles.eventIcon}>{getEventIcon(item.type)}</Text>
+      </View>
+      <View style={styles.eventDetails}>
+        <Text style={styles.eventType}>{item.type.charAt(0).toUpperCase() + item.type.slice(1)}</Text>
+        <Text style={styles.eventDate}>{new Date(item.date).toLocaleDateString()}</Text>
+        
+        {item.type === 'mint' && (
+          <Text style={styles.eventSubText}>To: {formatAddress(item.toAddress)}</Text>
+        )}
+        
+        {(item.type === 'sale' || item.type === 'transfer') && (
+          <Text style={styles.eventSubText}>
+            {item.fromAddress ? `${formatAddress(item.fromAddress)} → ` : ''}{formatAddress(item.toAddress)}
+          </Text>
+        )}
+        
+        {item.price && (
+          <Text style={styles.eventPrice}>{item.price}</Text>
+        )}
+      </View>
+      
+      <TouchableOpacity 
+        style={styles.explorerButton} 
+        onPress={() => openExplorer(item.transactionHash)}
+      >
+        <Text style={styles.explorerIcon}>🔗</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  if (isLoading) {
+    return renderSkeleton();
+  }
+
+  if (!events || events.length === 0) {
+    return renderEmptyState();
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Provenance</Text>
+      <FlatList
+        data={events}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        showsVerticalScrollIndicator={false}
+        scrollEnabled={false} // usually rendered inside a ScrollView in detail screen
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: spacing.md,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text,
+    marginBottom: spacing.md,
+  },
+  eventItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  eventIconContainer: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.surface,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: spacing.md,
+  },
+  eventIcon: {
+    fontSize: 20,
+  },
+  eventDetails: {
+    flex: 1,
+  },
+  eventType: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  eventDate: {
+    fontSize: 12,
+    color: colors.textTertiary,
+    marginTop: 2,
+  },
+  eventSubText: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    marginTop: 4,
+  },
+  eventPrice: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: colors.primary,
+    marginTop: 4,
+  },
+  explorerButton: {
+    padding: spacing.sm,
+  },
+  explorerIcon: {
+    fontSize: 20,
+  },
+  emptyState: {
+    padding: spacing.xl,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyStateIcon: {
+    fontSize: 40,
+    marginBottom: spacing.sm,
+  },
+  emptyStateText: {
+    fontSize: 16,
+    color: colors.textSecondary,
+  },
+  skeletonContainer: {
+    marginTop: spacing.md,
+  },
+  skeletonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  skeletonIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.border,
+    marginRight: spacing.md,
+  },
+  skeletonContent: {
+    flex: 1,
+    gap: 8,
+  },
+  skeletonTextLong: {
+    height: 16,
+    backgroundColor: colors.border,
+    borderRadius: 4,
+    width: '60%',
+  },
+  skeletonTextShort: {
+    height: 12,
+    backgroundColor: colors.border,
+    borderRadius: 4,
+    width: '40%',
+  },
+});

--- a/nftopia-mobile-app/navigation/MainNavigator.tsx
+++ b/nftopia-mobile-app/navigation/MainNavigator.tsx
@@ -3,11 +3,15 @@ import React from 'react';
 import HomeScreen from '@/screens/Home/HomeScreen';
 import ProfileScreen from '@/screens/Profile/ProfileScreen';
 import WalletManagementScreen from '@/screens/Profile/WalletManagementScreen';
+import MarketplaceScreen from '@/screens/Marketplace/MarketplaceScreen';
+import NFTDetailScreen from '@/screens/Marketplace/NFTDetailScreen';
 
 export type MainStackParamList = {
   Home: undefined;
   WalletManagement: undefined;
   Profile: undefined;
+  Marketplace: undefined;
+  NFTDetail: { nftId: string };
 };
 
 const Stack = createNativeStackNavigator<MainStackParamList>();
@@ -22,6 +26,8 @@ export default function MainNavigator() {
       <Stack.Screen name="Home" component={HomeScreen} />
       <Stack.Screen name="Profile" component={ProfileScreen} />
       <Stack.Screen name="WalletManagement" component={WalletManagementScreen} />
+      <Stack.Screen name="Marketplace" component={MarketplaceScreen} />
+      <Stack.Screen name="NFTDetail" component={NFTDetailScreen} />
     </Stack.Navigator>
   );
 }

--- a/nftopia-mobile-app/screens/Home/HomeScreen.tsx
+++ b/nftopia-mobile-app/screens/Home/HomeScreen.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, RefreshControl } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { MainStackParamList } from '@/navigation/MainNavigator';
 import { colors, spacing, borderRadius, shadows } from '@/constants/theme';
 import { useWalletConnect } from '@/hooks/useWalletConnect';
 import { useWalletStore } from '@/stores/walletStore';
 import BalanceDisplay from '@/components/wallet/BalanceDisplay';
 
 export default function HomeScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<MainStackParamList>>();
   const {
     activeWallet,
     activePublicKey,
@@ -66,6 +70,10 @@ export default function HomeScreen() {
       />
 
       <View style={styles.actions}>
+        <TouchableOpacity style={styles.actionCard} onPress={() => navigation.navigate('Marketplace')}>
+          <Text style={styles.actionIcon}>🛍️</Text>
+          <Text style={styles.actionLabel}>Marketplace</Text>
+        </TouchableOpacity>
         <TouchableOpacity style={styles.actionCard}>
           <Text style={styles.actionIcon}>📤</Text>
           <Text style={styles.actionLabel}>Send</Text>

--- a/nftopia-mobile-app/screens/Marketplace/MarketplaceScreen.tsx
+++ b/nftopia-mobile-app/screens/Marketplace/MarketplaceScreen.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Image } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { MainStackParamList } from '@/navigation/MainNavigator';
+import { colors, spacing, borderRadius, shadows } from '@/constants/theme';
+
+export interface NFT {
+  id: string;
+  name: string;
+  description: string;
+  imageUrl: string;
+  creator: string;
+  owner: string;
+  attributes: { trait_type: string; value: string }[];
+  history: TransferEvent[];
+}
+
+export interface TransferEvent {
+  id: string;
+  type: 'mint' | 'transfer' | 'sale';
+  fromAddress?: string;
+  toAddress: string;
+  date: string;
+  price?: string;
+  transactionHash: string;
+}
+
+// Mock data for Marketplace
+export const MOCK_NFTS: NFT[] = [
+  {
+    id: '1',
+    name: 'Cosmic Stellar #1',
+    description: 'A beautiful digital artwork representing the Stellar network ecosystem in a cosmic style.',
+    imageUrl: 'https://picsum.photos/id/1018/400/400',
+    creator: 'GAHQ7...XYZ',
+    owner: 'GBDX3...ABC',
+    attributes: [
+      { trait_type: 'Background', value: 'Deep Space' },
+      { trait_type: 'Rarity', value: 'Legendary' },
+      { trait_type: 'Planet', value: 'Stellar' }
+    ],
+    history: [
+      { id: 'ev1', type: 'mint', toAddress: 'GAHQ7...XYZ', date: '2023-10-01T12:00:00Z', transactionHash: '0x123...' },
+      { id: 'ev2', type: 'sale', fromAddress: 'GAHQ7...XYZ', toAddress: 'GBDX3...ABC', date: '2023-10-15T15:30:00Z', price: '500 XLM', transactionHash: '0x456...' }
+    ]
+  },
+  {
+    id: '2',
+    name: 'Abstract Node',
+    description: 'An abstract visualization of a validator node processing transactions.',
+    imageUrl: 'https://picsum.photos/id/1043/400/400',
+    creator: 'GAHQ7...XYZ',
+    owner: 'GCXY9...DEF',
+    attributes: [
+      { trait_type: 'Color', value: 'Neon Green' },
+      { trait_type: 'Type', value: 'Abstract' }
+    ],
+    history: [
+      { id: 'ev3', type: 'mint', toAddress: 'GAHQ7...XYZ', date: '2023-11-05T09:20:00Z', transactionHash: '0x789...' }
+    ]
+  }
+];
+
+export default function MarketplaceScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<MainStackParamList>>();
+
+  const renderItem = ({ item }: { item: NFT }) => (
+    <TouchableOpacity 
+      style={styles.card} 
+      onPress={() => navigation.navigate('NFTDetail', { nftId: item.id })}
+    >
+      <Image source={{ uri: item.imageUrl }} style={styles.cardImage} />
+      <View style={styles.cardContent}>
+        <Text style={styles.cardTitle}>{item.name}</Text>
+        <Text style={styles.cardOwner}>Owner: {item.owner}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
+          <Text style={styles.backButtonText}>←</Text>
+        </TouchableOpacity>
+        <Text style={styles.title}>Marketplace</Text>
+      </View>
+      <FlatList
+        data={MOCK_NFTS}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.md,
+    paddingTop: 60,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  backButton: {
+    padding: spacing.sm,
+    marginRight: spacing.sm,
+  },
+  backButtonText: {
+    fontSize: 24,
+    color: colors.text,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: colors.text,
+  },
+  listContent: {
+    padding: spacing.md,
+    gap: spacing.md,
+  },
+  card: {
+    backgroundColor: colors.surfaceElevated,
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+    ...shadows.md,
+    marginBottom: spacing.md,
+  },
+  cardImage: {
+    width: '100%',
+    height: 200,
+    backgroundColor: colors.border,
+  },
+  cardContent: {
+    padding: spacing.md,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text,
+    marginBottom: spacing.xs,
+  },
+  cardOwner: {
+    fontSize: 14,
+    color: colors.textSecondary,
+  },
+});

--- a/nftopia-mobile-app/screens/Marketplace/NFTDetailScreen.tsx
+++ b/nftopia-mobile-app/screens/Marketplace/NFTDetailScreen.tsx
@@ -1,0 +1,355 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { 
+  View, 
+  Text, 
+  StyleSheet, 
+  ScrollView, 
+  TouchableOpacity, 
+  Image, 
+  RefreshControl,
+  ActivityIndicator,
+  Alert
+} from 'react-native';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import * as Clipboard from 'expo-clipboard';
+import { MainStackParamList } from '@/navigation/MainNavigator';
+import { colors, spacing, borderRadius, shadows } from '@/constants/theme';
+import TransferHistory from '@/components/wallet/TransferHistory';
+import { MOCK_NFTS, NFT } from './MarketplaceScreen';
+
+type NFTDetailRouteProp = RouteProp<MainStackParamList, 'NFTDetail'>;
+type NavigationProp = NativeStackNavigationProp<MainStackParamList>;
+
+export default function NFTDetailScreen() {
+  const route = useRoute<NFTDetailRouteProp>();
+  const navigation = useNavigation<NavigationProp>();
+  const { nftId } = route.params;
+
+  const [nft, setNft] = useState<NFT | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchNFTDetails = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      // Simulate network request
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      const foundNft = MOCK_NFTS.find(n => n.id === nftId);
+      if (foundNft) {
+        setNft(foundNft);
+      } else {
+        setError('NFT not found.');
+      }
+    } catch (err) {
+      setError('Failed to load NFT details.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [nftId]);
+
+  useEffect(() => {
+    fetchNFTDetails();
+  }, [fetchNFTDetails]);
+
+  const copyToClipboard = async (text: string, type: string) => {
+    await Clipboard.setStringAsync(text);
+    Alert.alert('Copied!', `${type} address copied to clipboard.`);
+  };
+
+  const renderSkeleton = () => (
+    <View style={styles.skeletonContainer}>
+      <View style={styles.skeletonImage} />
+      <View style={styles.content}>
+        <View style={styles.skeletonTitle} />
+        <View style={styles.skeletonDesc} />
+        <View style={styles.skeletonDesc} />
+        <View style={[styles.skeletonDesc, { width: '60%' }]} />
+      </View>
+    </View>
+  );
+
+  const renderError = () => (
+    <View style={styles.centerContainer}>
+      <Text style={styles.errorText}>{error}</Text>
+      <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()}>
+        <Text style={styles.backButtonText}>Go Back</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  if (isLoading && !nft) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => navigation.goBack()} style={styles.headerBackButton}>
+            <Text style={styles.headerBackText}>←</Text>
+          </TouchableOpacity>
+        </View>
+        {renderSkeleton()}
+      </View>
+    );
+  }
+
+  if (error || !nft) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => navigation.goBack()} style={styles.headerBackButton}>
+            <Text style={styles.headerBackText}>←</Text>
+          </TouchableOpacity>
+        </View>
+        {renderError()}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.headerBackButton}>
+          <Text style={styles.headerBackText}>←</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {nft.name}
+        </Text>
+      </View>
+      
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        refreshControl={<RefreshControl refreshing={isLoading} onRefresh={fetchNFTDetails} />}
+      >
+        {/* Image viewer with zoom and pinch support */}
+        <ScrollView 
+          horizontal 
+          contentContainerStyle={styles.imageScrollContainer}
+          maximumZoomScale={3}
+          minimumZoomScale={1}
+          showsHorizontalScrollIndicator={false}
+          bouncesZoom={true}
+        >
+          <Image 
+            source={{ uri: nft.imageUrl }} 
+            style={styles.image} 
+            resizeMode="contain"
+          />
+        </ScrollView>
+
+        <View style={styles.content}>
+          <Text style={styles.title}>{nft.name}</Text>
+          <Text style={styles.description}>{nft.description}</Text>
+
+          {/* Creator and Owner */}
+          <View style={styles.addressSection}>
+            <View style={styles.addressRow}>
+              <Text style={styles.addressLabel}>Creator</Text>
+              <TouchableOpacity style={styles.addressPill} onPress={() => copyToClipboard(nft.creator, 'Creator')}>
+                <Text style={styles.addressText}>{nft.creator}</Text>
+                <Text style={styles.copyIcon}>📋</Text>
+              </TouchableOpacity>
+            </View>
+            <View style={styles.addressRow}>
+              <Text style={styles.addressLabel}>Owner</Text>
+              <TouchableOpacity style={styles.addressPill} onPress={() => copyToClipboard(nft.owner, 'Owner')}>
+                <Text style={styles.addressText}>{nft.owner}</Text>
+                <Text style={styles.copyIcon}>📋</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          {/* Attributes Grid */}
+          {nft.attributes && nft.attributes.length > 0 && (
+            <View style={styles.attributesSection}>
+              <Text style={styles.sectionTitle}>Attributes</Text>
+              <View style={styles.attributesGrid}>
+                {nft.attributes.map((attr, index) => (
+                  <View key={index} style={styles.attributeCard}>
+                    <Text style={styles.attributeType}>{attr.trait_type}</Text>
+                    <Text style={styles.attributeValue}>{attr.value}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          )}
+
+          {/* Transfer History */}
+          <TransferHistory events={nft.history} isLoading={isLoading} />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.md,
+    paddingTop: 60,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerBackButton: {
+    padding: spacing.sm,
+    marginRight: spacing.sm,
+  },
+  headerBackText: {
+    fontSize: 24,
+    color: colors.text,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text,
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: spacing.xxl,
+  },
+  imageScrollContainer: {
+    width: '100%',
+    height: 350,
+    backgroundColor: '#000',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  image: {
+    width: 350,
+    height: 350,
+  },
+  content: {
+    padding: spacing.md,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: colors.text,
+    marginBottom: spacing.xs,
+  },
+  description: {
+    fontSize: 16,
+    color: colors.textSecondary,
+    lineHeight: 24,
+    marginBottom: spacing.lg,
+  },
+  addressSection: {
+    backgroundColor: colors.surfaceElevated,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    marginBottom: spacing.lg,
+    ...shadows.sm,
+  },
+  addressRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginVertical: spacing.xs,
+  },
+  addressLabel: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    fontWeight: '500',
+  },
+  addressPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  addressText: {
+    fontSize: 14,
+    color: colors.text,
+    marginRight: spacing.xs,
+  },
+  copyIcon: {
+    fontSize: 14,
+  },
+  attributesSection: {
+    marginBottom: spacing.lg,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text,
+    marginBottom: spacing.md,
+  },
+  attributesGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  attributeCard: {
+    flexBasis: '48%',
+    backgroundColor: colors.surfaceElevated,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  attributeType: {
+    fontSize: 12,
+    color: colors.primary,
+    textTransform: 'uppercase',
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  attributeValue: {
+    fontSize: 14,
+    color: colors.text,
+    fontWeight: '500',
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  errorText: {
+    fontSize: 16,
+    color: colors.error,
+    marginBottom: spacing.md,
+  },
+  backButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+  },
+  backButtonText: {
+    color: '#FFF',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  skeletonContainer: {
+    flex: 1,
+  },
+  skeletonImage: {
+    width: '100%',
+    height: 350,
+    backgroundColor: colors.border,
+  },
+  skeletonTitle: {
+    height: 32,
+    backgroundColor: colors.border,
+    borderRadius: 4,
+    width: '70%',
+    marginBottom: spacing.md,
+  },
+  skeletonDesc: {
+    height: 16,
+    backgroundColor: colors.border,
+    borderRadius: 4,
+    width: '100%',
+    marginBottom: spacing.sm,
+  },
+});


### PR DESCRIPTION
# Implement NFT Detail Screen with Transfer History

## What was done
- Added `MarketplaceScreen` with a grid of mock NFTs to serve as the navigation entry point for details.
- Added a "Marketplace" quick action button on the Home screen to improve navigation.
- Created `NFTDetailScreen` featuring:
  - An image viewer with pinch-to-zoom support (up to 3x zoom).
  - NFT metadata displayed in an organized attributes grid.
  - Creator and owner addresses with copy-to-clipboard functionality (`expo-clipboard`).
  - Full support for loading skeletons, pull-to-refresh, empty states, and error handling.
- Implemented the `TransferHistory` component to display mint, sale, and transfer provenance events.
- Added deep links within the transfer history to view transaction hashes on the Stellar blockchain explorer.
- Cleaned up empty placeholder files (`sample.tsx`) from the original structure.

## Why it was done
To resolve the missing functionality where users had no way to view specific NFT details, metadata, or their chain of custody/transfer history directly in the mobile app.

## How it was verified
- Verified navigation from Home → Marketplace → NFT Detail.
- Verified pinch-to-zoom works as intended on the `ScrollView`.
- Verified copying addresses successfully drops text into the device clipboard.
- Verified the UI handles empty, error, and loading states without crashing.

Closes #403