### PR TITLE
fix(ci): add package-lock.json and simplify mobile CI to npm-only

### DIFF
--- a/.github/workflows/nftopia-mobile-app.yml
+++ b/.github/workflows/nftopia-mobile-app.yml
@@ -30,77 +30,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Detect package manager
-        id: detect
-        run: |
-          if [ -f pnpm-lock.yaml ]; then
-            echo "manager=pnpm" >> $GITHUB_OUTPUT
-          elif [ -f package-lock.json ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-          else
-            echo "No lockfile found. CI requires a lockfile."
-            exit 1
-          fi
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: ${{ steps.detect.outputs.manager }}
-          cache-dependency-path: |
-            nftopia-mobile-app/pnpm-lock.yaml
-            nftopia-mobile-app/package-lock.json
+          cache: npm
+          cache-dependency-path: nftopia-mobile-app/package-lock.json
 
-      - name: Setup pnpm
-        if: steps.detect.outputs.manager == 'pnpm'
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10
-
-      - name: Install dependencies (pnpm)
-        if: steps.detect.outputs.manager == 'pnpm'
-        run: pnpm install --frozen-lockfile
-
-      - name: Install dependencies (npm)
-        if: steps.detect.outputs.manager == 'npm'
+      - name: Install dependencies
         run: npm ci
 
       - name: Type check
-        run: |
-          if [ "${{ steps.detect.outputs.manager }}" = "pnpm" ]; then
-            pnpm exec tsc --noEmit
-          else
-            npx tsc --noEmit
-          fi
+        run: npx tsc --noEmit
 
       - name: Lint (if available)
-        run: |
-          if [ "${{ steps.detect.outputs.manager }}" = "pnpm" ]; then
-            pnpm run lint --if-present
-          else
-            npm run lint --if-present
-          fi
+        run: npm run lint --if-present
 
       - name: Run tests (if available)
-        run: |
-          if [ "${{ steps.detect.outputs.manager }}" = "pnpm" ]; then
-            pnpm run test --if-present
-          else
-            npm run test --if-present
-          fi
+        run: npm run test --if-present
 
       - name: Validate Expo config
-        run: |
-          if [ "${{ steps.detect.outputs.manager }}" = "pnpm" ]; then
-            pnpm exec expo config --type public > /dev/null
-          else
-            npx expo config --type public > /dev/null
-          fi
+        run: npx expo config --type public > /dev/null
 
       - name: Build web bundle (if available)
-        run: |
-          if [ "${{ steps.detect.outputs.manager }}" = "pnpm" ]; then
-            pnpm run build --if-present
-          else
-            npm run build --if-present
-          fi
+        run: npm run build --if-present

--- a/nftopia-mobile-app/.gitignore
+++ b/nftopia-mobile-app/.gitignore
@@ -2,7 +2,6 @@
 # Dependencies
 # =========================
 node_modules/
-pnpm-lock.yaml
 yarn.lock
 
 # =========================

--- a/nftopia-mobile-app/package-lock.json
+++ b/nftopia-mobile-app/package-lock.json
@@ -9714,9 +9714,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9736,9 +9733,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9760,9 +9754,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9782,9 +9773,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,


### PR DESCRIPTION
Closes #400

---

Fixes the NFTopia Mobile App CI build-and-verify job that was failing because no lockfile existed in the repo.

Changes:
- Generate and commit package-lock.json
- Simplify workflow to npm-only (remove all pnpm branching)
- Remove pnpm-lock.yaml from .gitignore