### PR TITLE
feat(frontend): improve marketplace pagination loading

### DIFF
--- a/nftopia-frontend/__tests__/marketplace-pagination.test.ts
+++ b/nftopia-frontend/__tests__/marketplace-pagination.test.ts
@@ -1,0 +1,111 @@
+import type { GetListingsQuery } from "@/hooks/graphql/generated";
+import { ListingStatus } from "@/hooks/graphql/generated";
+import { mergeListingConnection } from "@/lib/services/marketplace-pagination";
+
+type ListingEdge = GetListingsQuery["listings"]["edges"][number];
+
+function listingEdge(id: string, cursor = `cursor-${id}`): ListingEdge {
+  return {
+    __typename: "ListingEdge",
+    cursor,
+    node: {
+      __typename: "Listing",
+      id,
+      nftId: `nft-${id}`,
+      sellerId: `seller-${id}`,
+      price: "10",
+      currency: "XLM",
+      status: ListingStatus.Active,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: null,
+      nft: {
+        __typename: "NFT",
+        id: `nft-${id}`,
+        name: `NFT ${id}`,
+        image: null,
+        tokenId: id,
+      },
+      seller: {
+        __typename: "User",
+        id: `seller-${id}`,
+        username: `seller-${id}`,
+        walletAddress: null,
+      },
+    },
+  };
+}
+
+function listingsQuery(
+  ids: string[],
+  overrides: Partial<GetListingsQuery["listings"]> = {},
+): GetListingsQuery {
+  return {
+    __typename: "Query",
+    listings: {
+      __typename: "ListingConnection",
+      totalCount: ids.length,
+      edges: ids.map((id) => listingEdge(id)),
+      pageInfo: {
+        __typename: "PageInfo",
+        hasNextPage: false,
+        startCursor: ids.length ? `cursor-${ids[0]}` : null,
+        endCursor: ids.length ? `cursor-${ids[ids.length - 1]}` : null,
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe("mergeListingConnection", () => {
+  it("appends new listing edges and keeps incoming pagination metadata", () => {
+    const previous = listingsQuery(["1", "2"], {
+      totalCount: 4,
+      pageInfo: {
+        __typename: "PageInfo",
+        hasNextPage: true,
+        startCursor: "cursor-1",
+        endCursor: "cursor-2",
+      },
+    });
+    const incoming = listingsQuery(["3", "4"], {
+      totalCount: 4,
+      pageInfo: {
+        __typename: "PageInfo",
+        hasNextPage: false,
+        startCursor: "cursor-3",
+        endCursor: "cursor-4",
+      },
+    });
+
+    const result = mergeListingConnection(previous, incoming);
+
+    expect(result.listings.edges.map((edge) => edge.node.id)).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+    ]);
+    expect(result.listings.totalCount).toBe(4);
+    expect(result.listings.pageInfo.hasNextPage).toBe(false);
+    expect(result.listings.pageInfo.endCursor).toBe("cursor-4");
+  });
+
+  it("does not append duplicate listing ids when a page overlaps", () => {
+    const result = mergeListingConnection(
+      listingsQuery(["1", "2"]),
+      listingsQuery(["2", "3"]),
+    );
+
+    expect(result.listings.edges.map((edge) => edge.node.id)).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
+  });
+
+  it("returns the previous result when fetchMore has no payload", () => {
+    const previous = listingsQuery(["1"]);
+
+    expect(mergeListingConnection(previous, undefined)).toBe(previous);
+  });
+});

--- a/nftopia-frontend/components/todays-picks.tsx
+++ b/nftopia-frontend/components/todays-picks.tsx
@@ -2,16 +2,16 @@
 
 import { OptimizedImage } from './image';
 import { Button } from "@/components/ui/button";
-import { emitCtaClicked, CTA_IDS, CTA_PLACEMENTS } from "@/lib/telemetry/navigation-instrumentation";
-import { Clock, Heart, Search, ShoppingBag, AlertCircle, RefreshCw } from "lucide-react";
+import { Heart, Search, ShoppingBag, AlertCircle } from "lucide-react";
 import { useTranslation } from "@/hooks/useTranslation";
-import { useState, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PurchaseModal } from './marketplace/PurchaseModal';
 import { MarketplaceFilters } from './marketplace/MarketplaceFilters';
 import { useListingsQuery } from '@/hooks/graphql/useListingsQuery';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ListingStatus } from '@/hooks/graphql/generated';
+import { mergeListingConnection } from "@/lib/services/marketplace-pagination";
 
 type NFTItem = {
   id: string;
@@ -30,6 +30,8 @@ export function TodaysPicks() {
   const { t } = useTranslation();
   const searchParams = useSearchParams();
   const [selectedNFT, setSelectedNFT] = useState<NFTItem | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
   
   const search = searchParams.get("search") || "";
   const minPrice = searchParams.get("minPrice") ? Number(searchParams.get("minPrice")) : undefined;
@@ -37,23 +39,28 @@ export function TodaysPicks() {
   const sortBy = searchParams.get("sortBy") || "newest";
 
   const router = useRouter();
+  const listingFilter = useMemo(
+    () => ({
+      status: ListingStatus.Active,
+      search,
+      minPrice,
+      maxPrice,
+      sortBy,
+    }),
+    [maxPrice, minPrice, search, sortBy],
+  );
 
   const { data, loading, error, fetchMore, refetch } = useListingsQuery({
     variables: {
       pagination: { first: 8 },
-      filter: {
-        status: ListingStatus.Active,
-        search,
-        minPrice,
-        maxPrice,
-        sortBy,
-      }
+      filter: listingFilter,
     },
     fetchPolicy: "cache-and-network"
   });
 
   const listings = data?.listings?.edges.map(e => e.node) || [];
   const pageInfo = data?.listings?.pageInfo;
+  const totalCount = data?.listings?.totalCount ?? listings.length;
   const hasActiveFilters = !!(search || minPrice || maxPrice);
 
   const clearFilters = () => {
@@ -77,6 +84,45 @@ export function TodaysPicks() {
       image: listing.nft?.image,
     }));
   }, [listings]);
+
+  const loadMoreListings = useCallback(async () => {
+    if (isLoadingMore || !pageInfo?.hasNextPage || !pageInfo.endCursor) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    try {
+      await fetchMore({
+        variables: {
+          pagination: { first: 8, after: pageInfo.endCursor },
+          filter: listingFilter,
+        },
+        updateQuery: (previous, { fetchMoreResult }) =>
+          mergeListingConnection(previous, fetchMoreResult),
+      });
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [fetchMore, isLoadingMore, listingFilter, pageInfo?.endCursor, pageInfo?.hasNextPage]);
+
+  useEffect(() => {
+    const target = loadMoreRef.current;
+    if (!target || !pageInfo?.hasNextPage) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          void loadMoreListings();
+        }
+      },
+      { rootMargin: "600px 0px" },
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [loadMoreListings, pageInfo?.hasNextPage]);
 
   return (
     <section className="py-16 relative">
@@ -112,6 +158,10 @@ export function TodaysPicks() {
         />
       ) : (
         <>
+          <div className="mb-5 text-sm text-[#9398a8]" aria-live="polite">
+            Showing {nftItems.length} of {totalCount} NFTs
+          </div>
+
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {nftItems.map((item) => (
               <div
@@ -186,19 +236,17 @@ export function TodaysPicks() {
           </div>
 
           {pageInfo?.hasNextPage && (
-            <div className="flex justify-center mt-10">
+            <div ref={loadMoreRef} className="flex justify-center mt-10">
               <Button
                 variant="ghost"
-                className="text-purple-400 hover:bg-transparent hover:text-purple-300 rounded-full px-8"
-                onClick={() => {
-                  fetchMore({
-                    variables: {
-                      pagination: { first: 8, after: pageInfo.endCursor }
-                    }
-                  });
-                }}
+                className="text-purple-400 hover:bg-transparent hover:text-purple-300 rounded-full px-8 disabled:opacity-60"
+                onClick={() => void loadMoreListings()}
+                disabled={isLoadingMore}
+                aria-busy={isLoadingMore}
               >
-                {t("todaysPicks.loadMore") || "Load More"}
+                {isLoadingMore
+                  ? t("todaysPicks.loadingMore") || "Loading..."
+                  : t("todaysPicks.loadMore") || "Load More"}
               </Button>
             </div>
           )}

--- a/nftopia-frontend/lib/services/marketplace-pagination.ts
+++ b/nftopia-frontend/lib/services/marketplace-pagination.ts
@@ -1,0 +1,34 @@
+import type { GetListingsQuery } from "@/hooks/graphql/generated";
+
+type ListingEdge = GetListingsQuery["listings"]["edges"][number];
+
+function listingEdgeKey(edge: ListingEdge): string {
+  return edge.node?.id || edge.cursor;
+}
+
+export function mergeListingConnection(
+  previous: GetListingsQuery,
+  incoming?: GetListingsQuery,
+): GetListingsQuery {
+  if (!incoming?.listings) {
+    return previous;
+  }
+
+  const seen = new Set(previous.listings.edges.map(listingEdgeKey));
+  const nextEdges = incoming.listings.edges.filter((edge) => {
+    const key = listingEdgeKey(edge);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+
+  return {
+    ...previous,
+    listings: {
+      ...incoming.listings,
+      edges: [...previous.listings.edges, ...nextEdges],
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated merge helper for paginated marketplace listing results so fetchMore appends and deduplicates edges
- wire Today’s Picks load-more to preserve filters, update Apollo cache explicitly, disable while loading, and show loaded/total count
- add unit coverage for append, dedupe, and empty fetchMore payload cases

Closes #389

## Verification
- git diff --check
- Not run: frontend dependency installation timed out in this environment, so Jest could not be executed locally.