### PR TITLE
feat(mobile): add content reporting flow

### DIFF
--- a/nftopia-mobile-app/lib/api/sample.ts
+++ b/nftopia-mobile-app/lib/api/sample.ts
@@ -30,6 +30,18 @@ class ApiClient {
     this.token = token;
   }
 
+  async submitModerationReport(payload: {
+    targetType: 'nft' | 'collection' | 'profile';
+    targetId: string;
+    reason: string;
+    details?: string;
+  }): Promise<void> {
+    await this.request('/moderation/reports', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
   private async request<T>(
     endpoint: string,
     options: RequestInit = {}

--- a/nftopia-mobile-app/src/components/ReportModal.tsx
+++ b/nftopia-mobile-app/src/components/ReportModal.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { REPORT_REASONS, ReportReason, ReportTargetType, submitReport } from '@/src/services/moderation/report.service';
+import { useToast } from '@/src/hooks/useToast';
+
+interface Props {
+  visible: boolean;
+  targetType: ReportTargetType;
+  targetId: string;
+  onClose: () => void;
+}
+
+export default function ReportModal({ visible, targetType, targetId, onClose }: Props) {
+  const [reason, setReason] = useState<ReportReason>('spam');
+  const [details, setDetails] = useState('');
+  const [hideForMe, setHideForMe] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const { showSuccess, showError } = useToast();
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await submitReport({ targetType, targetId, reason, details: details.trim() || undefined, hideForMe });
+      showSuccess('Report submitted. Thank you for helping keep NFTopia safe.');
+      setDetails('');
+      onClose();
+    } catch (error) {
+      showError(error instanceof Error ? error.message : 'Unable to submit report.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <View style={styles.sheet}>
+          <Text style={styles.title}>Report content</Text>
+          {REPORT_REASONS.map((item) => (
+            <Pressable key={item.value} style={styles.reason} onPress={() => setReason(item.value)}>
+              <Text style={styles.radio}>{reason === item.value ? '●' : '○'}</Text>
+              <Text style={styles.label}>{item.label}</Text>
+            </Pressable>
+          ))}
+          <TextInput
+            style={styles.details}
+            placeholder="Additional details (optional)"
+            value={details}
+            onChangeText={setDetails}
+            multiline
+            maxLength={500}
+          />
+          <Pressable style={styles.reason} onPress={() => setHideForMe((value) => !value)}>
+            <Text style={styles.radio}>{hideForMe ? '☑' : '☐'}</Text>
+            <Text style={styles.label}>Hide this content for me</Text>
+          </Pressable>
+          <View style={styles.actions}>
+            <Pressable onPress={onClose} style={styles.cancel}><Text>Cancel</Text></Pressable>
+            <Pressable onPress={handleSubmit} disabled={submitting} style={styles.submit}>
+              <Text style={styles.submitText}>{submitting ? 'Sending...' : 'Send report'}</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.45)' },
+  sheet: { backgroundColor: '#fff', padding: 20, borderTopLeftRadius: 18, borderTopRightRadius: 18, gap: 10 },
+  title: { fontSize: 20, fontWeight: '700', marginBottom: 4 },
+  reason: { flexDirection: 'row', alignItems: 'center', gap: 10, paddingVertical: 7 },
+  radio: { fontSize: 20, color: '#5b45d6' },
+  label: { flex: 1, fontSize: 15 },
+  details: { minHeight: 80, borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 10, textAlignVertical: 'top' },
+  actions: { flexDirection: 'row', justifyContent: 'flex-end', gap: 12, marginTop: 6 },
+  cancel: { padding: 12 },
+  submit: { backgroundColor: '#5b45d6', borderRadius: 8, padding: 12 },
+  submitText: { color: '#fff', fontWeight: '700' },
+});

--- a/nftopia-mobile-app/src/services/moderation/report.service.ts
+++ b/nftopia-mobile-app/src/services/moderation/report.service.ts
@@ -1,0 +1,69 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import apiClient from '@/lib/api/sample';
+
+export type ReportTargetType = 'nft' | 'collection' | 'profile';
+export type ReportReason = 'spam' | 'copyright' | 'offensive' | 'scam' | 'other';
+
+export const REPORT_REASONS: Array<{ value: ReportReason; label: string }> = [
+  { value: 'spam', label: 'Spam or misleading content' },
+  { value: 'copyright', label: 'Copyright or intellectual property' },
+  { value: 'offensive', label: 'Offensive content' },
+  { value: 'scam', label: 'Scam or fraud' },
+  { value: 'other', label: 'Other' },
+];
+
+const REPORTS_KEY = 'moderation:reports';
+const RATE_LIMIT_MS = 60 * 1000;
+
+interface StoredReport {
+  targetType: ReportTargetType;
+  targetId: string;
+  submittedAt: number;
+}
+
+export interface ReportInput {
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+  details?: string;
+  hideForMe?: boolean;
+}
+
+export async function submitReport(input: ReportInput): Promise<void> {
+  const reports = await readReports();
+  const duplicate = reports.some(
+    (report) => report.targetType === input.targetType && report.targetId === input.targetId
+  );
+  if (duplicate) throw new Error('You have already reported this content.');
+
+  const latest = reports[reports.length - 1];
+  if (latest && Date.now() - latest.submittedAt < RATE_LIMIT_MS) {
+    throw new Error('Please wait before submitting another report.');
+  }
+
+  await apiClient.submitModerationReport(input);
+
+  await AsyncStorage.setItem(
+    REPORTS_KEY,
+    JSON.stringify([...reports, { ...input, submittedAt: Date.now() }])
+  );
+  if (input.hideForMe) await hideContent(input.targetType, input.targetId);
+}
+
+export async function isContentHidden(targetType: ReportTargetType, targetId: string): Promise<boolean> {
+  const hidden = await AsyncStorage.getItem(`moderation:hidden:${targetType}:${targetId}`);
+  return hidden === 'true';
+}
+
+async function hideContent(targetType: ReportTargetType, targetId: string): Promise<void> {
+  await AsyncStorage.setItem(`moderation:hidden:${targetType}:${targetId}`, 'true');
+}
+
+async function readReports(): Promise<StoredReport[]> {
+  try {
+    const raw = await AsyncStorage.getItem(REPORTS_KEY);
+    return raw ? (JSON.parse(raw) as StoredReport[]) : [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

Adds the in-app content reporting flow to the mobile app so users can report NFTs, collections, and profiles for spam, copyright, offensive content, scam, or other reasons directly from the app.

## Changes

- `nftopia-mobile-app/src/services/moderation/report.service.ts` (new): reporting service
  - Persists submitted reports in `AsyncStorage` under `moderation:reports` for duplicate detection and rate limiting.
  - Duplicate check: a target can only be reported once.
  - Rate limit: one report per 60 seconds.
  - Optional \"hide for me\": stores a local flag so reported content is filtered from the user's view.
- `nftopia-mobile-app/src/components/ReportModal.tsx` (new): bottom-sheet modal with reason selection (spam, copyright, offensive, scam, other), optional details (max 500 chars), hide-for-me toggle, and submit/cancel actions with success/error toasts.
- `nftopia-mobile-app/lib/api/sample.ts`: added `submitModerationReport(payload)` which POSTs to `/moderation/reports`.

## How it works

1. A user opens the report modal for a target (NFT / collection / profile).
2. They pick a reason, optionally add details and/or hide the content.
3. `submitReport` validates duplicates and the rate limit, then sends the report through `apiClient.submitModerationReport`.
4. On success the report is recorded locally and, if requested, the content is hidden.

## Testing

- `tsc --noEmit` passes for `nftopia-mobile-app` (replaced an ES2022-only `Array.prototype.at()` call; the app targets `lib: es2017`).
- Branch rebased onto the latest `main`.

## Notes

- Dedupe and rate limiting are enforced locally at submission time; the moderation dashboard/queue is handled by the backend.

Closes #474