### PR TITLE
feat: connect wallet send flow to Stellar

### DIFF
--- a/nftopia-mobile-app/navigation/MainNavigator.tsx
+++ b/nftopia-mobile-app/navigation/MainNavigator.tsx
@@ -26,6 +26,7 @@ import EarningsScreen from '@/screens/Creator/EarningsScreen';
 import NotificationsScreen from '@/screens/Notifications/NotificationsScreen';
 import NotificationSettingsScreen from '@/screens/Notifications/NotificationSettingsScreen';
 import SettingsScreen from '@/screens/Settings/SettingsScreen';
+import { SendScreen } from '@/screens/Wallet/SendScreen';
 
 export type MainStackParamList = {
   Home: undefined;
@@ -42,6 +43,7 @@ export type MainStackParamList = {
   Notifications: undefined;
   NotificationSettings: undefined;
   Settings: undefined;
+  Send: { prefilledAddress?: string } | undefined;
   Marketplace: { category?: string } | undefined;
 };
 
@@ -121,6 +123,8 @@ export default function MainNavigator() {
             </ScreenErrorBoundary>
           )}
         </Stack.Screen>
+
+        <Stack.Screen name="Send" component={SendScreen} />
         
         {/* Marketplace with detail transition */}
         <Stack.Screen 

--- a/nftopia-mobile-app/screens/Home/HomeScreen.tsx
+++ b/nftopia-mobile-app/screens/Home/HomeScreen.tsx
@@ -241,7 +241,7 @@ function HomeContent() {
             <Text style={styles.actionIcon}>🛍️</Text>
             <Text style={styles.actionLabel}>{t('home.actions.marketplace')}</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.actionCard}>
+          <TouchableOpacity style={styles.actionCard} onPress={() => navigation.navigate('Send')}>
             <Text style={styles.actionIcon}>📤</Text>
             <Text style={styles.actionLabel}>{t('home.actions.send')}</Text>
           </TouchableOpacity>

--- a/nftopia-mobile-app/screens/Wallet/SendScreen.tsx
+++ b/nftopia-mobile-app/screens/Wallet/SendScreen.tsx
@@ -15,6 +15,8 @@ import {
   useAddressBookStore,
   isValidStellarAddress,
 } from '@/stores/addressBookStore';
+import { useWalletStore } from '@/stores/walletStore';
+import { StellarWalletService } from '@/src/services/stellar/wallet.service';
 
 interface SendScreenProps {
   navigation?: any;
@@ -23,6 +25,7 @@ interface SendScreenProps {
 }
 
 export function SendScreen({ navigation, route, onSend }: SendScreenProps) {
+  const { wallets, activePublicKey, network } = useWalletStore();
   const { entries, recentRecipients, getRecentRecipients, addRecentRecipient } = useAddressBookStore();
 
   const [recipient, setRecipient] = useState(route?.params?.prefilledAddress || '');
@@ -90,8 +93,11 @@ export function SendScreen({ navigation, route, onSend }: SendScreenProps) {
       if (onSend) {
         await onSend({ address: recipient.trim(), amount: amount.trim(), memo: memo.trim() || undefined });
       } else {
-        // Placeholder: in real app call wallet service
-        Alert.alert('Sent', `Would send ${amount} XLM to ${recipient}`);
+        const wallet = wallets.find((item) => item.publicKey === activePublicKey);
+        if (!wallet) throw new Error('Connect a wallet before sending');
+        const service = new StellarWalletService(undefined, network);
+        await service.sendPayment(wallet.secretKey, recipient.trim(), amount.trim(), 'XLM', undefined, memo.trim() || undefined);
+        Alert.alert('Sent', `${amount.trim()} XLM sent successfully`);
       }
       // Record as recent recipient (unless already saved – still useful, but filtered in suggestions)
       addRecentRecipient(recipient.trim());

--- a/nftopia-mobile-app/src/services/stellar/wallet.service.ts
+++ b/nftopia-mobile-app/src/services/stellar/wallet.service.ts
@@ -1,4 +1,4 @@
-import { Keypair, Horizon } from 'stellar-sdk';
+import { Asset, Horizon, Keypair, Memo, Networks, Operation, StrKey, TransactionBuilder } from 'stellar-sdk';
 import * as bip39 from 'bip39';
 import { Wallet, WalletCreateResult, WalletError, WalletErrorCode, Transaction, TransactionType, TransactionFilters, PaginatedTransactions } from './types';
 import {
@@ -17,10 +17,33 @@ export type { Wallet, WalletCreateResult, Transaction, TransactionFilters, Pagin
 export class StellarWalletService {
   private readonly storage: SecureStorage;
   private readonly server: Horizon.Server;
+  private readonly network: NetworkType;
 
   constructor(storage?: SecureStorage, network: NetworkType = 'testnet') {
     this.storage = storage ?? new SecureStorage();
+    this.network = network;
     this.server = createServer(network);
+  }
+
+  async sendPayment(secretKey: string, destination: string, amount: string, assetCode = 'XLM', assetIssuer?: string, memo?: string): Promise<{ hash: string }> {
+    assertValidSecretKey(secretKey);
+    if (!StrKey.isValidEd25519PublicKey(destination)) throw new WalletError('Invalid recipient address', WalletErrorCode.TRANSACTION_ERROR);
+    if (!/^\d+(?:\.\d{1,7})?$/.test(amount) || Number(amount) <= 0) throw new WalletError('Amount must be a positive decimal', WalletErrorCode.TRANSACTION_ERROR);
+    if (memo && Buffer.byteLength(memo, 'utf8') > 28) throw new WalletError('Memo must be 28 bytes or fewer', WalletErrorCode.TRANSACTION_ERROR);
+    try {
+      const source = Keypair.fromSecret(secretKey);
+      const account = await this.server.loadAccount(source.publicKey());
+      const asset = assetCode === 'XLM' ? Asset.native() : assetIssuer ? new Asset(assetCode, assetIssuer) : (() => { throw new Error('Asset issuer is required'); })();
+      const builder = new TransactionBuilder(account, { fee: String(await this.server.fetchBaseFee()), networkPassphrase: this.network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET }).addOperation(Operation.payment({ destination, asset, amount }));
+      if (memo) builder.addMemo(Memo.text(memo));
+      const transaction = builder.setTimeout(180).build();
+      transaction.sign(source);
+      const submitted = await this.server.submitTransaction(transaction);
+      return { hash: submitted.hash };
+    } catch (error) {
+      if (error instanceof WalletError) throw error;
+      throw new WalletError(`Failed to submit payment: ${(error as Error).message}`, WalletErrorCode.TRANSACTION_ERROR);
+    }
   }
 
   async createWallet(password?: string): Promise<WalletCreateResult> {


### PR DESCRIPTION
Connected the existing Send screen to StellarWalletService transaction construction and submission, with recipient and amount validation, optional memo validation, network-aware fees/passphrase, success/failure feedback, and a Home navigation entry. Added a Send route without changing unrelated screens. Verification: npx tsc --noEmit passes in nftopia-mobile-app.

Closes #454