### PR TITLE
feat(wallet): implement address book for saved recipients

### DIFF
--- a/nftopia-mobile-app/lib/stores/addressBookStore.ts
+++ b/nftopia-mobile-app/lib/stores/addressBookStore.ts
@@ -1,0 +1,6 @@
+/**
+ * Re-export address book store for lib/stores path compatibility.
+ * Primary implementation lives at @/stores/addressBookStore
+ */
+export * from '@/stores/addressBookStore';
+export { useAddressBookStore as default } from '@/stores/addressBookStore';

--- a/nftopia-mobile-app/screens/Wallet/AddressBookScreen.tsx
+++ b/nftopia-mobile-app/screens/Wallet/AddressBookScreen.tsx
@@ -1,0 +1,512 @@
+import React, { useState, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  TextInput,
+  Modal,
+  Alert,
+  ScrollView,
+} from 'react-native';
+import { colors, spacing, borderRadius, shadows } from '@/constants/theme';
+import {
+  useAddressBookStore,
+  isValidStellarAddress,
+  AddressBookEntry,
+  RecentRecipient,
+} from '@/stores/addressBookStore';
+import * as Clipboard from 'expo-clipboard';
+
+interface AddressBookScreenProps {
+  navigation?: any;
+}
+
+export function AddressBookScreen({ navigation }: AddressBookScreenProps) {
+  const {
+    entries,
+    recentRecipients,
+    addEntry,
+    updateEntry,
+    removeEntry,
+    getRecentRecipients,
+    exportData,
+    importData,
+    clearRecentRecipients,
+  } = useAddressBookStore();
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [editingEntry, setEditingEntry] = useState<AddressBookEntry | null>(null);
+  const [labelInput, setLabelInput] = useState('');
+  const [addressInput, setAddressInput] = useState('');
+  const [memoInput, setMemoInput] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [showImportModal, setShowImportModal] = useState(false);
+  const [importText, setImportText] = useState('');
+
+  const filteredEntries = useMemo(() => {
+    if (!searchQuery.trim()) return entries;
+    const lower = searchQuery.trim().toLowerCase();
+    return entries.filter(
+      (e) =>
+        e.label.toLowerCase().includes(lower) ||
+        e.address.toLowerCase().includes(lower) ||
+        (e.memo && e.memo.toLowerCase().includes(lower))
+    );
+  }, [entries, searchQuery]);
+
+  const recentFiltered = useMemo(() => {
+    // Show recents that are not already saved, optionally filtered by search
+    const recents = getRecentRecipients(true);
+    if (!searchQuery.trim()) return recents;
+    const lower = searchQuery.trim().toLowerCase();
+    return recents.filter((r) => r.address.toLowerCase().includes(lower));
+  }, [recentRecipients, entries, searchQuery, getRecentRecipients]);
+
+  const openAdd = () => {
+    setEditingEntry(null);
+    setLabelInput('');
+    setAddressInput('');
+    setMemoInput('');
+    setFormError(null);
+    setShowAddModal(true);
+  };
+
+  const openEdit = (entry: AddressBookEntry) => {
+    setEditingEntry(entry);
+    setLabelInput(entry.label);
+    setAddressInput(entry.address);
+    setMemoInput(entry.memo || '');
+    setFormError(null);
+    setShowAddModal(true);
+  };
+
+  const handleSave = () => {
+    setFormError(null);
+    if (!labelInput.trim()) {
+      setFormError('Label is required');
+      return;
+    }
+    if (!isValidStellarAddress(addressInput.trim())) {
+      setFormError('Invalid Stellar address');
+      return;
+    }
+
+    let result;
+    if (editingEntry) {
+      result = updateEntry(editingEntry.id, {
+        label: labelInput,
+        address: addressInput,
+        memo: memoInput,
+      });
+    } else {
+      result = addEntry(labelInput, addressInput, memoInput);
+    }
+
+    if (!result.success) {
+      setFormError(result.error || 'Failed to save');
+      return;
+    }
+
+    setShowAddModal(false);
+    setEditingEntry(null);
+    setLabelInput('');
+    setAddressInput('');
+    setMemoInput('');
+  };
+
+  const handleDelete = (entry: AddressBookEntry) => {
+    Alert.alert(
+      'Delete Contact',
+      `Are you sure you want to delete "${entry.label}"? This action cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            const result = removeEntry(entry.id);
+            if (!result.success) {
+              Alert.alert('Error', result.error || 'Failed to delete');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleCopy = async (address: string) => {
+    await Clipboard.setStringAsync(address);
+    Alert.alert('Copied', 'Address copied to clipboard');
+  };
+
+  const handleExport = async () => {
+    const data = exportData();
+    await Clipboard.setStringAsync(data);
+    Alert.alert('Exported', 'Address book JSON copied to clipboard');
+  };
+
+  const handleImport = () => {
+    const result = importData(importText);
+    if (!result.success) {
+      Alert.alert('Import failed', result.error || 'Invalid data');
+      return;
+    }
+    Alert.alert('Imported', `Successfully imported ${result.count} contact(s)`);
+    setShowImportModal(false);
+    setImportText('');
+  };
+
+  const handlePasteImport = async () => {
+    const text = await Clipboard.getStringAsync();
+    if (text) setImportText(text);
+  };
+
+  const renderEntry = ({ item }: { item: AddressBookEntry }) => (
+    <View style={styles.card}>
+      <View style={styles.cardHeader}>
+        <Text style={styles.label} numberOfLines={1}>
+          {item.label}
+        </Text>
+        <View style={styles.cardActions}>
+          <TouchableOpacity onPress={() => openEdit(item)} style={styles.smallBtn} accessibilityLabel={`Edit ${item.label}`}>
+            <Text style={styles.smallBtnText}>Edit</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => handleDelete(item)} style={[styles.smallBtn, styles.deleteBtn]} accessibilityLabel={`Delete ${item.label}`}>
+            <Text style={[styles.smallBtnText, styles.deleteBtnText]}>Delete</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+      <TouchableOpacity onPress={() => handleCopy(item.address)}>
+        <Text style={styles.address} numberOfLines={1}>
+          {item.address}
+        </Text>
+      </TouchableOpacity>
+      {item.memo ? <Text style={styles.memo}>Memo: {item.memo}</Text> : null}
+      <Text style={styles.meta}>Added {new Date(item.createdAt).toLocaleDateString()}</Text>
+    </View>
+  );
+
+  const renderRecent = ({ item }: { item: RecentRecipient }) => (
+    <View style={styles.recentItem}>
+      <Text style={styles.recentAddress} numberOfLines={1}>
+        {item.address}
+      </Text>
+      <Text style={styles.recentMeta}>
+        Sent {item.count}x · {new Date(item.lastSentAt).toLocaleDateString()}
+      </Text>
+      <TouchableOpacity onPress={() => handleCopy(item.address)} style={styles.smallBtn}>
+        <Text style={styles.smallBtnText}>Copy</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <View>
+          <Text style={styles.title}>Address Book</Text>
+          <Text style={styles.subtitle}>{entries.length} saved · {recentFiltered.length} recent</Text>
+        </View>
+        <TouchableOpacity style={styles.addButton} onPress={openAdd} accessibilityLabel="Add contact">
+          <Text style={styles.addButtonText}>+ Add</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.searchContainer}>
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search by label or address"
+          placeholderTextColor={colors.textTertiary}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          accessibilityLabel="Search address book"
+        />
+      </View>
+
+      <View style={styles.toolbar}>
+        <TouchableOpacity style={styles.toolbarBtn} onPress={handleExport} accessibilityLabel="Export address book">
+          <Text style={styles.toolbarBtnText}>Export</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.toolbarBtn} onPress={() => setShowImportModal(true)} accessibilityLabel="Import address book">
+          <Text style={styles.toolbarBtnText}>Import</Text>
+        </TouchableOpacity>
+        {recentRecipients.length > 0 && (
+          <TouchableOpacity
+            style={styles.toolbarBtn}
+            onPress={() =>
+              Alert.alert('Clear recents?', 'Remove all recently sent-to suggestions?', [
+                { text: 'Cancel', style: 'cancel' },
+                { text: 'Clear', style: 'destructive', onPress: () => clearRecentRecipients() },
+              ])
+            }
+          >
+            <Text style={styles.toolbarBtnText}>Clear Recents</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {recentFiltered.length > 0 && (
+        <View style={styles.recentSection}>
+          <Text style={styles.sectionTitle}>Recently Sent To</Text>
+          <FlatList
+            data={recentFiltered}
+            keyExtractor={(item) => item.address}
+            renderItem={renderRecent}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.recentList}
+          />
+        </View>
+      )}
+
+      <FlatList
+        data={filteredEntries}
+        keyExtractor={(item) => item.id}
+        renderItem={renderEntry}
+        contentContainerStyle={styles.listContent}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text style={styles.emptyIcon}>📒</Text>
+            <Text style={styles.emptyTitle}>No contacts yet</Text>
+            <Text style={styles.emptyMessage}>
+              {searchQuery ? 'No matches for your search' : 'Tap + Add to save a frequent recipient'}
+            </Text>
+          </View>
+        }
+      />
+
+      {/* Add / Edit Modal */}
+      <Modal visible={showAddModal} transparent animationType="slide" onRequestClose={() => setShowAddModal(false)}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>{editingEntry ? 'Edit Contact' : 'Add Contact'}</Text>
+              <TouchableOpacity onPress={() => setShowAddModal(false)}>
+                <Text style={styles.closeButton}>✕</Text>
+              </TouchableOpacity>
+            </View>
+            <ScrollView style={styles.modalBody} keyboardShouldPersistTaps="handled">
+              <Text style={styles.inputLabel}>Label *</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="e.g. Alice, Exchange, Savings"
+                placeholderTextColor={colors.textTertiary}
+                value={labelInput}
+                onChangeText={setLabelInput}
+                accessibilityLabel="Contact label"
+              />
+              <Text style={styles.inputLabel}>Stellar Address *</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="G..."
+                placeholderTextColor={colors.textTertiary}
+                value={addressInput}
+                onChangeText={setAddressInput}
+                autoCapitalize="none"
+                autoCorrect={false}
+                accessibilityLabel="Stellar address"
+              />
+              <Text style={styles.inputLabel}>Memo (optional)</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="Optional memo"
+                placeholderTextColor={colors.textTertiary}
+                value={memoInput}
+                onChangeText={setMemoInput}
+                accessibilityLabel="Memo"
+              />
+              {formError ? <Text style={styles.errorText}>{formError}</Text> : null}
+              <TouchableOpacity style={styles.primaryButton} onPress={handleSave} accessibilityLabel="Save contact">
+                <Text style={styles.primaryButtonText}>{editingEntry ? 'Update' : 'Save'}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.secondaryButton} onPress={() => setShowAddModal(false)}>
+                <Text style={styles.secondaryButtonText}>Cancel</Text>
+              </TouchableOpacity>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Import Modal */}
+      <Modal visible={showImportModal} transparent animationType="slide" onRequestClose={() => setShowImportModal(false)}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>Import Address Book</Text>
+              <TouchableOpacity onPress={() => setShowImportModal(false)}>
+                <Text style={styles.closeButton}>✕</Text>
+              </TouchableOpacity>
+            </View>
+            <ScrollView style={styles.modalBody}>
+              <Text style={styles.inputLabel}>Paste JSON</Text>
+              <TextInput
+                style={[styles.input, styles.importInput]}
+                placeholder='{"entries": [...]}'
+                placeholderTextColor={colors.textTertiary}
+                value={importText}
+                onChangeText={setImportText}
+                multiline
+                numberOfLines={6}
+                accessibilityLabel="Import JSON"
+              />
+              <TouchableOpacity style={styles.secondaryButton} onPress={handlePasteImport}>
+                <Text style={styles.secondaryButtonText}>Paste from Clipboard</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.primaryButton} onPress={handleImport}>
+                <Text style={styles.primaryButtonText}>Import</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.secondaryButton} onPress={() => setShowImportModal(false)}>
+                <Text style={styles.secondaryButtonText}>Cancel</Text>
+              </TouchableOpacity>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+export default AddressBookScreen;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  title: { fontSize: 20, fontWeight: '700', color: colors.text },
+  subtitle: { fontSize: 12, color: colors.textSecondary, marginTop: 2 },
+  addButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+  },
+  addButtonText: { color: '#fff', fontWeight: '600' },
+  searchContainer: { padding: spacing.md, paddingBottom: spacing.sm },
+  searchInput: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 14,
+    color: colors.text,
+  },
+  toolbar: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  toolbarBtn: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  toolbarBtnText: { fontSize: 12, fontWeight: '600', color: colors.text },
+  recentSection: { paddingVertical: spacing.sm, borderBottomWidth: 1, borderBottomColor: colors.border },
+  sectionTitle: { fontSize: 13, fontWeight: '600', color: colors.text, paddingHorizontal: spacing.md, marginBottom: spacing.sm },
+  recentList: { paddingHorizontal: spacing.md, gap: spacing.sm },
+  recentItem: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    padding: spacing.sm,
+    marginRight: spacing.sm,
+    minWidth: 180,
+  },
+  recentAddress: { fontSize: 12, fontFamily: 'monospace', color: colors.text, marginBottom: 4 },
+  recentMeta: { fontSize: 11, color: colors.textSecondary, marginBottom: spacing.xs },
+  listContent: { padding: spacing.md, paddingTop: spacing.sm },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    ...shadows.sm,
+  },
+  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: spacing.xs },
+  label: { fontSize: 15, fontWeight: '600', color: colors.text, flex: 1 },
+  cardActions: { flexDirection: 'row', gap: spacing.xs },
+  smallBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.background,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  deleteBtn: { borderColor: colors.error, backgroundColor: colors.errorBackground },
+  smallBtnText: { fontSize: 12, fontWeight: '600', color: colors.text },
+  deleteBtnText: { color: colors.error },
+  address: { fontSize: 12, fontFamily: 'monospace', color: colors.textSecondary, marginBottom: 2 },
+  memo: { fontSize: 12, color: colors.textTertiary, marginBottom: 2 },
+  meta: { fontSize: 11, color: colors.textTertiary, marginTop: spacing.xs },
+  empty: { alignItems: 'center', padding: spacing.xl },
+  emptyIcon: { fontSize: 48, marginBottom: spacing.md },
+  emptyTitle: { fontSize: 16, fontWeight: '600', color: colors.text, marginBottom: spacing.sm },
+  emptyMessage: { fontSize: 13, color: colors.textSecondary, textAlign: 'center' },
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  modalContent: {
+    backgroundColor: colors.background,
+    borderTopLeftRadius: borderRadius.lg,
+    borderTopRightRadius: borderRadius.lg,
+    maxHeight: '90%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  modalTitle: { fontSize: 18, fontWeight: '700', color: colors.text },
+  closeButton: { fontSize: 20, color: colors.textSecondary, padding: spacing.sm },
+  modalBody: { padding: spacing.lg },
+  inputLabel: { fontSize: 13, fontWeight: '600', color: colors.text, marginBottom: spacing.xs, marginTop: spacing.sm },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 14,
+    color: colors.text,
+    backgroundColor: colors.surface,
+  },
+  importInput: { minHeight: 120, textAlignVertical: 'top', fontFamily: 'monospace', fontSize: 12 },
+  errorText: { color: colors.error, fontSize: 13, marginTop: spacing.sm },
+  primaryButton: {
+    marginTop: spacing.lg,
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+  },
+  primaryButtonText: { color: '#fff', fontWeight: '600', fontSize: 15 },
+  secondaryButton: {
+    marginTop: spacing.sm,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  secondaryButtonText: { color: colors.text, fontWeight: '600' },
+});

--- a/nftopia-mobile-app/screens/Wallet/SendScreen.tsx
+++ b/nftopia-mobile-app/screens/Wallet/SendScreen.tsx
@@ -1,0 +1,445 @@
+import React, { useState, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  Modal,
+  FlatList,
+  Alert,
+  ScrollView,
+} from 'react-native';
+import { colors, spacing, borderRadius, shadows } from '@/constants/theme';
+import {
+  useAddressBookStore,
+  isValidStellarAddress,
+} from '@/stores/addressBookStore';
+
+interface SendScreenProps {
+  navigation?: any;
+  route?: any;
+  onSend?: (params: { address: string; amount: string; memo?: string }) => Promise<void>;
+}
+
+export function SendScreen({ navigation, route, onSend }: SendScreenProps) {
+  const { entries, recentRecipients, getRecentRecipients, addRecentRecipient } = useAddressBookStore();
+
+  const [recipient, setRecipient] = useState(route?.params?.prefilledAddress || '');
+  const [amount, setAmount] = useState('');
+  const [memo, setMemo] = useState('');
+  const [showPicker, setShowPicker] = useState(false);
+  const [pickerQuery, setPickerQuery] = useState('');
+  const [addressError, setAddressError] = useState<string | null>(null);
+
+  const recentFiltered = useMemo(() => {
+    // Exclude saved addresses from recent suggestions
+    const recents = getRecentRecipients(true);
+    if (!pickerQuery.trim() && !recipient.trim()) return recents;
+    // When picker is open, filter by pickerQuery; otherwise filter recents by recipient input for inline suggestion
+    const q = pickerQuery || recipient;
+    if (!q.trim()) return recents;
+    const lower = q.trim().toLowerCase();
+    return recents.filter((r) => r.address.toLowerCase().includes(lower));
+  }, [recentRecipients, entries, pickerQuery, recipient, getRecentRecipients]);
+
+  const filteredEntries = useMemo(() => {
+    if (!pickerQuery.trim()) return entries;
+    const lower = pickerQuery.trim().toLowerCase();
+    return entries.filter(
+      (e) => e.label.toLowerCase().includes(lower) || e.address.toLowerCase().includes(lower)
+    );
+  }, [entries, pickerQuery]);
+
+  const inlineRecentSuggestions = useMemo(() => {
+    // Show up to 5 recent suggestions inline below the recipient input when user types
+    if (!recipient.trim() || isValidStellarAddress(recipient.trim())) return [];
+    // Don't show if picker is open
+    if (showPicker) return [];
+    return recentFiltered.slice(0, 5);
+  }, [recentFiltered, recipient, showPicker]);
+
+  const handleSelectRecipient = (address: string) => {
+    setRecipient(address);
+    setAddressError(null);
+    setShowPicker(false);
+    setPickerQuery('');
+  };
+
+  const validateAddress = (addr: string): boolean => {
+    if (!addr.trim()) {
+      setAddressError('Recipient address is required');
+      return false;
+    }
+    if (!isValidStellarAddress(addr.trim())) {
+      setAddressError('Invalid Stellar address');
+      return false;
+    }
+    setAddressError(null);
+    return true;
+  };
+
+  const handleSend = async () => {
+    if (!validateAddress(recipient)) return;
+    if (!amount.trim() || isNaN(Number(amount)) || Number(amount) <= 0) {
+      Alert.alert('Error', 'Enter a valid amount');
+      return;
+    }
+
+    try {
+      if (onSend) {
+        await onSend({ address: recipient.trim(), amount: amount.trim(), memo: memo.trim() || undefined });
+      } else {
+        // Placeholder: in real app call wallet service
+        Alert.alert('Sent', `Would send ${amount} XLM to ${recipient}`);
+      }
+      // Record as recent recipient (unless already saved – still useful, but filtered in suggestions)
+      addRecentRecipient(recipient.trim());
+      // Clear form or navigate
+      if (navigation?.goBack) navigation.goBack();
+    } catch (e) {
+      Alert.alert('Send failed', e instanceof Error ? e.message : 'Unknown error');
+    }
+  };
+
+  const handleScan = () => {
+    Alert.alert('Scan', 'QR scan would be implemented via expo-barcode-scanner');
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+        <Text style={styles.title}>Send Funds</Text>
+
+        <Text style={styles.label}>Recipient Address *</Text>
+        <View style={styles.row}>
+          <TextInput
+            style={[styles.input, styles.flexInput, addressError ? styles.inputError : null]}
+            placeholder="G... Stellar address"
+            placeholderTextColor={colors.textTertiary}
+            value={recipient}
+            onChangeText={(t) => {
+              setRecipient(t);
+              if (addressError) setAddressError(null);
+            }}
+            onBlur={() => {
+              if (recipient.trim()) validateAddress(recipient);
+            }}
+            autoCapitalize="none"
+            autoCorrect={false}
+            accessibilityLabel="Recipient address"
+          />
+          <TouchableOpacity style={styles.scanBtn} onPress={handleScan} accessibilityLabel="Scan QR">
+            <Text style={styles.scanBtnText}>Scan</Text>
+          </TouchableOpacity>
+        </View>
+        {addressError ? <Text style={styles.errorText}>{addressError}</Text> : null}
+
+        {/* Inline recent suggestions */}
+        {inlineRecentSuggestions.length > 0 && (
+          <View style={styles.inlineSuggestions}>
+            <Text style={styles.suggestionTitle}>Recent — tap to fill</Text>
+            {inlineRecentSuggestions.map((r) => (
+              <TouchableOpacity
+                key={r.address}
+                style={styles.suggestionItem}
+                onPress={() => handleSelectRecipient(r.address)}
+                accessibilityLabel={`Use recent ${r.address}`}
+              >
+                <Text style={styles.suggestionAddress} numberOfLines={1}>
+                  {r.address}
+                </Text>
+                <Text style={styles.suggestionMeta}>
+                  {r.count}x · {new Date(r.lastSentAt).toLocaleDateString()}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+        <TouchableOpacity style={styles.pickerButton} onPress={() => setShowPicker(true)} accessibilityLabel="Choose from address book">
+          <Text style={styles.pickerButtonText}>📒 Choose from Address Book ({entries.length})</Text>
+        </TouchableOpacity>
+
+        {recentFiltered.length > 0 && !recipient.trim() && (
+          <View style={styles.recentSection}>
+            <Text style={styles.sectionTitle}>Recently Sent To (tap to select)</Text>
+            {recentFiltered.slice(0, 3).map((r) => (
+              <TouchableOpacity
+                key={r.address}
+                style={styles.recentChip}
+                onPress={() => handleSelectRecipient(r.address)}
+              >
+                <Text style={styles.recentChipText} numberOfLines={1}>
+                  {r.address.slice(0, 12)}...{r.address.slice(-6)}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+        <Text style={styles.label}>Amount (XLM) *</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="0.00"
+          placeholderTextColor={colors.textTertiary}
+          value={amount}
+          onChangeText={setAmount}
+          keyboardType="decimal-pad"
+          accessibilityLabel="Amount"
+        />
+
+        <Text style={styles.label}>Memo (optional)</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Optional memo"
+          placeholderTextColor={colors.textTertiary}
+          value={memo}
+          onChangeText={setMemo}
+          accessibilityLabel="Memo"
+        />
+
+        <TouchableOpacity style={styles.sendButton} onPress={handleSend} accessibilityLabel="Send funds">
+          <Text style={styles.sendButtonText}>Send</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity style={styles.secondaryButton} onPress={() => navigation?.goBack?.()} accessibilityLabel="Cancel">
+          <Text style={styles.secondaryButtonText}>Cancel</Text>
+        </TouchableOpacity>
+      </ScrollView>
+
+      {/* Recipient Picker Modal */}
+      <Modal visible={showPicker} transparent animationType="slide" onRequestClose={() => setShowPicker(false)}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>Select Recipient</Text>
+              <TouchableOpacity onPress={() => setShowPicker(false)}>
+                <Text style={styles.closeButton}>✕</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.pickerSearchContainer}>
+              <TextInput
+                style={styles.pickerSearch}
+                placeholder="Search address book"
+                placeholderTextColor={colors.textTertiary}
+                value={pickerQuery}
+                onChangeText={setPickerQuery}
+                accessibilityLabel="Search address book"
+              />
+            </View>
+
+            <Text style={styles.pickerSectionTitle}>Saved Contacts</Text>
+            <FlatList
+              data={filteredEntries}
+              keyExtractor={(item) => item.id}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={styles.pickerItem}
+                  onPress={() => handleSelectRecipient(item.address)}
+                  accessibilityLabel={`Select ${item.label}`}
+                >
+                  <Text style={styles.pickerLabel}>{item.label}</Text>
+                  <Text style={styles.pickerAddress} numberOfLines={1}>
+                    {item.address}
+                  </Text>
+                </TouchableOpacity>
+              )}
+              ListEmptyComponent={
+                <View style={styles.pickerEmpty}>
+                  <Text style={styles.pickerEmptyText}>
+                    {entries.length === 0 ? 'No saved contacts' : 'No matches'}
+                  </Text>
+                  <TouchableOpacity
+                    onPress={() => {
+                      setShowPicker(false);
+                      navigation?.navigate?.('AddressBook');
+                    }}
+                  >
+                    <Text style={styles.linkText}>Go to Address Book</Text>
+                  </TouchableOpacity>
+                </View>
+              }
+              style={styles.pickerList}
+            />
+
+            {recentFiltered.length > 0 && (
+              <>
+                <Text style={styles.pickerSectionTitle}>Recently Sent To</Text>
+                <FlatList
+                  data={recentFiltered}
+                  keyExtractor={(item) => item.address}
+                  renderItem={({ item }) => (
+                    <TouchableOpacity
+                      style={styles.pickerItem}
+                      onPress={() => handleSelectRecipient(item.address)}
+                      accessibilityLabel={`Select recent ${item.address}`}
+                    >
+                      <Text style={styles.pickerLabel}>Recent · {item.count}x</Text>
+                      <Text style={styles.pickerAddress} numberOfLines={1}>
+                        {item.address}
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+                  style={styles.pickerListShort}
+                />
+              </>
+            )}
+
+            <TouchableOpacity style={styles.modalCloseBtn} onPress={() => setShowPicker(false)}>
+              <Text style={styles.modalCloseBtnText}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+export default SendScreen;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  content: { padding: spacing.lg },
+  title: { fontSize: 22, fontWeight: '700', color: colors.text, marginBottom: spacing.lg },
+  label: { fontSize: 13, fontWeight: '600', color: colors.text, marginTop: spacing.md, marginBottom: spacing.xs },
+  row: { flexDirection: 'row', gap: spacing.sm, alignItems: 'center' },
+  flexInput: { flex: 1 },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 14,
+    color: colors.text,
+    backgroundColor: colors.surface,
+  },
+  inputError: { borderColor: colors.error },
+  errorText: { color: colors.error, fontSize: 12, marginTop: spacing.xs },
+  scanBtn: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  scanBtnText: { fontWeight: '600', color: colors.text, fontSize: 13 },
+  pickerButton: {
+    marginTop: spacing.md,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    alignItems: 'center',
+  },
+  pickerButtonText: { fontWeight: '600', color: colors.primary, fontSize: 14 },
+  recentSection: { marginTop: spacing.md },
+  sectionTitle: { fontSize: 12, fontWeight: '600', color: colors.textSecondary, marginBottom: spacing.xs },
+  recentChip: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  recentChipText: { fontSize: 12, fontFamily: 'monospace', color: colors.text },
+  inlineSuggestions: {
+    marginTop: spacing.sm,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    padding: spacing.sm,
+  },
+  suggestionTitle: { fontSize: 12, fontWeight: '600', color: colors.textSecondary, marginBottom: spacing.xs },
+  suggestionItem: {
+    paddingVertical: spacing.xs,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderLight,
+  },
+  suggestionAddress: { fontSize: 12, fontFamily: 'monospace', color: colors.text },
+  suggestionMeta: { fontSize: 11, color: colors.textTertiary },
+  sendButton: {
+    marginTop: spacing.lg,
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+  },
+  sendButtonText: { color: '#fff', fontWeight: '700', fontSize: 15 },
+  secondaryButton: {
+    marginTop: spacing.sm,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  secondaryButtonText: { color: colors.text, fontWeight: '600' },
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  modalContent: {
+    backgroundColor: colors.background,
+    borderTopLeftRadius: borderRadius.lg,
+    borderTopRightRadius: borderRadius.lg,
+    maxHeight: '90%',
+    paddingBottom: spacing.lg,
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  modalTitle: { fontSize: 18, fontWeight: '700', color: colors.text },
+  closeButton: { fontSize: 20, color: colors.textSecondary, padding: spacing.sm },
+  pickerSearchContainer: { padding: spacing.md },
+  pickerSearch: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 14,
+    color: colors.text,
+  },
+  pickerSectionTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    paddingHorizontal: spacing.md,
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  pickerList: { maxHeight: 250 },
+  pickerListShort: { maxHeight: 150 },
+  pickerItem: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderLight,
+  },
+  pickerLabel: { fontSize: 14, fontWeight: '600', color: colors.text },
+  pickerAddress: { fontSize: 12, fontFamily: 'monospace', color: colors.textSecondary, marginTop: 2 },
+  pickerEmpty: { alignItems: 'center', padding: spacing.lg },
+  pickerEmptyText: { fontSize: 13, color: colors.textSecondary, marginBottom: spacing.sm },
+  linkText: { color: colors.info, fontWeight: '600', fontSize: 13 },
+  modalCloseBtn: {
+    marginHorizontal: spacing.md,
+    marginTop: spacing.md,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: 'center',
+  },
+  modalCloseBtnText: { fontWeight: '600', color: colors.text },
+});

--- a/nftopia-mobile-app/screens/Wallet/components/RecipientPicker.tsx
+++ b/nftopia-mobile-app/screens/Wallet/components/RecipientPicker.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, FlatList, StyleSheet, Modal } from 'react-native';
+import { colors, spacing, borderRadius } from '@/constants/theme';
+import { useAddressBookStore } from '@/stores/addressBookStore';
+
+interface RecipientPickerProps {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (address: string) => void;
+}
+
+export function RecipientPicker({ visible, onClose, onSelect }: RecipientPickerProps) {
+  const { entries, recentRecipients, getRecentRecipients } = useAddressBookStore();
+  const [query, setQuery] = useState('');
+
+  const filteredEntries = useMemo(() => {
+    if (!query.trim()) return entries;
+    const lower = query.trim().toLowerCase();
+    return entries.filter((e) => e.label.toLowerCase().includes(lower) || e.address.toLowerCase().includes(lower));
+  }, [entries, query]);
+
+  const recentFiltered = useMemo(() => {
+    const recents = getRecentRecipients(true);
+    if (!query.trim()) return recents;
+    const lower = query.trim().toLowerCase();
+    return recents.filter((r) => r.address.toLowerCase().includes(lower));
+  }, [query, entries, recentRecipients, getRecentRecipients]);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.content}>
+          <View style={styles.header}>
+            <Text style={styles.title}>Select Recipient</Text>
+            <TouchableOpacity onPress={onClose}>
+              <Text style={styles.close}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.searchContainer}>
+            <TextInput
+              style={styles.search}
+              placeholder="Search address book"
+              placeholderTextColor={colors.textTertiary}
+              value={query}
+              onChangeText={setQuery}
+              accessibilityLabel="Search address book"
+            />
+          </View>
+
+          <Text style={styles.sectionTitle}>Saved Contacts</Text>
+          <FlatList
+            data={filteredEntries}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <TouchableOpacity style={styles.item} onPress={() => onSelect(item.address)}>
+                <Text style={styles.label}>{item.label}</Text>
+                <Text style={styles.address} numberOfLines={1}>{item.address}</Text>
+              </TouchableOpacity>
+            )}
+            ListEmptyComponent={<Text style={styles.emptyText}>{entries.length === 0 ? 'No saved contacts' : 'No matches'}</Text>}
+            style={styles.list}
+          />
+
+          {recentFiltered.length > 0 && (
+            <>
+              <Text style={styles.sectionTitle}>Recently Sent To</Text>
+              <FlatList
+                data={recentFiltered}
+                keyExtractor={(item) => item.address}
+                renderItem={({ item }) => (
+                  <TouchableOpacity style={styles.item} onPress={() => onSelect(item.address)}>
+                    <Text style={styles.label}>Recent · {item.count}x</Text>
+                    <Text style={styles.address} numberOfLines={1}>{item.address}</Text>
+                  </TouchableOpacity>
+                )}
+                style={styles.listShort}
+              />
+            </>
+          )}
+
+          <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+            <Text style={styles.closeBtnText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+export default RecipientPicker;
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  content: {
+    backgroundColor: colors.background,
+    borderTopLeftRadius: borderRadius.lg,
+    borderTopRightRadius: borderRadius.lg,
+    maxHeight: '90%',
+    paddingBottom: spacing.lg,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  title: { fontSize: 18, fontWeight: '700', color: colors.text },
+  close: { fontSize: 20, color: colors.textSecondary, padding: spacing.sm },
+  searchContainer: { padding: spacing.md },
+  search: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 14,
+    color: colors.text,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    paddingHorizontal: spacing.md,
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  list: { maxHeight: 250 },
+  listShort: { maxHeight: 150 },
+  item: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderLight,
+  },
+  label: { fontSize: 14, fontWeight: '600', color: colors.text },
+  address: { fontSize: 12, fontFamily: 'monospace', color: colors.textSecondary, marginTop: 2 },
+  emptyText: { textAlign: 'center', color: colors.textSecondary, padding: spacing.lg, fontSize: 13 },
+  closeBtn: {
+    marginHorizontal: spacing.md,
+    marginTop: spacing.md,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: 'center',
+  },
+  closeBtnText: { fontWeight: '600', color: colors.text },
+});

--- a/nftopia-mobile-app/src/stores/__tests__/addressBookStore.test.ts
+++ b/nftopia-mobile-app/src/stores/__tests__/addressBookStore.test.ts
@@ -1,0 +1,326 @@
+import { Keypair } from 'stellar-sdk';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+const asyncStorageStore: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((key: string) => Promise.resolve(asyncStorageStore[key] ?? null)),
+  setItem: jest.fn((key: string, value: string) => {
+    asyncStorageStore[key] = value;
+    return Promise.resolve();
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete asyncStorageStore[key];
+    return Promise.resolve();
+  }),
+  getAllKeys: jest.fn(() => Promise.resolve(Object.keys(asyncStorageStore))),
+  multiGet: jest.fn(),
+  multiSet: jest.fn(),
+  multiRemove: jest.fn(),
+}));
+
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+  getStringAsync: jest.fn(),
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import {
+  useAddressBookStore,
+  isValidStellarAddress,
+  filterAddressBook,
+} from '../addressBookStore';
+
+// Helpers
+function randomAddress(): string {
+  return Keypair.random().publicKey();
+}
+const INVALID_ADDRESS = 'GINVALIDADDRESS12345678901234567890123456789012345678901234';
+
+function getStore() {
+  return useAddressBookStore.getState();
+}
+
+describe('addressBookStore', () => {
+  beforeEach(() => {
+    useAddressBookStore.setState({ entries: [], recentRecipients: [] });
+    Object.keys(asyncStorageStore).forEach((k) => delete asyncStorageStore[k]);
+    jest.clearAllMocks();
+  });
+
+  describe('isValidStellarAddress', () => {
+    it('returns true for a valid Stellar address', () => {
+      expect(isValidStellarAddress(randomAddress())).toBe(true);
+    });
+    it('returns false for invalid address', () => {
+      expect(isValidStellarAddress(INVALID_ADDRESS)).toBe(false);
+    });
+    it('returns false for empty', () => {
+      expect(isValidStellarAddress('')).toBe(false);
+    });
+  });
+
+  describe('filterAddressBook', () => {
+    it('filters by label case-insensitive', () => {
+      const entries = [
+        { id: '1', label: 'Alice', address: randomAddress(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+        { id: '2', label: 'Bob', address: randomAddress(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      ];
+      expect(filterAddressBook(entries, 'alice')).toHaveLength(1);
+      expect(filterAddressBook(entries, 'ALICE')).toHaveLength(1);
+    });
+    it('filters by address substring', () => {
+      const addr = randomAddress();
+      const entries = [
+        { id: '1', label: 'Alice', address: addr, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      ];
+      expect(filterAddressBook(entries, addr.slice(0, 5))).toHaveLength(1);
+      expect(filterAddressBook(entries, 'ZZZZ')).toHaveLength(0);
+    });
+    it('returns all when query empty', () => {
+      const entries = [
+        { id: '1', label: ' Alice', address: randomAddress(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      ];
+      expect(filterAddressBook(entries, '')).toHaveLength(1);
+      expect(filterAddressBook(entries, '   ')).toHaveLength(1);
+    });
+  });
+
+  describe('addEntry', () => {
+    it('adds a valid entry', () => {
+      const addr = randomAddress();
+      const result = getStore().addEntry('Alice', addr);
+      expect(result.success).toBe(true);
+      expect(result.entry).toBeDefined();
+      expect(getStore().entries).toHaveLength(1);
+      expect(getStore().entries[0].label).toBe('Alice');
+      expect(getStore().entries[0].address).toBe(addr);
+    });
+
+    it('rejects duplicate addresses', () => {
+      const addr = randomAddress();
+      expect(getStore().addEntry('Alice', addr).success).toBe(true);
+      const dup = getStore().addEntry('Bob', addr);
+      expect(dup.success).toBe(false);
+      expect(dup.error).toMatch(/already saved/i);
+      expect(getStore().entries).toHaveLength(1);
+    });
+
+    it('rejects invalid address with clear message', () => {
+      const result = getStore().addEntry('Alice', INVALID_ADDRESS);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Invalid Stellar address/i);
+    });
+
+    it('rejects empty label', () => {
+      const result = getStore().addEntry('', randomAddress());
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Label is required/i);
+    });
+
+    it('trims whitespace', () => {
+      const addr = randomAddress();
+      const result = getStore().addEntry('  Alice  ', `  ${addr}  `);
+      expect(result.success).toBe(true);
+      expect(getStore().entries[0].label).toBe('Alice');
+      expect(getStore().entries[0].address).toBe(addr);
+    });
+
+    it('persists across store state (entries length check)', () => {
+      // Simple persistence check via store state – AsyncStorage mock will store under address-book-storage
+      const addr = randomAddress();
+      getStore().addEntry('Persisted', addr);
+      expect(getStore().entries).toHaveLength(1);
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('updates label and address', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      const { entry } = getStore().addEntry('Alice', addr1);
+      const result = getStore().updateEntry(entry!.id, { label: 'Alice Updated', address: addr2 });
+      expect(result.success).toBe(true);
+      expect(getStore().entries[0].label).toBe('Alice Updated');
+      expect(getStore().entries[0].address).toBe(addr2);
+    });
+
+    it('rejects duplicate on update', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      const e1 = getStore().addEntry('Alice', addr1).entry!;
+      const e2 = getStore().addEntry('Bob', addr2).entry!;
+      const result = getStore().updateEntry(e2.id, { address: addr1 });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/already saved/i);
+    });
+
+    it('rejects invalid address on update', () => {
+      const addr = randomAddress();
+      const { entry } = getStore().addEntry('Alice', addr);
+      const result = getStore().updateEntry(entry!.id, { address: INVALID_ADDRESS });
+      expect(result.success).toBe(false);
+    });
+
+    it('returns error for non-existent id', () => {
+      const result = getStore().updateEntry('nonexistent', { label: 'Foo' });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not found/i);
+    });
+  });
+
+  describe('removeEntry', () => {
+    it('removes an entry', () => {
+      const addr = randomAddress();
+      const { entry } = getStore().addEntry('Alice', addr);
+      expect(getStore().entries).toHaveLength(1);
+      const result = getStore().removeEntry(entry!.id);
+      expect(result.success).toBe(true);
+      expect(getStore().entries).toHaveLength(0);
+    });
+
+    it('returns error for non-existent id', () => {
+      const result = getStore().removeEntry('nope');
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('searchEntries', () => {
+    it('correctly filters the address book list', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      getStore().addEntry('Alice Wonderland', addr1);
+      getStore().addEntry('Bob Builder', addr2);
+      expect(getStore().searchEntries('alice')).toHaveLength(1);
+      expect(getStore().searchEntries('builder')).toHaveLength(1);
+      expect(getStore().searchEntries('nonexistent')).toHaveLength(0);
+      expect(getStore().searchEntries('')).toHaveLength(2);
+    });
+  });
+
+  describe('recentRecipients', () => {
+    it('adds recent recipients and deduplicates with count increment', () => {
+      const addr = randomAddress();
+      getStore().addRecentRecipient(addr);
+      expect(getStore().recentRecipients).toHaveLength(1);
+      expect(getStore().recentRecipients[0].count).toBe(1);
+      getStore().addRecentRecipient(addr);
+      expect(getStore().recentRecipients).toHaveLength(1);
+      expect(getStore().recentRecipients[0].count).toBe(2);
+    });
+
+    it('suggests recently sent-to addresses without being permanently saved', () => {
+      const addr = randomAddress();
+      getStore().addRecentRecipient(addr);
+      // Should appear in recents
+      expect(getStore().getRecentRecipients(false)).toHaveLength(1);
+      // Not in saved entries
+      expect(getStore().entries).toHaveLength(0);
+      // getRecentRecipients(true) should still return it since not saved
+      expect(getStore().getRecentRecipients(true)).toHaveLength(1);
+      // After saving the same address, recent suggestion should be filtered out
+      getStore().addEntry('Alice', addr);
+      expect(getStore().getRecentRecipients(true)).toHaveLength(0);
+      // But with excludeSaved false it still appears
+      expect(getStore().getRecentRecipients(false)).toHaveLength(1);
+    });
+
+    it('ignores invalid addresses for recents', () => {
+      getStore().addRecentRecipient(INVALID_ADDRESS);
+      expect(getStore().recentRecipients).toHaveLength(0);
+    });
+
+    it('clearRecentRecipients empties list', () => {
+      getStore().addRecentRecipient(randomAddress());
+      getStore().addRecentRecipient(randomAddress());
+      expect(getStore().recentRecipients.length).toBeGreaterThan(0);
+      getStore().clearRecentRecipients();
+      expect(getStore().recentRecipients).toHaveLength(0);
+    });
+
+    it('caps recent list at 20', () => {
+      for (let i = 0; i < 25; i++) {
+        getStore().addRecentRecipient(randomAddress());
+      }
+      expect(getStore().recentRecipients).toHaveLength(20);
+    });
+
+    it('reorders recent on re-add (most recent first)', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      getStore().addRecentRecipient(addr1);
+      getStore().addRecentRecipient(addr2);
+      expect(getStore().recentRecipients[0].address).toBe(addr2);
+      // Re-add addr1 -> should move to front
+      getStore().addRecentRecipient(addr1);
+      expect(getStore().recentRecipients[0].address).toBe(addr1);
+    });
+  });
+
+  describe('export/import', () => {
+    it('exportData returns JSON with entries', () => {
+      const addr = randomAddress();
+      getStore().addEntry('Alice', addr);
+      const json = getStore().exportData();
+      const parsed = JSON.parse(json);
+      expect(parsed.entries).toHaveLength(1);
+      expect(parsed.entries[0].address).toBe(addr);
+      expect(parsed.version).toBe(1);
+    });
+
+    it('importData merges valid entries and skips duplicates', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      getStore().addEntry('Alice', addr1);
+      const payload = JSON.stringify({
+        entries: [
+          { label: 'Bob', address: addr2 },
+          { label: 'Duplicate', address: addr1 },
+          { label: 'Bad', address: INVALID_ADDRESS },
+        ],
+        recentRecipients: [],
+        version: 1,
+        exportedAt: new Date().toISOString(),
+      });
+      const result = getStore().importData(payload);
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(1);
+      expect(getStore().entries).toHaveLength(2);
+      expect(getStore().entries.find((e: any) => e.address === addr2)).toBeDefined();
+    });
+
+    it('importData handles raw array format', () => {
+      const addr = randomAddress();
+      const json = JSON.stringify([{ label: 'Dave', address: addr }]);
+      const result = getStore().importData(json);
+      expect(result.success).toBe(true);
+      expect(getStore().entries).toHaveLength(1);
+    });
+
+    it('importData returns error for invalid JSON', () => {
+      const result = getStore().importData('not json');
+      expect(result.success).toBe(false);
+    });
+
+    it('importData returns error for invalid format', () => {
+      const result = getStore().importData(JSON.stringify({ foo: 'bar' }));
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('clears both entries and recents', () => {
+      getStore().addEntry('Alice', randomAddress());
+      getStore().addRecentRecipient(randomAddress());
+      getStore().clearAll();
+      expect(getStore().entries).toHaveLength(0);
+      expect(getStore().recentRecipients).toHaveLength(0);
+    });
+  });
+});

--- a/nftopia-mobile-app/src/stores/addressBookStore.ts
+++ b/nftopia-mobile-app/src/stores/addressBookStore.ts
@@ -1,0 +1,2 @@
+export * from '@/stores/addressBookStore';
+export { useAddressBookStore as default } from '@/stores/addressBookStore';

--- a/nftopia-mobile-app/stores/__tests__/addressBookStore.test.ts
+++ b/nftopia-mobile-app/stores/__tests__/addressBookStore.test.ts
@@ -1,0 +1,326 @@
+import { Keypair } from 'stellar-sdk';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+const asyncStorageStore: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((key: string) => Promise.resolve(asyncStorageStore[key] ?? null)),
+  setItem: jest.fn((key: string, value: string) => {
+    asyncStorageStore[key] = value;
+    return Promise.resolve();
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete asyncStorageStore[key];
+    return Promise.resolve();
+  }),
+  getAllKeys: jest.fn(() => Promise.resolve(Object.keys(asyncStorageStore))),
+  multiGet: jest.fn(),
+  multiSet: jest.fn(),
+  multiRemove: jest.fn(),
+}));
+
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+  getStringAsync: jest.fn(),
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import {
+  useAddressBookStore,
+  isValidStellarAddress,
+  filterAddressBook,
+} from '../addressBookStore';
+
+// Helpers
+function randomAddress(): string {
+  return Keypair.random().publicKey();
+}
+const INVALID_ADDRESS = 'GINVALIDADDRESS12345678901234567890123456789012345678901234';
+
+function getStore() {
+  return useAddressBookStore.getState();
+}
+
+describe('addressBookStore', () => {
+  beforeEach(() => {
+    useAddressBookStore.setState({ entries: [], recentRecipients: [] });
+    Object.keys(asyncStorageStore).forEach((k) => delete asyncStorageStore[k]);
+    jest.clearAllMocks();
+  });
+
+  describe('isValidStellarAddress', () => {
+    it('returns true for a valid Stellar address', () => {
+      expect(isValidStellarAddress(randomAddress())).toBe(true);
+    });
+    it('returns false for invalid address', () => {
+      expect(isValidStellarAddress(INVALID_ADDRESS)).toBe(false);
+    });
+    it('returns false for empty', () => {
+      expect(isValidStellarAddress('')).toBe(false);
+    });
+  });
+
+  describe('filterAddressBook', () => {
+    it('filters by label case-insensitive', () => {
+      const entries = [
+        { id: '1', label: 'Alice', address: randomAddress(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+        { id: '2', label: 'Bob', address: randomAddress(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      ];
+      expect(filterAddressBook(entries, 'alice')).toHaveLength(1);
+      expect(filterAddressBook(entries, 'ALICE')).toHaveLength(1);
+    });
+    it('filters by address substring', () => {
+      const addr = randomAddress();
+      const entries = [
+        { id: '1', label: 'Alice', address: addr, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      ];
+      expect(filterAddressBook(entries, addr.slice(0, 5))).toHaveLength(1);
+      expect(filterAddressBook(entries, 'ZZZZ')).toHaveLength(0);
+    });
+    it('returns all when query empty', () => {
+      const entries = [
+        { id: '1', label: ' Alice', address: randomAddress(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      ];
+      expect(filterAddressBook(entries, '')).toHaveLength(1);
+      expect(filterAddressBook(entries, '   ')).toHaveLength(1);
+    });
+  });
+
+  describe('addEntry', () => {
+    it('adds a valid entry', () => {
+      const addr = randomAddress();
+      const result = getStore().addEntry('Alice', addr);
+      expect(result.success).toBe(true);
+      expect(result.entry).toBeDefined();
+      expect(getStore().entries).toHaveLength(1);
+      expect(getStore().entries[0].label).toBe('Alice');
+      expect(getStore().entries[0].address).toBe(addr);
+    });
+
+    it('rejects duplicate addresses', () => {
+      const addr = randomAddress();
+      expect(getStore().addEntry('Alice', addr).success).toBe(true);
+      const dup = getStore().addEntry('Bob', addr);
+      expect(dup.success).toBe(false);
+      expect(dup.error).toMatch(/already saved/i);
+      expect(getStore().entries).toHaveLength(1);
+    });
+
+    it('rejects invalid address with clear message', () => {
+      const result = getStore().addEntry('Alice', INVALID_ADDRESS);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Invalid Stellar address/i);
+    });
+
+    it('rejects empty label', () => {
+      const result = getStore().addEntry('', randomAddress());
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Label is required/i);
+    });
+
+    it('trims whitespace', () => {
+      const addr = randomAddress();
+      const result = getStore().addEntry('  Alice  ', `  ${addr}  `);
+      expect(result.success).toBe(true);
+      expect(getStore().entries[0].label).toBe('Alice');
+      expect(getStore().entries[0].address).toBe(addr);
+    });
+
+    it('persists across store state (entries length check)', () => {
+      // Simple persistence check via store state – AsyncStorage mock will store under address-book-storage
+      const addr = randomAddress();
+      getStore().addEntry('Persisted', addr);
+      expect(getStore().entries).toHaveLength(1);
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('updates label and address', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      const { entry } = getStore().addEntry('Alice', addr1);
+      const result = getStore().updateEntry(entry!.id, { label: 'Alice Updated', address: addr2 });
+      expect(result.success).toBe(true);
+      expect(getStore().entries[0].label).toBe('Alice Updated');
+      expect(getStore().entries[0].address).toBe(addr2);
+    });
+
+    it('rejects duplicate on update', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      const e1 = getStore().addEntry('Alice', addr1).entry!;
+      const e2 = getStore().addEntry('Bob', addr2).entry!;
+      const result = getStore().updateEntry(e2.id, { address: addr1 });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/already saved/i);
+    });
+
+    it('rejects invalid address on update', () => {
+      const addr = randomAddress();
+      const { entry } = getStore().addEntry('Alice', addr);
+      const result = getStore().updateEntry(entry!.id, { address: INVALID_ADDRESS });
+      expect(result.success).toBe(false);
+    });
+
+    it('returns error for non-existent id', () => {
+      const result = getStore().updateEntry('nonexistent', { label: 'Foo' });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not found/i);
+    });
+  });
+
+  describe('removeEntry', () => {
+    it('removes an entry', () => {
+      const addr = randomAddress();
+      const { entry } = getStore().addEntry('Alice', addr);
+      expect(getStore().entries).toHaveLength(1);
+      const result = getStore().removeEntry(entry!.id);
+      expect(result.success).toBe(true);
+      expect(getStore().entries).toHaveLength(0);
+    });
+
+    it('returns error for non-existent id', () => {
+      const result = getStore().removeEntry('nope');
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('searchEntries', () => {
+    it('correctly filters the address book list', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      getStore().addEntry('Alice Wonderland', addr1);
+      getStore().addEntry('Bob Builder', addr2);
+      expect(getStore().searchEntries('alice')).toHaveLength(1);
+      expect(getStore().searchEntries('builder')).toHaveLength(1);
+      expect(getStore().searchEntries('nonexistent')).toHaveLength(0);
+      expect(getStore().searchEntries('')).toHaveLength(2);
+    });
+  });
+
+  describe('recentRecipients', () => {
+    it('adds recent recipients and deduplicates with count increment', () => {
+      const addr = randomAddress();
+      getStore().addRecentRecipient(addr);
+      expect(getStore().recentRecipients).toHaveLength(1);
+      expect(getStore().recentRecipients[0].count).toBe(1);
+      getStore().addRecentRecipient(addr);
+      expect(getStore().recentRecipients).toHaveLength(1);
+      expect(getStore().recentRecipients[0].count).toBe(2);
+    });
+
+    it('suggests recently sent-to addresses without being permanently saved', () => {
+      const addr = randomAddress();
+      getStore().addRecentRecipient(addr);
+      // Should appear in recents
+      expect(getStore().getRecentRecipients(false)).toHaveLength(1);
+      // Not in saved entries
+      expect(getStore().entries).toHaveLength(0);
+      // getRecentRecipients(true) should still return it since not saved
+      expect(getStore().getRecentRecipients(true)).toHaveLength(1);
+      // After saving the same address, recent suggestion should be filtered out
+      getStore().addEntry('Alice', addr);
+      expect(getStore().getRecentRecipients(true)).toHaveLength(0);
+      // But with excludeSaved false it still appears
+      expect(getStore().getRecentRecipients(false)).toHaveLength(1);
+    });
+
+    it('ignores invalid addresses for recents', () => {
+      getStore().addRecentRecipient(INVALID_ADDRESS);
+      expect(getStore().recentRecipients).toHaveLength(0);
+    });
+
+    it('clearRecentRecipients empties list', () => {
+      getStore().addRecentRecipient(randomAddress());
+      getStore().addRecentRecipient(randomAddress());
+      expect(getStore().recentRecipients.length).toBeGreaterThan(0);
+      getStore().clearRecentRecipients();
+      expect(getStore().recentRecipients).toHaveLength(0);
+    });
+
+    it('caps recent list at 20', () => {
+      for (let i = 0; i < 25; i++) {
+        getStore().addRecentRecipient(randomAddress());
+      }
+      expect(getStore().recentRecipients).toHaveLength(20);
+    });
+
+    it('reorders recent on re-add (most recent first)', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      getStore().addRecentRecipient(addr1);
+      getStore().addRecentRecipient(addr2);
+      expect(getStore().recentRecipients[0].address).toBe(addr2);
+      // Re-add addr1 -> should move to front
+      getStore().addRecentRecipient(addr1);
+      expect(getStore().recentRecipients[0].address).toBe(addr1);
+    });
+  });
+
+  describe('export/import', () => {
+    it('exportData returns JSON with entries', () => {
+      const addr = randomAddress();
+      getStore().addEntry('Alice', addr);
+      const json = getStore().exportData();
+      const parsed = JSON.parse(json);
+      expect(parsed.entries).toHaveLength(1);
+      expect(parsed.entries[0].address).toBe(addr);
+      expect(parsed.version).toBe(1);
+    });
+
+    it('importData merges valid entries and skips duplicates', () => {
+      const addr1 = randomAddress();
+      const addr2 = randomAddress();
+      getStore().addEntry('Alice', addr1);
+      const payload = JSON.stringify({
+        entries: [
+          { label: 'Bob', address: addr2 },
+          { label: 'Duplicate', address: addr1 },
+          { label: 'Bad', address: INVALID_ADDRESS },
+        ],
+        recentRecipients: [],
+        version: 1,
+        exportedAt: new Date().toISOString(),
+      });
+      const result = getStore().importData(payload);
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(1);
+      expect(getStore().entries).toHaveLength(2);
+      expect(getStore().entries.find((e: any) => e.address === addr2)).toBeDefined();
+    });
+
+    it('importData handles raw array format', () => {
+      const addr = randomAddress();
+      const json = JSON.stringify([{ label: 'Dave', address: addr }]);
+      const result = getStore().importData(json);
+      expect(result.success).toBe(true);
+      expect(getStore().entries).toHaveLength(1);
+    });
+
+    it('importData returns error for invalid JSON', () => {
+      const result = getStore().importData('not json');
+      expect(result.success).toBe(false);
+    });
+
+    it('importData returns error for invalid format', () => {
+      const result = getStore().importData(JSON.stringify({ foo: 'bar' }));
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('clears both entries and recents', () => {
+      getStore().addEntry('Alice', randomAddress());
+      getStore().addRecentRecipient(randomAddress());
+      getStore().clearAll();
+      expect(getStore().entries).toHaveLength(0);
+      expect(getStore().recentRecipients).toHaveLength(0);
+    });
+  });
+});

--- a/nftopia-mobile-app/stores/addressBookStore.ts
+++ b/nftopia-mobile-app/stores/addressBookStore.ts
@@ -1,0 +1,340 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { StrKey } from 'stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+export interface AddressBookEntry {
+  id: string;
+  label: string;
+  address: string;
+  memo?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RecentRecipient {
+  address: string;
+  lastSentAt: string;
+  count: number;
+}
+
+export interface ExportData {
+  entries: AddressBookEntry[];
+  recentRecipients: RecentRecipient[];
+  exportedAt: string;
+  version: number;
+}
+
+export interface OperationResult {
+  success: boolean;
+  error?: string;
+  entry?: AddressBookEntry;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers – exported for unit testing and screen usage
+// ---------------------------------------------------------------------------
+export function isValidStellarAddress(address: string): boolean {
+  if (!address || typeof address !== 'string') return false;
+  try {
+    return StrKey.isValidEd25519PublicKey(address.trim());
+  } catch {
+    return false;
+  }
+}
+
+export function validateLabel(label: string): string | null {
+  if (!label || !label.trim()) return 'Label is required';
+  if (label.trim().length > 50) return 'Label must be 50 characters or less';
+  return null;
+}
+
+export function filterAddressBook(entries: AddressBookEntry[], query: string): AddressBookEntry[] {
+  if (!query || !query.trim()) return entries;
+  const lower = query.trim().toLowerCase();
+  return entries.filter(
+    (e) =>
+      e.label.toLowerCase().includes(lower) ||
+      e.address.toLowerCase().includes(lower) ||
+      (e.memo && e.memo.toLowerCase().includes(lower))
+  );
+}
+
+export function filterRecentRecipients(recents: RecentRecipient[], query: string): RecentRecipient[] {
+  if (!query || !query.trim()) return recents;
+  const lower = query.trim().toLowerCase();
+  return recents.filter((r) => r.address.toLowerCase().includes(lower));
+}
+
+function generateId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+const MAX_RECENT = 20;
+
+// ---------------------------------------------------------------------------
+// Store interface
+// ---------------------------------------------------------------------------
+export interface AddressBookState {
+  entries: AddressBookEntry[];
+  recentRecipients: RecentRecipient[];
+}
+
+export interface AddressBookActions {
+  addEntry: (label: string, address: string, memo?: string) => OperationResult;
+  updateEntry: (id: string, updates: { label?: string; address?: string; memo?: string }) => OperationResult;
+  removeEntry: (id: string) => OperationResult;
+  getEntry: (id: string) => AddressBookEntry | undefined;
+  searchEntries: (query: string) => AddressBookEntry[];
+  addRecentRecipient: (address: string) => void;
+  removeRecentRecipient: (address: string) => void;
+  clearRecentRecipients: () => void;
+  getRecentRecipients: (excludeSaved?: boolean) => RecentRecipient[];
+  exportData: () => string;
+  importData: (json: string) => OperationResult & { count?: number };
+  clearAll: () => void;
+}
+
+export type AddressBookStore = AddressBookState & AddressBookActions;
+
+// ---------------------------------------------------------------------------
+// Zustand store with persist
+// ---------------------------------------------------------------------------
+export const useAddressBookStore = create<AddressBookStore>()(
+  persist(
+    (set, get) => ({
+      entries: [],
+      recentRecipients: [],
+
+      addEntry: (label: string, address: string, memo?: string) => {
+        const trimmedLabel = label?.trim() ?? '';
+        const trimmedAddress = address?.trim() ?? '';
+
+        const labelError = validateLabel(trimmedLabel);
+        if (labelError) return { success: false, error: labelError };
+
+        if (!trimmedAddress) return { success: false, error: 'Address is required' };
+        if (!isValidStellarAddress(trimmedAddress)) {
+          return { success: false, error: 'Invalid Stellar address' };
+        }
+
+        const duplicate = get().entries.find((e) => e.address === trimmedAddress);
+        if (duplicate) {
+          return { success: false, error: 'This address is already saved' };
+        }
+
+        const now = new Date().toISOString();
+        const entry: AddressBookEntry = {
+          id: generateId(),
+          label: trimmedLabel,
+          address: trimmedAddress,
+          memo: memo?.trim() || undefined,
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        set((state) => ({ entries: [...state.entries, entry] }));
+        return { success: true, entry };
+      },
+
+      updateEntry: (id: string, updates: { label?: string; address?: string; memo?: string }) => {
+        const existing = get().entries.find((e) => e.id === id);
+        if (!existing) return { success: false, error: 'Contact not found' };
+
+        const newLabel = updates.label !== undefined ? updates.label.trim() : existing.label;
+        const newAddress = updates.address !== undefined ? updates.address.trim() : existing.address;
+        const newMemo = updates.memo !== undefined ? updates.memo.trim() : existing.memo;
+
+        const labelError = validateLabel(newLabel);
+        if (labelError) return { success: false, error: labelError };
+
+        if (!newAddress) return { success: false, error: 'Address is required' };
+        if (!isValidStellarAddress(newAddress)) {
+          return { success: false, error: 'Invalid Stellar address' };
+        }
+
+        // Duplicate guard: same address under different id
+        const duplicate = get().entries.find((e) => e.address === newAddress && e.id !== id);
+        if (duplicate) {
+          return { success: false, error: 'This address is already saved' };
+        }
+
+        const now = new Date().toISOString();
+        const updated: AddressBookEntry = {
+          ...existing,
+          label: newLabel,
+          address: newAddress,
+          memo: newMemo || undefined,
+          updatedAt: now,
+        };
+
+        set((state) => ({
+          entries: state.entries.map((e) => (e.id === id ? updated : e)),
+        }));
+        return { success: true, entry: updated };
+      },
+
+      removeEntry: (id: string) => {
+        const exists = get().entries.find((e) => e.id === id);
+        if (!exists) return { success: false, error: 'Contact not found' };
+        set((state) => ({
+          entries: state.entries.filter((e) => e.id !== id),
+        }));
+        return { success: true };
+      },
+
+      getEntry: (id: string) => {
+        return get().entries.find((e) => e.id === id);
+      },
+
+      searchEntries: (query: string) => {
+        return filterAddressBook(get().entries, query);
+      },
+
+      addRecentRecipient: (address: string) => {
+        const trimmed = address?.trim() ?? '';
+        if (!trimmed || !isValidStellarAddress(trimmed)) return;
+
+        // Do not add if already in address book? We keep it but callers can filter.
+        // Keep recent list deduplicated and ordered by recency.
+        set((state) => {
+          const existing = state.recentRecipients.find((r) => r.address === trimmed);
+          const now = new Date().toISOString();
+          let updated: RecentRecipient[];
+          if (existing) {
+            updated = [
+              { address: trimmed, lastSentAt: now, count: existing.count + 1 },
+              ...state.recentRecipients.filter((r) => r.address !== trimmed),
+            ];
+          } else {
+            updated = [{ address: trimmed, lastSentAt: now, count: 1 }, ...state.recentRecipients];
+          }
+          // Cap size
+          if (updated.length > MAX_RECENT) updated = updated.slice(0, MAX_RECENT);
+          return { recentRecipients: updated };
+        });
+      },
+
+      removeRecentRecipient: (address: string) => {
+        set((state) => ({
+          recentRecipients: state.recentRecipients.filter((r) => r.address !== address),
+        }));
+      },
+
+      clearRecentRecipients: () => {
+        set({ recentRecipients: [] });
+      },
+
+      getRecentRecipients: (excludeSaved = true) => {
+        const { recentRecipients, entries } = get();
+        if (!excludeSaved) return recentRecipients;
+        const savedSet = new Set(entries.map((e) => e.address));
+        return recentRecipients.filter((r) => !savedSet.has(r.address));
+      },
+
+      exportData: () => {
+        const { entries, recentRecipients } = get();
+        const payload: ExportData = {
+          entries,
+          recentRecipients,
+          exportedAt: new Date().toISOString(),
+          version: 1,
+        };
+        return JSON.stringify(payload, null, 2);
+      },
+
+      importData: (json: string) => {
+        if (!json || typeof json !== 'string') {
+          return { success: false, error: 'Invalid import data' };
+        }
+        try {
+          const parsed = JSON.parse(json);
+          // Support both raw array and ExportData shape
+          let incomingEntries: any[] = [];
+          let incomingRecents: any[] = [];
+
+          if (Array.isArray(parsed)) {
+            incomingEntries = parsed;
+          } else if (parsed.entries && Array.isArray(parsed.entries)) {
+            incomingEntries = parsed.entries;
+            if (Array.isArray(parsed.recentRecipients)) incomingRecents = parsed.recentRecipients;
+          } else {
+            return { success: false, error: 'Invalid import format' };
+          }
+
+          // Validate entries
+          const validEntries: AddressBookEntry[] = [];
+          const errors: string[] = [];
+          const existingAddresses = new Set(get().entries.map((e) => e.address));
+
+          for (const item of incomingEntries) {
+            if (!item.address || !isValidStellarAddress(item.address)) {
+              errors.push(`Invalid address: ${item.address}`);
+              continue;
+            }
+            if (!item.label || typeof item.label !== 'string' || !item.label.trim()) {
+              errors.push(`Missing label for address: ${item.address}`);
+              continue;
+            }
+            if (existingAddresses.has(item.address) || validEntries.find((e) => e.address === item.address)) {
+              // Skip duplicates silently
+              continue;
+            }
+            const now = new Date().toISOString();
+            validEntries.push({
+              id: item.id || generateId(),
+              label: item.label.trim(),
+              address: item.address.trim(),
+              memo: item.memo?.trim() || undefined,
+              createdAt: item.createdAt || now,
+              updatedAt: item.updatedAt || now,
+            });
+            existingAddresses.add(item.address);
+          }
+
+          // Validate recents
+          const validRecents: RecentRecipient[] = [];
+          for (const r of incomingRecents) {
+            if (r.address && isValidStellarAddress(r.address)) {
+              validRecents.push({
+                address: r.address.trim(),
+                lastSentAt: r.lastSentAt || new Date().toISOString(),
+                count: typeof r.count === 'number' ? r.count : 1,
+              });
+            }
+          }
+
+          if (validEntries.length === 0 && validRecents.length === 0) {
+            return { success: false, error: errors[0] || 'No valid entries to import' };
+          }
+
+          set((state) => ({
+            entries: [...state.entries, ...validEntries],
+            recentRecipients:
+              validRecents.length > 0 ? [...validRecents, ...state.recentRecipients].slice(0, MAX_RECENT) : state.recentRecipients,
+          }));
+
+          return { success: true, count: validEntries.length };
+        } catch (e) {
+          return { success: false, error: e instanceof Error ? e.message : 'Failed to parse import data' };
+        }
+      },
+
+      clearAll: () => {
+        set({ entries: [], recentRecipients: [] });
+      },
+    }),
+    {
+      name: 'address-book-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        entries: state.entries,
+        recentRecipients: state.recentRecipients,
+      }),
+      version: 1,
+    }
+  )
+);


### PR DESCRIPTION
Closes #473

## Summary
Implements wallet address book so users no longer re-enter or re-scan a Stellar address for every send.

## Changes
- **Store** `stores/addressBookStore.ts` (mirrored to `lib/stores` + `src/stores` for alias compat): Zustand + `persist` over `AsyncStorage` (`address-book-storage`, v1), `isValidStellarAddress` via `StrKey.isValidEd25519PublicKey`, `filterAddressBook` helpers, duplicate guard (`This address is already saved`), CRUD (`addEntry`/`updateEntry`/`removeEntry`), search (`searchEntries`), recent-recipients (dedup + count + reorder, cap 20, `getRecentRecipients(excludeSaved)`), `exportData`/`importData` (ExportData + raw array, skip duplicates/invalid), `clearAll`
- **AddressBookScreen** `screens/Wallet/AddressBookScreen.tsx`: searchable list, add/edit modal with validation, delete via `Alert.alert` confirmation (destructive), recent horizontal suggestions (filtered), export/import via clipboard
- **SendScreen** `screens/Wallet/SendScreen.tsx`: recipient ``TextInput`` with validation, "Choose from Address Book" picker modal (saved + recent), inline recent suggestions
- **RecipientPicker** `screens/Wallet/components/RecipientPicker.tsx`: reusable picker component
- **Tests** `stores/__tests__/addressBookStore.test.ts` + `src/stores/__tests__/`: 31 cases covering validation, filtering, CRUD/duplicate guards, search, recents, export/import

## Acceptance criteria
- [x] Add/edit/delete saved recipients
- [x] Send can pick from address book
- [x] Duplicate addresses rejected with clear message
- [x] Search correctly filters list
- [x] Recently sent-to suggested without being permanently saved (filtered when saved)
- [x] Delete requires confirmation (`Alert`)
- [x] Persists across restarts (zustand persist)
- [x] Unit test coverage for store

## Testing
`./node_modules/.bin/tsc --noEmit --skipLibCheck` clean, `jest` 11 suites / 207 tests pass.