### PR TITLE
feat(mobile): implement in-app update checker and force-update prompt

### DIFF
--- a/nftopia-mobile-app/.env.example
+++ b/nftopia-mobile-app/.env.example
@@ -34,3 +34,7 @@ EXPO_PUBLIC_DEEP_LINK_HOST=nftopia.io
 
 # Security
 EXPO_PUBLIC_ENCRYPTION_KEY=your-encryption-key-here
+
+# Version Check (in-app update checker)
+EXPO_PUBLIC_VERSION_CHECK_URL=https://api.nftopia.app/v1/app/version
+EXPO_PUBLIC_VERSION_CHECK_INTERVAL_MS=3600000

--- a/nftopia-mobile-app/App.tsx
+++ b/nftopia-mobile-app/App.tsx
@@ -9,6 +9,7 @@ import { NetworkStatusManager } from './src/components/NetworkStatusManager';
 import { SessionManager } from './src/components/SessionManager';
 import { AppLockManager } from './src/components/AppLockManager';
 import { PrivacyOverlay } from './src/components/PrivacyOverlay';
+import { VersionCheckManager } from './src/components/VersionCheckManager';
 import { setupApollo } from './lib/api/apolloClient';
 
 export default function App() {
@@ -31,6 +32,7 @@ export default function App() {
       <AppLayout>
         <PrivacyOverlay />
         <AppLockManager>
+          <VersionCheckManager />
           <SafeAreaView style={styles.container}>
             <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
             <NetworkStatusManager />

--- a/nftopia-mobile-app/components/ui/UpdatePromptModal.tsx
+++ b/nftopia-mobile-app/components/ui/UpdatePromptModal.tsx
@@ -1,0 +1,213 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Modal,
+  Platform,
+  AccessibilityInfo,
+} from 'react-native';
+import * as Linking from 'expo-linking';
+import { colors, spacing, borderRadius, shadows } from '@/constants/theme';
+import type { VersionCheckResult } from '@/lib/versionCheck';
+import { getStoreDeepLink } from '@/lib/versionCheck';
+
+export interface UpdatePromptModalProps {
+  visible: boolean;
+  result: VersionCheckResult | null;
+  onClose?: () => void;
+  forceDismissible?: boolean;
+}
+
+/**
+ * In-app update prompt.
+ *
+ * - Soft nudge (update available): dismissible, offers an update button.
+ * - Hard block (update required): non-dismissible, back button is swallowed, the
+ *   only action is to open the store; cannot be closed without updating.
+ */
+export function UpdatePromptModal({
+  visible,
+  result,
+  onClose,
+  forceDismissible,
+}: UpdatePromptModalProps) {
+  if (!result || !visible) return null;
+
+  const isHard = result.state === 'update_required';
+  const dismissible = isHard ? false : forceDismissible ?? true;
+
+  React.useEffect(() => {
+    if (visible) {
+      const message = isHard
+        ? 'A new version of NFTopia is required. Please update to continue.'
+        : `A new version of NFTopia is available (${result.latest}). Would you like to update?`;
+      AccessibilityInfo.announceForAccessibility(message);
+    }
+  }, [visible, isHard, result.latest]);
+
+  const handleUpdate = async () => {
+    const url = getStoreDeepLink(Platform.OS === 'android' ? 'android' : 'ios');
+    const supported = await Linking.canOpenURL(url);
+    if (supported) {
+      await Linking.openURL(url);
+    }
+  };
+
+  const handleClose = () => {
+    if (dismissible && onClose) {
+      onClose();
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      // Swallow the hardware back button on Android for the hard block so it
+      // cannot be dismissed without updating.
+      onRequestClose={handleClose}
+      accessibilityViewIsModal
+    >
+      <View style={styles.overlay}>
+        <View
+          style={[styles.dialog, isHard && styles.hardDialog]}
+          accessible
+          accessibilityLiveRegion="assertive"
+          accessibilityLabel={
+            isHard
+              ? 'Update required'
+              : `Update available, version ${result.latest}`
+          }
+        >
+          <View style={[styles.iconContainer, isHard && styles.hardIconContainer]}>
+            <Text style={styles.icon}>{isHard ? '🚨' : '🔄'}</Text>
+          </View>
+
+          <Text style={styles.title}>
+            {isHard ? 'Update Required' : 'Update Available'}
+          </Text>
+
+          <Text style={styles.message}>
+            {isHard
+              ? `Your version (${result.currentVersion}) is no longer supported. Update to ${result.latest} to continue using NFTopia.`
+              : `A new version (${result.latest}) is available. You're running ${result.currentVersion}.`}
+          </Text>
+
+          <View style={styles.buttons}>
+            {dismissible && (
+              <TouchableOpacity
+                style={[styles.button, styles.laterButton]}
+                onPress={handleClose}
+                accessibilityRole="button"
+                accessibilityLabel="Maybe later"
+              >
+                <Text style={styles.laterText}>Maybe Later</Text>
+              </TouchableOpacity>
+            )}
+
+            <TouchableOpacity
+              style={[styles.button, styles.updateButton, isHard && styles.hardUpdateButton]}
+              onPress={handleUpdate}
+              accessibilityRole="button"
+              accessibilityLabel="Update now"
+            >
+              <Text style={styles.updateText}>Update Now</Text>
+            </TouchableOpacity>
+          </View>
+
+          {isHard && (
+            <Text style={styles.footerText}>
+              This version is no longer supported and may be unstable.
+            </Text>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  dialog: {
+    backgroundColor: colors.background,
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+    width: '100%',
+    maxWidth: 360,
+    ...shadows.md,
+  },
+  hardDialog: {
+    borderWidth: 2,
+    borderColor: colors.warning,
+  },
+  iconContainer: {
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  hardIconContainer: {
+    marginBottom: spacing.md,
+  },
+  icon: {
+    fontSize: 48,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  message: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 20,
+    marginBottom: spacing.lg,
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  laterButton: {
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  laterText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.textSecondary,
+  },
+  updateButton: {
+    backgroundColor: colors.primary,
+  },
+  hardUpdateButton: {
+    backgroundColor: colors.warning,
+  },
+  updateText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: Platform.OS === 'ios' ? '#FFFFFF' : '#1a1a1a',
+  },
+  footerText: {
+    fontSize: 12,
+    color: colors.textTertiary,
+    textAlign: 'center',
+    marginTop: spacing.md,
+  },
+});

--- a/nftopia-mobile-app/lib/__tests__/versionCheck.test.ts
+++ b/nftopia-mobile-app/lib/__tests__/versionCheck.test.ts
@@ -1,0 +1,161 @@
+import {
+  parseVersion,
+  compareVersions,
+  isAtLeast,
+  isOlder,
+  isNewer,
+  evaluateVersionState,
+  getStoreDeepLink,
+} from '../versionCheck';
+
+describe('parseVersion', () => {
+  it('parses a standard three-part semver', () => {
+    expect(parseVersion('1.2.3')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: undefined,
+    });
+  });
+
+  it('treats missing minor/patch as zero', () => {
+    expect(parseVersion('2')).toEqual({ major: 2, minor: 0, patch: 0, prerelease: undefined });
+    expect(parseVersion('2.5')).toEqual({ major: 2, minor: 5, patch: 0, prerelease: undefined });
+  });
+
+  it('handles a leading "v" prefix', () => {
+    expect(parseVersion('v3.1.4')?.major).toBe(3);
+    expect(parseVersion('V3.1.4')?.major).toBe(3);
+  });
+
+  it('strips leading zeros from numeric segments', () => {
+    expect(parseVersion('01.02.03')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: undefined,
+    });
+  });
+
+  it('parses a prerelease suffix', () => {
+    expect(parseVersion('1.0.0-beta')).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: { identifier: 'beta', numeric: undefined },
+    });
+    expect(parseVersion('1.0.0-beta.2')?.prerelease?.numeric).toBe(2);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(parseVersion('')).toBeNull();
+    expect(parseVersion(null)).toBeNull();
+    expect(parseVersion(undefined)).toBeNull();
+    expect(parseVersion('abc')).toBeNull();
+    expect(parseVersion('1.2.x')).toBeNull();
+    expect(parseVersion('1.2.3.4.5')).toBeNull();
+  });
+});
+
+describe('compareVersions', () => {
+  it('compares simple versions correctly', () => {
+    expect(compareVersions('1.0.0', '1.0.0')).toBe(0);
+    expect(compareVersions('1.0.0', '1.0.1')).toBe(-1);
+    expect(compareVersions('1.0.1', '1.0.0')).toBe(1);
+    expect(compareVersions('1.2.0', '1.1.9')).toBe(1);
+    expect(compareVersions('1.2.0', '2.0.0')).toBe(-1);
+  });
+
+  it('treats partial versions with implicit zeros', () => {
+    expect(compareVersions('1', '1.0.0')).toBe(0);
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+  });
+
+  it('orders prereleases below the release', () => {
+    expect(compareVersions('1.0.0-beta', '1.0.0')).toBe(-1);
+    expect(compareVersions('1.0.0', '1.0.0-beta')).toBe(1);
+    expect(compareVersions('1.0.0-alpha', '1.0.0-beta')).toBe(-1);
+  });
+
+  it('compares prerelease numeric identifiers', () => {
+    expect(compareVersions('1.0.0-beta.1', '1.0.0-beta.2')).toBe(-1);
+    expect(compareVersions('1.0.0-beta.10', '1.0.0-beta.2')).toBe(1);
+  });
+});
+
+describe('helpers', () => {
+  it('isNewer and isOlder are opposites', () => {
+    expect(isNewer('2.0.0', '1.0.0')).toBe(true);
+    expect(isOlder('1.0.0', '2.0.0')).toBe(true);
+    expect(isOlder('2.0.0', '1.0.0')).toBe(false);
+  });
+
+  it('isAtLeast includes equality', () => {
+    expect(isAtLeast('1.2.0', '1.2.0')).toBe(true);
+    expect(isAtLeast('1.3.0', '1.2.0')).toBe(true);
+    expect(isAtLeast('1.1.0', '1.2.0')).toBe(false);
+  });
+});
+
+describe('evaluateVersionState', () => {
+  it('requires an update when below the minimum', () => {
+    expect(
+      evaluateVersionState('1.0.0', { minimum: '1.5.0', latest: '2.0.0' })
+    ).toBe('update_required');
+  });
+
+  it('offers a soft update when at/above minimum but below latest', () => {
+    expect(
+      evaluateVersionState('1.5.0', { minimum: '1.5.0', latest: '2.0.0' })
+    ).toBe('update_available');
+    expect(
+      evaluateVersionState('1.9.0', { minimum: '1.5.0', latest: '2.0.0' })
+    ).toBe('update_available');
+  });
+
+  it('is up to date when current is at or above latest', () => {
+    expect(
+      evaluateVersionState('2.0.0', { minimum: '1.5.0', latest: '2.0.0' })
+    ).toBe('up_to_date');
+    expect(
+      evaluateVersionState('2.1.0', { minimum: '1.5.0', latest: '2.0.0' })
+    ).toBe('up_to_date');
+  });
+
+  it('prefers the hard requirement over the soft nudge when both apply', () => {
+    // Below minimum and below latest => hard requirement wins.
+    expect(
+      evaluateVersionState('1.2.0', { minimum: '1.5.0', latest: '3.0.0' })
+    ).toBe('update_required');
+  });
+
+  it('defaults to up to date on an unparseable current version', () => {
+    expect(evaluateVersionState('garbage', { minimum: '1.0.0', latest: '2.0.0' })).toBe(
+      'up_to_date'
+    );
+  });
+
+  it('does not block when remote thresholds are unparseable', () => {
+    // An unparseable minimum cannot trigger a hard block.
+    expect(evaluateVersionState('1.0.0', { minimum: 'bad', latest: '2.0.0' })).not.toBe(
+      'update_required'
+    );
+    // An unparseable latest cannot trigger a soft/hard prompt at all.
+    expect(evaluateVersionState('1.0.0', { minimum: '1.0.0', latest: 'bad' })).toBe(
+      'up_to_date'
+    );
+  });
+});
+
+describe('getStoreDeepLink', () => {
+  it('returns an App Store link for iOS using the bundle id', () => {
+    const link = getStoreDeepLink('ios');
+    expect(link).toContain('apps.apple.com');
+  });
+
+  it('returns a Play Store link for Android using the package id', () => {
+    const link = getStoreDeepLink('android');
+    expect(link).toContain('play.google.com');
+    expect(link).toContain('id=com.nftopia.app');
+  });
+});

--- a/nftopia-mobile-app/lib/__tests__/versionCheckService.test.ts
+++ b/nftopia-mobile-app/lib/__tests__/versionCheckService.test.ts
@@ -1,0 +1,163 @@
+// ── Mocks (must be hoisted before imports) ───────────────────────────────────
+const asyncStorageStore: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((key: string) => Promise.resolve(asyncStorageStore[key] ?? null)),
+  setItem: jest.fn((key: string, value: string) => {
+    asyncStorageStore[key] = value;
+    return Promise.resolve();
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete asyncStorageStore[key];
+    return Promise.resolve();
+  }),
+}));
+
+const mockNetInfo = {
+  fetch: jest.fn(),
+};
+jest.mock('@react-native-community/netinfo', () => ({
+  fetch: (...args: unknown[]) => mockNetInfo.fetch(...args),
+  addEventListener: jest.fn(),
+}));
+
+const mockAppStateListeners: Array<(next: string) => void> = [];
+jest.mock('react-native', () => ({
+  AppState: {
+    currentState: 'active',
+    addEventListener: jest.fn((_type: string, handler: (next: string) => void) => {
+      mockAppStateListeners.push(handler);
+      return { remove: jest.fn() };
+    }),
+  },
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import {
+  runVersionCheck,
+  shouldCheck,
+  fetchVersionGate,
+  sealCurrentVersion,
+} from '../versionCheckService';
+import { CACHED_GATE_KEY, LAST_CHECK_KEY } from '../versionCheck';
+
+function jsonOk(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+describe('versionCheckService', () => {
+  beforeEach(() => {
+    Object.keys(asyncStorageStore).forEach((k) => delete asyncStorageStore[k]);
+    mockNetInfo.fetch.mockReset();
+    mockAppStateListeners.length = 0;
+    jest.clearAllMocks();
+    sealCurrentVersion('1.0.0');
+  });
+
+  describe('shouldCheck', () => {
+    it('returns true when no previous check exists', async () => {
+      // No stored timestamp => last treated as 0 => elapsed for any real "now".
+      expect(await shouldCheck(Date.now(), 60000)).toBe(true);
+    });
+
+    it('returns false within the throttle window', async () => {
+      asyncStorageStore[LAST_CHECK_KEY] = '1000';
+      expect(await shouldCheck(5000, 60000)).toBe(false);
+    });
+
+    it('returns true once the interval has elapsed', async () => {
+      asyncStorageStore[LAST_CHECK_KEY] = '1000';
+      expect(await shouldCheck(1000 + 60001, 60000)).toBe(true);
+    });
+  });
+
+  describe('fetchVersionGate', () => {
+    it('resolves the gate from the endpoint payload', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue(
+        jsonOk({ minimum: '1.2.0', latest: '2.0.0' })
+      );
+      const gate = await fetchVersionGate(fetchImpl as unknown as typeof fetch, 'http://x');
+      expect(gate).toEqual({ minimum: '1.2.0', latest: '2.0.0' });
+    });
+
+    it('returns null on an HTTP error status', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+      expect(await fetchVersionGate(fetchImpl as unknown as typeof fetch)).toBeNull();
+    });
+
+    it('returns null on a network exception (no-op failure)', async () => {
+      const fetchImpl = jest.fn().mockRejectedValue(new Error('offline'));
+      expect(await fetchVersionGate(fetchImpl as unknown as typeof fetch)).toBeNull();
+    });
+  });
+
+  describe('runVersionCheck', () => {
+    it('no-ops when throttled (returning null)', async () => {
+      asyncStorageStore[LAST_CHECK_KEY] = String(Date.now());
+      const result = await runVersionCheck({ checkIntervalMs: 60 * 60 * 1000 });
+      expect(result).toBeNull();
+      expect(mockNetInfo.fetch).not.toHaveBeenCalled();
+    });
+
+    it('no-ops gracefully when offline and no cached gate exists', async () => {
+      mockNetInfo.fetch.mockResolvedValue({
+        isConnected: false,
+        isInternetReachable: false,
+      });
+      const result = await runVersionCheck({ checkIntervalMs: 0 });
+      expect(result).toBeNull();
+    });
+
+    it('reuses the cached gate when offline', async () => {
+      asyncStorageStore[CACHED_GATE_KEY] = JSON.stringify({
+        minimum: '1.5.0',
+        latest: '2.0.0',
+      });
+      mockNetInfo.fetch.mockResolvedValue({
+        isConnected: false,
+        isInternetReachable: false,
+      });
+      const result = await runVersionCheck({ checkIntervalMs: 0 });
+      expect(result?.state).toBe('update_required');
+      expect(result?.latest).toBe('2.0.0');
+    });
+
+    it('returns a soft nudge when below latest but above minimum', async () => {
+      mockNetInfo.fetch.mockResolvedValue({
+        isConnected: true,
+        isInternetReachable: true,
+      });
+      const fetchImpl = jest.fn().mockResolvedValue(
+        jsonOk({ minimum: '1.2.0', latest: '2.0.0' })
+      );
+      const result = await runVersionCheck({
+        checkIntervalMs: 0,
+        appVersion: '1.5.0',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        endpoint: 'http://x',
+      });
+      expect(result?.state).toBe('update_available');
+    });
+
+    it('returns a hard requirement when below minimum', async () => {
+      mockNetInfo.fetch.mockResolvedValue({
+        isConnected: true,
+        isInternetReachable: true,
+      });
+      const fetchImpl = jest.fn().mockResolvedValue(
+        jsonOk({ minimum: '1.5.0', latest: '2.0.0' })
+      );
+      const result = await runVersionCheck({
+        checkIntervalMs: 0,
+        appVersion: '1.0.0',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        endpoint: 'http://x',
+      });
+      expect(result?.state).toBe('update_required');
+    });
+  });
+});

--- a/nftopia-mobile-app/lib/versionCheck.ts
+++ b/nftopia-mobile-app/lib/versionCheck.ts
@@ -1,0 +1,194 @@
+/**
+ * Pure version-comparison + policy utilities for the in-app update checker.
+ * Kept free of network/UI/side-effect dependencies so it is trivial to unit
+ * test in isolation (no react-native import).
+ */
+
+export interface VersionGate {
+  /** Minimum version still allowed to run. Users below this get a hard block. */
+  minimum: string;
+  /** Latest published version. Users above `minimum` but below this get a soft nudge. */
+  latest: string;
+  /** The app version is considered outdated when it is below this (inclusive floor). */
+  outdatedBelow?: string;
+}
+
+/** Result of comparing two version strings following semver ordering. */
+export type CompareResult = -1 | 0 | 1;
+
+/** Overall update state of the running app relative to the remote gate. */
+export type VersionState = 'up_to_date' | 'update_available' | 'update_required';
+
+export interface VersionCheckResult {
+  state: VersionState;
+  currentVersion: string;
+  minimum: string;
+  latest: string;
+  /** A user-facing title for the latest available version. */
+  releaseNotes?: string;
+}
+
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  /** Numeric prerelease id, e.g. 1.0.0-beta.2 -> 2. Lower = older. */
+  prerelease?: {
+    identifier: string;
+    numeric?: number;
+  };
+}
+
+/**
+ * Parse a version string into numeric components for reliable comparison.
+ * Handles `1`, `1.2`, `1.2.3`, `v1.2.3`, leading zeros, and an optional
+ * `-prerelease` suffix. Non-numeric/invalid input returns `null`.
+ */
+export function parseVersion(input: string | number | null | undefined): ParsedVersion | null {
+  if (input === null || input === undefined) return null;
+  const raw = String(input).trim();
+  if (raw === '') return null;
+
+  const core = raw.replace(/^[vV]/, '');
+
+  const [numbersPart, prereleasePart] = core.split('-', 2);
+
+  const segments = numbersPart.split('.');
+  if (segments.length === 0 || segments.length > 4) return null;
+
+  const nums = segments.map((s) => {
+    if (!/^\d+$/.test(s)) return Number.NaN;
+    // Strip leading zeros to avoid "01" being parsed as octal in some engines.
+    return Number(s.replace(/^0+(?=\d)/, ''));
+  });
+  if (nums.some(Number.isNaN)) return null;
+
+  const major = nums[0];
+  const minor = nums[1] ?? 0;
+  const patch = nums[2] ?? 0;
+  // A 4th segment (e.g. build number) is ignored for ordering.
+
+  let prerelease: ParsedVersion['prerelease'];
+  if (prereleasePart !== undefined && prereleasePart !== '') {
+    const match = prereleasePart.match(/^([a-zA-Z][0-9a-zA-Z-]*)\.?([0-9]+)?$/);
+    if (!match) return null;
+    prerelease = {
+      identifier: prereleasePart.replace(/\.\d+$/, ''),
+      numeric: match[2] !== undefined ? Number(match[2]) : undefined,
+    };
+  }
+
+  return {
+    major,
+    minor,
+    patch,
+    prerelease,
+  };
+}
+
+/**
+ * Compare two version strings following semver ordering.
+ * Returns -1 if `a` < `b`, 0 if equal, 1 if `a` > `b`.
+ */
+export function compareVersions(a: string, b: string): CompareResult {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+
+  // A non-numeric side sorts as less than a numeric one (defensive fallback).
+  if (!pa && !pb) return 0;
+  if (!pa) return -1;
+  if (!pb) return 1;
+
+  const coreDiff =
+    pa.major !== pb.major
+      ? Math.sign(pa.major - pb.major)
+      : pa.minor !== pb.minor
+        ? Math.sign(pa.minor - pb.minor)
+        : Math.sign(pa.patch - pb.patch);
+
+  if (coreDiff !== 0) return coreDiff as CompareResult;
+
+  // Same core version: a release sorts > a prerelease.
+  if (!pa.prerelease && !pb.prerelease) return 0;
+  if (!pa.prerelease) return 1;
+  if (!pb.prerelease) return -1;
+
+  if (pa.prerelease.identifier !== pb.prerelease.identifier) {
+    const paId = pa.prerelease.identifier;
+    const pbId = pb.prerelease.identifier;
+    // Numeric identifiers compare by number; otherwise lexically.
+    const aNum = Number(paId);
+    const bNum = Number(pbId);
+    if (Number.isInteger(aNum) && Number.isInteger(bNum)) {
+      return (Math.sign(aNum - bNum) || 0) as CompareResult;
+    }
+    return (paId < pbId ? -1 : paId > pbId ? 1 : 0) as CompareResult;
+  }
+
+  const aN = pa.prerelease.numeric ?? 0;
+  const bN = pb.prerelease.numeric ?? 0;
+  return (Math.sign(aN - bN) || 0) as CompareResult;
+}
+
+/** True when version `a` is strictly newer than version `b`. */
+export function isNewer(a: string, b: string): boolean {
+  return compareVersions(a, b) > 0;
+}
+
+/** True when version `a` is equal to or newer than version `b`. */
+export function isAtLeast(a: string, b: string): boolean {
+  return compareVersions(a, b) >= 0;
+}
+
+/** True when version `a` is strictly older than version `b`. */
+export function isOlder(a: string, b: string): boolean {
+  return compareVersions(a, b) < 0;
+}
+
+/**
+ * Decide the update state for the running app version given a remote gate.
+ *
+ *   - update_required: current < minimum (must update to keep using the app)
+ *   - update_available: minimum <= current < latest (optional soft nudge)
+ *   - up_to_date: current >= latest
+ */
+export function evaluateVersionState(
+  currentVersion: string,
+  gate: Pick<VersionGate, 'minimum' | 'latest'>
+): VersionState {
+  const current = parseVersion(currentVersion);
+  if (!current) return 'up_to_date';
+
+  // If the remote config is unparseable, default to no update required so the
+  // app never blocks on bad server data.
+  const minimum = parseVersion(gate.minimum);
+  const latest = parseVersion(gate.latest);
+
+  if (minimum && isOlder(currentVersion, gate.minimum)) {
+    return 'update_required';
+  }
+  if (latest && isOlder(currentVersion, gate.latest)) {
+    return 'update_available';
+  }
+  return 'up_to_date';
+}
+
+const BUNDLE_IDENTITY = 'com.nftopia.app';
+
+/** App Store / Play Store listing URL built from the app's bundle/package id. */
+export function getStoreDeepLink(platform: 'ios' | 'android' = 'ios'): string {
+  const appStoreId = 'id0000000000';
+  if (platform === 'android') {
+    return `https://play.google.com/store/apps/details?id=${BUNDLE_IDENTITY}`;
+  }
+  return `https://apps.apple.com/app/${appStoreId}`;
+}
+
+/** Throttle window in ms: only check once per app foreground within this time. */
+export const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+/** AsyncStorage key holding the last successful version check timestamp. */
+export const LAST_CHECK_KEY = '@nftopia/version_check/last_check';
+
+/** AsyncStorage key holding the last known cached gate (for offline reuse). */
+export const CACHED_GATE_KEY = '@nftopia/version_check/cached_gate';

--- a/nftopia-mobile-app/lib/versionCheckService.ts
+++ b/nftopia-mobile-app/lib/versionCheckService.ts
@@ -1,0 +1,219 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import NetInfo from '@react-native-community/netinfo';
+import { AppState, AppStateStatus } from 'react-native';
+import {
+  CACHED_GATE_KEY,
+  CHECK_INTERVAL_MS,
+  LAST_CHECK_KEY,
+  VersionCheckResult,
+  VersionGate,
+  VersionState,
+  evaluateVersionState,
+} from './versionCheck';
+
+/**
+ * Orchestrates the in-app update check:
+ *   - fetches the version policy from a lightweight remote endpoint,
+ *   - throttles to at most once per app foreground,
+ *   - no-ops gracefully when offline / the endpoint fails,
+ *   - falls back to a cached gate so re-launches still surface prompts.
+ */
+
+export interface VersionCheckServiceConfig {
+  fetchImpl?: typeof fetch;
+  checkIntervalMs?: number;
+  appVersion?: string;
+  endpoint?: string;
+}
+
+let cachedCurrentVersion: string | null = null;
+
+export function sealCurrentVersion(version: string): void {
+  cachedCurrentVersion = version;
+}
+
+function getAppVersion(): string {
+  return cachedCurrentVersion ?? '1.0.0';
+}
+
+function defaultEndpoint(): string {
+  return (
+    process.env.EXPO_PUBLIC_VERSION_CHECK_URL || 'https://api.nftopia.app/v1/app/version'
+  );
+}
+
+function defaultInterval(): number {
+  const fromEnv = Number(process.env.EXPO_PUBLIC_VERSION_CHECK_INTERVAL_MS);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : CHECK_INTERVAL_MS;
+}
+
+function normalizeGate(raw: unknown): VersionGate | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const minimum = typeof obj.minimum === 'string' ? obj.minimum : undefined;
+  const latest = typeof obj.latest === 'string' ? obj.latest : undefined;
+  if (!minimum || !latest) return null;
+  return {
+    minimum,
+    latest,
+    outdatedBelow: typeof obj.outdatedBelow === 'string' ? obj.outdatedBelow : undefined,
+  };
+}
+
+async function readLastCheck(): Promise<number> {
+  try {
+    const stored = await AsyncStorage.getItem(LAST_CHECK_KEY);
+    const value = stored ? Number(stored) : 0;
+    return Number.isFinite(value) ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function writeLastCheck(now: number): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LAST_CHECK_KEY, String(now));
+  } catch {
+    // Best-effort; throttling will simply be less sticky.
+  }
+}
+
+async function readCachedGate(): Promise<VersionGate | null> {
+  try {
+    const stored = await AsyncStorage.getItem(CACHED_GATE_KEY);
+    if (!stored) return null;
+    return normalizeGate(JSON.parse(stored));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true when a fresh network check should be attempted based on the
+ * configured throttle window, otherwise false.
+ */
+export async function shouldCheck(now = Date.now(), intervalMs = CHECK_INTERVAL_MS): Promise<boolean> {
+  const last = await readLastCheck();
+  return now - last >= intervalMs;
+}
+
+/**
+ * Fetch the version gate from the remote endpoint. Resolves to `null` on any
+ * connectivity / network error so callers can no-op without crashing.
+ */
+export async function fetchVersionGate(
+  fetchImpl: typeof fetch = fetch,
+  endpoint = defaultEndpoint()
+): Promise<VersionGate | null> {
+  try {
+    const res = await fetchImpl(endpoint, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return normalizeGate(data);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * High-level entry point. Returns null when the app should be left to run
+ * untouched (offline, throttled, or below no network), otherwise evaluates
+ * the current version against the fetched/cached gate.
+ */
+export async function runVersionCheck(
+  config: VersionCheckServiceConfig = {}
+): Promise<VersionCheckResult | null> {
+  const now = Date.now();
+  const appVersion = config.appVersion ?? getAppVersion();
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const intervalMs = config.checkIntervalMs ?? defaultInterval();
+
+  // Throttle: at most once per app foreground window.
+  if (!(await shouldCheck(now, intervalMs))) {
+    return null;
+  }
+
+  // Offline no-op: don't attempt network when there is no connectivity.
+  let isConnected = true;
+  try {
+    const state = await NetInfo.fetch();
+    isConnected = state.isConnected !== false && state.isInternetReachable !== false;
+  } catch {
+    isConnected = true; // If NetInfo is unavailable, proceed and let fetch fail softly.
+  }
+
+  let gate: VersionGate | null = null;
+  if (isConnected) {
+    gate = await fetchVersionGate(fetchImpl, config.endpoint ?? defaultEndpoint());
+    if (gate) {
+      await writeLastCheck(now);
+      try {
+        await AsyncStorage.setItem(CACHED_GATE_KEY, JSON.stringify(gate));
+      } catch {
+        // Non-fatal.
+      }
+    }
+  }
+
+  // Fall back to a cached gate so re-launches surface prompts even offline.
+  if (!gate) {
+    gate = await readCachedGate();
+  }
+
+  if (!gate) {
+    return null;
+  }
+
+  const state: VersionState = evaluateVersionState(appVersion, gate);
+  return {
+    state,
+    currentVersion: appVersion,
+    minimum: gate.minimum,
+    latest: gate.latest,
+  };
+}
+
+let didListen = false;
+
+/**
+ * Register an AppState listener so the check re-runs on each foreground
+ * (cold start and every resume), gated by the throttle window.
+ */
+export function startVersionCheckListener(
+  onResult: (result: VersionCheckResult | null) => void,
+  config: VersionCheckServiceConfig = {}
+): () => void {
+  let running = false;
+
+  const run = async () => {
+    if (running) return;
+    running = true;
+    try {
+      const result = await runVersionCheck(config);
+      onResult(result);
+    } finally {
+      running = false;
+    }
+  };
+
+  const handleAppStateChange = (next: AppStateStatus) => {
+    // Only evaluate when the app becomes active (foreground).
+    if (next === 'active') {
+      run();
+    }
+  };
+
+  const subscription = AppState.addEventListener('change', handleAppStateChange);
+
+  if (!didListen) {
+    // Fire once on the first mount to cover cold start, where the 'active'
+    // event may have already been emitted before we subscribed.
+    didListen = true;
+    run();
+  }
+
+  return () => subscription.remove();
+}

--- a/nftopia-mobile-app/src/components/VersionCheckManager.tsx
+++ b/nftopia-mobile-app/src/components/VersionCheckManager.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { appConfig } from '@/src/config';
+import { UpdatePromptModal } from '@/components/ui/UpdatePromptModal';
+import type { VersionCheckResult } from '@/lib/versionCheck';
+import { startVersionCheckListener, sealCurrentVersion } from '@/lib/versionCheckService';
+
+/**
+ * Mounted at the app root. Runs the update check once per app foreground and
+ * renders the appropriate soft-nudge / hard-block prompt.
+ */
+export function VersionCheckManager() {
+  const [result, setResult] = useState<VersionCheckResult | null>(null);
+
+  useEffect(() => {
+    // Provide the running version so the service can compare against the gate.
+    sealCurrentVersion(appConfig.version);
+
+    const unsubscribe = startVersionCheckListener((res) => {
+      setResult(res);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  return <UpdatePromptModal visible={!!result} result={result} />;
+}


### PR DESCRIPTION
Add an in-app version check service, update prompt UI, and tests:
- lib/versionCheck.ts: semver comparison + policy evaluation + store deep links
- lib/versionCheckService.ts: remote gate fetch, throttle, offline/cached fallback
- components/ui/UpdatePromptModal.tsx: soft-nudge and non-dismissible hard-block UI
- src/components/VersionCheckManager.tsx: runs the check per app foreground
- wire manager into App root; add env config for endpoint/throttle
- unit tests for version comparison edge cases and service throttling

Closes #476 