### PR TITLE
fix(mobile): accessibility audit and screen reader support for Auth, Home, Profile, Wallet screens

### DIFF
--- a/nftopia-mobile-app/README.md
+++ b/nftopia-mobile-app/README.md
@@ -27,7 +27,8 @@ NFTopia Mobile App is the React Native surface for onboarding users, creating or
 5. [Project Structure](#-project-structure)
 6. [Authentication and Wallet Layer](#-authentication-and-wallet-layer)
 7. [Testing](#-testing)
-8. [Repository Notes](#-repository-notes)
+8. [Accessibility](#-accessibility)
+9. [Repository Notes](#-repository-notes)
 
 ## 🏗️ Architecture
 
@@ -126,6 +127,15 @@ npm test
 ```
 
 There are tests for wallet services, auth services, and auth store behavior in the repository.
+
+## ♿ Accessibility
+
+New and updated screens are expected to follow
+[`docs/ACCESSIBILITY.md`](./docs/ACCESSIBILITY.md) — a short checklist
+covering accessibility labels/roles, touch target sizing, focus order, font
+scaling, and color contrast. See
+[`docs/ACCESSIBILITY_AUDIT.md`](./docs/ACCESSIBILITY_AUDIT.md) for the audit
+findings behind it.
 
 ## 📌 Repository Notes
 

--- a/nftopia-mobile-app/components/wallet/WalletList.tsx
+++ b/nftopia-mobile-app/components/wallet/WalletList.tsx
@@ -32,38 +32,56 @@ export default function WalletList({
 
   const renderItem = ({ item }: { item: Wallet }) => {
     const isActive = item.publicKey === activePublicKey;
+    const shortKey = `${item.publicKey.slice(0, 12)}...${item.publicKey.slice(-8)}`;
+    const selectLabel = `Wallet ${shortKey}, ${isActive ? 'active' : 'inactive'}${
+      !item.backupConfirmed ? ', backup not confirmed' : ''
+    }`;
 
     return (
-      <TouchableOpacity
-        style={[styles.walletCard, isActive && styles.walletCardActive]}
-        onPress={() => onSelect(item.publicKey)}
-        activeOpacity={0.7}
-      >
-        <View style={styles.walletHeader}>
-          <View style={[styles.dot, isActive && styles.dotActive]} />
-          <Text style={styles.walletLabel} numberOfLines={1}>
-            {item.publicKey.slice(0, 12)}...{item.publicKey.slice(-8)}
-          </Text>
-          <View style={styles.badgeContainer}>
-            {isActive && <View style={styles.activeBadge}><Text style={styles.activeBadgeText}>Active</Text></View>}
-            {!item.backupConfirmed && <View style={styles.warningBadge}><Text style={styles.warningBadgeText}>At Risk</Text></View>}
+      <View style={[styles.walletCard, isActive && styles.walletCardActive]}>
+        {/* A plain TouchableOpacity wraps only the select action here (rather than
+            wrapping the whole card) so the nested Export/Remove buttons below stay
+            independently reachable by VoiceOver/TalkBack instead of being merged
+            into one unreachable "dead end" element. */}
+        <TouchableOpacity
+          onPress={() => onSelect(item.publicKey)}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={selectLabel}
+          accessibilityState={{ selected: isActive }}
+        >
+          <View style={styles.walletHeader}>
+            <View style={[styles.dot, isActive && styles.dotActive]} />
+            <Text style={styles.walletLabel} numberOfLines={1}>
+              {shortKey}
+            </Text>
+            <View style={styles.badgeContainer}>
+              {isActive && <View style={styles.activeBadge}><Text style={styles.activeBadgeText}>Active</Text></View>}
+              {!item.backupConfirmed && <View style={styles.warningBadge}><Text style={styles.warningBadgeText}>At Risk</Text></View>}
+            </View>
           </View>
-        </View>
+        </TouchableOpacity>
         <View style={styles.walletActions}>
           <TouchableOpacity
             style={styles.actionButton}
             onPress={() => onExport(item.publicKey)}
+            accessibilityRole="button"
+            accessibilityLabel={`Export wallet ${shortKey}`}
+            hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
           >
             <Text style={styles.actionText}>Export</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={[styles.actionButton, styles.actionRemove]}
             onPress={() => setRemovingKey(item.publicKey)}
+            accessibilityRole="button"
+            accessibilityLabel={`Remove wallet ${shortKey}`}
+            hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
           >
             <Text style={[styles.actionText, styles.actionRemoveText]}>Remove</Text>
           </TouchableOpacity>
         </View>
-      </TouchableOpacity>
+      </View>
     );
   };
 

--- a/nftopia-mobile-app/docs/ACCESSIBILITY.md
+++ b/nftopia-mobile-app/docs/ACCESSIBILITY.md
@@ -1,0 +1,75 @@
+# Accessibility Checklist
+
+Use this checklist whenever you build or edit a screen or shared component in
+`nftopia-mobile-app`. It reflects the fixes made in the Auth, Home, Profile,
+and Wallet Management accessibility pass — see
+[`ACCESSIBILITY_AUDIT.md`](./ACCESSIBILITY_AUDIT.md) for the full findings
+that produced these rules.
+
+## Before opening a PR
+
+- [ ] **Every interactive element has a role and a label.** Any `Pressable`,
+      `TouchableOpacity`, or custom control needs `accessibilityRole`
+      (`"button"`, `"switch"`, `"header"`, etc.) and a human-readable
+      `accessibilityLabel`. Don't rely on child `<Text>` alone — it's dropped
+      whenever you also set an explicit `accessibilityLabel`, and isn't
+      exposed at all if the element wraps an icon or image.
+- [ ] **State is exposed, not just styled.** If a control is disabled,
+      selected, checked, or busy, set the matching `accessibilityState` key
+      (`disabled`, `selected`, `checked`, `busy`) in addition to the visual
+      style. A greyed-out button that doesn't report `disabled: true` still
+      reads as tappable to a screen reader user.
+- [ ] **No nested interactive elements.** Never wrap a `TouchableOpacity` (or
+      any focusable control) inside another one. On a screen reader, the
+      outer element swallows the inner one, and the inner action becomes an
+      unreachable dead end. If a row needs one action on tap and other
+      actions on inner buttons, put them as siblings, not parent/child (see
+      `components/wallet/WalletList.tsx` for the pattern).
+- [ ] **Decorative content is hidden.** Emoji icons, arrows (`→`), and dots
+      used purely for visual effect should not be read aloud twice. Mark them
+      with `accessibilityElementsHidden` and
+      `importantForAccessibility="no-hide-descendants"`, and fold what they
+      convey into the parent's `accessibilityLabel` instead.
+- [ ] **Touch targets are at least 44x44 pt.** If the visual element is
+      smaller (a small icon button, a compact switch), pad the hit area with
+      `hitSlop` rather than growing the visible element.
+- [ ] **Validation errors announce themselves.** Don't just render red text.
+      Use `ValidationError` (or the pattern in `FormInput`), which sets
+      `accessibilityLiveRegion="polite"` and calls
+      `AccessibilityInfo.announceForAccessibility()` so the error is spoken
+      as soon as it appears, not only when a user happens to swipe onto it.
+- [ ] **Headings use `accessibilityRole="header"`.** Screen titles and
+      section titles should be marked as headers so screen reader users can
+      jump between sections instead of reading everything linearly.
+- [ ] **Layouts survive large font scales.** Test with the OS text size
+      turned up (Settings → Accessibility → Larger Text on iOS, Settings →
+      Accessibility → Font size on Android, both up to ~200%). Screens with
+      a fixed-height, non-scrolling container should be wrapped in a
+      `ScrollView` so scaled text can't get clipped or overlap other
+      elements.
+- [ ] **Color is not the only signal.** If a color communicates status (a
+      warning badge, an error border), also add a text label or icon change.
+- [ ] **New colors meet WCAG AA contrast.** Body text needs at least 4.5:1
+      contrast against its background (3:1 for large/bold text and for
+      non-text UI components like icons or borders). Check new colors with a
+      contrast calculator before adding them to `src/theme/colors.ts`, and
+      prefer the existing tokens (`text`, `textSecondary`, `textTertiary`,
+      `error`, `info`, etc.) — they're already verified.
+
+## Quick manual test
+
+1. **iOS**: enable VoiceOver (Settings → Accessibility → VoiceOver, or
+   triple-click the side button once configured) and swipe through the
+   screen left-to-right. Every interactive element should be reachable, and
+   every element's announcement should make sense out of context.
+2. **Android**: enable TalkBack (Settings → Accessibility → TalkBack) and do
+   the same swipe-through.
+3. Confirm there are no "dead ends" — an element that VoiceOver/TalkBack
+   announces but that either does nothing or hides other controls behind it.
+4. Confirm focus order matches visual/reading order (top-to-bottom,
+   left-to-right for LTR layouts).
+
+## Reference
+
+- [React Native accessibility docs](https://reactnative.dev/docs/accessibility)
+- [WCAG 2.1 AA quick reference](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_overview&levels=aaa)

--- a/nftopia-mobile-app/docs/ACCESSIBILITY_AUDIT.md
+++ b/nftopia-mobile-app/docs/ACCESSIBILITY_AUDIT.md
@@ -1,0 +1,176 @@
+# Accessibility Audit — Auth, Home, Profile, Wallet Management
+
+This documents the audit and fixes made against issue #480. It covers
+`screens/Auth/EmailLoginScreen.tsx` (plus its shared `FormInput` and
+`ValidationError` components), `screens/Home/HomeScreen.tsx`,
+`screens/Profile/ProfileScreen.tsx`, `screens/Profile/WalletManagementScreen.tsx`,
+and `components/wallet/WalletList.tsx`.
+
+**Method note:** this pass is a structural/semantic accessibility-tree
+walkthrough of each screen's code — tracing what VoiceOver/TalkBack would
+announce and in what order, based on each element's role, label, and state,
+per the [React Native accessibility API](https://reactnative.dev/docs/accessibility).
+No physical device or simulator with VoiceOver/TalkBack was available while
+producing this pass, so the "walkthrough" findings below are a code-level
+simulation, not a recorded live session. Before shipping, a contributor with
+an iOS and an Android device should do one live pass following the checklist
+in [`ACCESSIBILITY.md`](./ACCESSIBILITY.md) to confirm these findings
+in situ and catch anything platform-specific that static review can miss.
+
+## Summary of fixes
+
+| Area | Before | After |
+| --- | --- | --- |
+| Interactive elements (all 4 areas) | Most `TouchableOpacity`s had no `accessibilityRole`/`accessibilityLabel`; screen readers fell back to announcing raw child text (or nothing, for icon-only controls) | Explicit `accessibilityRole` + `accessibilityLabel` (+ `accessibilityState` for disabled/selected/checked/busy) on every interactive element |
+| `WalletList.tsx` wallet row | Whole card was one `TouchableOpacity` wrapping two more `TouchableOpacity`s (Export/Remove) — a nested-touchable dead end where screen readers can't reach the inner buttons | Select action and Export/Remove actions are now sibling controls, each independently reachable |
+| Validation errors | Plain `<Text>`, silent to screen readers unless swiped onto | `accessibilityLiveRegion="polite"` + `AccessibilityInfo.announceForAccessibility()` so errors are spoken immediately |
+| Headings | No heading semantics; screen reader users had to read every screen linearly | Screen titles and section titles use `accessibilityRole="header"` |
+| Decorative glyphs (`→`, emoji icons) | Read aloud as literal characters/emoji names, duplicating the adjacent label | Hidden via `accessibilityElementsHidden` + `importantForAccessibility="no-hide-descendants"` |
+| Touch targets | Several controls (wallet card action buttons, the App Lock switch, lock-timeout chips, back links) were visually smaller than 44x44pt | Padded with `hitSlop`, or given `minHeight: 44`, without changing the visible size |
+| Font scaling | `EmailLoginScreen` used a non-scrolling `View` with `justifyContent: 'center'`; at large OS font scales, content could overflow the screen with no way to reach it | Wrapped in a `ScrollView` (`keyboardShouldPersistTaps="handled"`) so scaled content scrolls instead of clipping |
+| Color contrast | Several `src/theme/colors.ts` tokens failed WCAG AA (see table below) | Tokens adjusted to pass AA at their existing font sizes/weights |
+
+## Color contrast audit (`src/theme/colors.ts`)
+
+Checked with the WCAG relative-luminance contrast formula. Targets: 4.5:1 for
+normal text, 3:1 for large/bold text and non-text UI components.
+
+| Token / pair | Before | Ratio | After | Ratio |
+| --- | --- | --- | --- | --- |
+| Light `textTertiary` vs `background`/`surface` | `#999999` | 2.85 / 2.70 (fail) | `#707070` | 4.95 / 4.70 (pass) |
+| Light `error` / `errorText` vs `errorBackground` | `#FF3B30` | 3.32 (fail) | `#D63228` | 4.52 (pass) |
+| Light `info` vs `background` (link/button text) | `#007AFF` | 4.02 (fail) | `#0070EB` | 4.65 (pass) |
+| Dark `textTertiary` vs `surface` | `#808080` | 4.22 (fail) | `#8C8C8C` | 4.96 (pass) |
+| Dark `infoText` vs `infoBackground` | `#0A84FF` | 4.30 (fail) | `#2B96FF` | 5.16 (pass) |
+
+Tokens already passing AA were left unchanged: `text`, `textSecondary`,
+`warningText`, `successText`, `infoText` (light), `error` (dark), and the
+dark-theme `text`/`textSecondary` pairs.
+
+**Not changed / out of scope for this pass:** `success` and `warning` (the
+base tokens, as opposed to `successText`/`warningText`) are only used as
+badge/icon fills, never as text color, in the screens audited here — WCAG's
+4.5:1 text requirement doesn't apply to them, and changing them would be a
+branding decision outside this issue's scope. If a future screen starts using
+`colors.success` or `colors.warning` as a text color, re-check contrast
+against that background before doing so.
+
+These are theme-level token changes, so the fix applies automatically
+everywhere the tokens are already used (43 files reference these tokens),
+not just the four screens named in this issue. `EmailLoginScreen.tsx` and
+`FormInput.tsx`/`ValidationError.tsx` hardcode their own colors instead of
+importing the theme, so their matching literal color values (`#FF3B30` /
+`#007AFF`) were updated directly to the same corrected hex values.
+
+## Screen-by-screen walkthrough
+
+### Auth → Email Login (`EmailLoginScreen.tsx`)
+
+Reading order (top to bottom) was already logical and matches focus order:
+title → subtitle → email field → password field → forgot-password link →
+sign-in button → sign-up link → back link. No reordering was needed.
+
+- Title now announces as a header ("Welcome Back").
+- Email/password fields now announce their label plus, on error, the error
+  message as a hint — previously a screen reader had no reliable way to
+  associate a validation error with its field.
+- Forgot Password / Sign Up / Back all now announce as buttons with a
+  descriptive label instead of just their visible text (which for "← Back"
+  previously included the arrow glyph).
+- Screen now scrolls, so it remains usable at large font scales instead of
+  clipping content that no longer fits `flex: 1` centering.
+
+### Home (`HomeScreen.tsx`)
+
+- Greeting and each discovery section title ("Categories", "Trending", "New
+  Drops") now announce as headers, so screen reader users can jump directly
+  between sections via the rotor/heading navigation instead of reading the
+  whole feed linearly.
+- The network badge ("Testnet"/"Mainnet") is grouped into one accessible
+  element with a clear label ("Network: Testnet") instead of being read as
+  bare text with no context.
+- The four quick-action cards (Marketplace, Send, Receive, Swap) now announce
+  as buttons with their label. Receive and Swap have no `onPress` handler yet
+  (pre-existing — not something this pass changed) so they're given an
+  `accessibilityHint` of "Coming soon" rather than left silently inert, which
+  matches what a sighted user would infer from them not doing anything either.
+
+### Profile (`ProfileScreen.tsx`)
+
+- Screen title and every card title now announce as headers.
+- "Manage wallets" and "App settings" rows previously announced only their
+  link text plus a stray "→" arrow character; the arrow is now hidden and the
+  row has one clean label.
+- The App Lock toggle was a custom `View`-based switch with no accessibility
+  semantics at all — a screen reader user couldn't tell it was a switch, let
+  alone its current state. It now has `accessibilityRole="switch"` and
+  `accessibilityState={{ checked }}`.
+- Lock-timeout options (Immediately / 30s / 1m / 5m) now announce as buttons
+  and report which one is currently selected.
+- Sign-out button now has an explicit label matching its visible text.
+
+### Wallet Management (`WalletManagementScreen.tsx`)
+
+- "← Back" now announces as a button labeled "Go back" instead of literal
+  arrow-plus-text.
+- Screen title announces as a header.
+- The empty state ("No Wallets" / "Import or create a wallet to get
+  started") is now grouped into a single accessible announcement instead of
+  two separate text reads.
+
+### Wallet list (`components/wallet/WalletList.tsx`)
+
+This was the most significant structural fix. Each row was a single
+`TouchableOpacity` (the "select this wallet" action) that itself contained
+two more `TouchableOpacity`s ("Export", "Remove"). Nesting focusable/
+pressable elements like this is a common but serious screen-reader
+regression: the OS accessibility tree collapses the nested elements into the
+outer one, so VoiceOver/TalkBack users can reach "select wallet" but never
+"Export" or "Remove" — a dead end, and one of the acceptance criteria for
+this issue was explicitly "without dead ends."
+
+Fixed by making select/export/remove siblings instead of parent/child, each
+with its own role, label (including the wallet's identity and active/backup
+state, e.g. "Wallet ABC...XYZ, active, backup not confirmed"), and — for the
+two action buttons, which were visually smaller than 44pt tall — `hitSlop`.
+
+## Touch target audit
+
+| Element | File | Visible size (approx.) | Fix |
+| --- | --- | --- | --- |
+| Export / Remove buttons | `WalletList.tsx` | ~34pt tall | `hitSlop` (top/bottom 8, left/right 4) |
+| App Lock switch | `ProfileScreen.tsx` | 50x28pt | `hitSlop` 8pt each side (→ ~66x44) |
+| Lock-timeout chips | `ProfileScreen.tsx` | ~32pt tall | `hitSlop` (top/bottom 6, left/right 4) |
+| Manage Wallets / App Settings rows | `ProfileScreen.tsx` | full-width row, but tight vertical padding | `hitSlop` 8pt each side |
+| Back button | `EmailLoginScreen.tsx` | ~40pt tall | `minHeight: 44` |
+| Forgot Password / Sign Up links | `EmailLoginScreen.tsx` | ~20pt tall | `hitSlop` (top/bottom 12, left/right 8) |
+| Back link | `WalletManagementScreen.tsx` | small text-only tap area | `hitSlop` (top/bottom 12, left/right 8) |
+
+Buttons already at or above 44pt (Sign In, Sign Out, action cards on Home)
+were left unchanged.
+
+## Focus order
+
+Verified for each screen that the accessibility tree order matches the
+visual top-to-bottom, left-to-right layout order — this is the default in
+React Native as long as `flexDirection` isn't reversed and no explicit
+`accessibilityViewIsModal`/`importantForAccessibility` reordering is in
+play, which held true for all four screens. No focus-order-specific bugs
+were found; this section exists to record that the check was made, per the
+issue's acceptance criteria.
+
+## Deferred / out of scope for this PR
+
+To keep this change reviewable, the following were **not** touched, but are
+good candidates for a follow-up:
+
+- `ConfirmationDialog.tsx`, `WalletExportModal.tsx`,
+  `BiometricConfirmationDialog.tsx` — modal dialogs used from Wallet
+  Management; worth a dedicated pass on `accessibilityViewIsModal` and focus
+  trapping.
+- `NetworkSwitcher.tsx`, `ThemeToggle`, `LanguageSwitcher` — shared controls
+  rendered inside `ProfileScreen`; not named in the original issue and have
+  their own component-level accessibility surface.
+- Automated accessibility testing (e.g. `jest-axe`-equivalent for React
+  Native, or Detox accessibility assertions) — there's no existing a11y test
+  tooling in this repo to extend; adding it is a larger, separate task.

--- a/nftopia-mobile-app/screens/Auth/EmailLoginScreen.tsx
+++ b/nftopia-mobile-app/screens/Auth/EmailLoginScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator, ScrollView } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '@/navigation/AuthNavigator';
 import { useAuthStore } from '@/stores/authStore';
@@ -93,9 +93,15 @@ export default function EmailLoginScreen({ navigation }: Props) {
   };
 
   return (
-    <View style={styles.container}>
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.scrollContent}
+      keyboardShouldPersistTaps="handled"
+    >
       <View style={styles.content}>
-        <Text style={styles.title}>Welcome Back</Text>
+        <Text style={styles.title} accessibilityRole="header">
+          Welcome Back
+        </Text>
         <Text style={styles.subtitle}>
           Sign in to continue to NFTopia
         </Text>
@@ -132,13 +138,17 @@ export default function EmailLoginScreen({ navigation }: Props) {
             testID="password-input"
           />
 
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.forgotPassword}
             onPress={() => {
               track('password_reset_clicked');
               Alert.alert('Feature coming soon!', 'Password reset will be implemented in the next update.');
             }}
             disabled={isLoading}
+            accessibilityRole="button"
+            accessibilityLabel="Forgot password"
+            accessibilityState={{ disabled: isLoading }}
+            hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
           >
             <Text style={[styles.forgotPasswordText, isLoading && styles.disabledLink]}>
               Forgot Password?
@@ -153,6 +163,9 @@ export default function EmailLoginScreen({ navigation }: Props) {
           onPress={handleLogin}
           disabled={isLoading}
           testID="login-button"
+          accessibilityRole="button"
+          accessibilityLabel="Sign in"
+          accessibilityState={{ disabled: isLoading, busy: isLoading }}
         >
           {isLoading ? (
             <ActivityIndicator color="#fff" />
@@ -163,10 +176,15 @@ export default function EmailLoginScreen({ navigation }: Props) {
 
         <View style={styles.row}>
           <Text style={styles.footerText}>Don't have an account? </Text>
-          <TouchableOpacity onPress={() => {
-            track('register_navigation');
-            navigation.navigate('EmailRegister');
-          }}>
+          <TouchableOpacity
+            onPress={() => {
+              track('register_navigation');
+              navigation.navigate('EmailRegister');
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Sign up for a new account"
+            hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+          >
             <Text style={styles.linkText}>Sign Up</Text>
           </TouchableOpacity>
         </View>
@@ -178,11 +196,14 @@ export default function EmailLoginScreen({ navigation }: Props) {
             navigation.goBack();
           }}
           disabled={isLoading}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+          accessibilityState={{ disabled: isLoading }}
         >
           <Text style={styles.backButtonText}>← Back</Text>
         </TouchableOpacity>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -190,6 +211,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#ffffff',
+  },
+  scrollContent: {
+    flexGrow: 1,
     paddingHorizontal: 24,
   },
   content: {
@@ -215,7 +239,9 @@ const styles = StyleSheet.create({
     marginTop: -8,
   },
   forgotPasswordText: {
-    color: '#007AFF',
+    // #0070EB (was #007AFF): the brighter blue only reached 4.02:1 against
+    // white, failing WCAG AA (4.5:1) for this 14px link text.
+    color: '#0070EB',
     fontSize: 14,
     fontWeight: '600',
   },
@@ -250,12 +276,14 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   linkText: {
-    color: '#007AFF',
+    color: '#0070EB',
     fontSize: 14,
     fontWeight: '600',
   },
   backButton: {
     alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
     paddingVertical: 12,
   },
   backButtonText: {

--- a/nftopia-mobile-app/screens/Auth/components/AuthButton.tsx
+++ b/nftopia-mobile-app/screens/Auth/components/AuthButton.tsx
@@ -72,6 +72,9 @@ export default function AuthButton({
       onPressOut={handlePressOut}
       activeOpacity={1}
       disabled={isDisabled}
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
     >
       <Animated.View
         style={[

--- a/nftopia-mobile-app/screens/Auth/components/FormInput.tsx
+++ b/nftopia-mobile-app/screens/Auth/components/FormInput.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, StyleSheet, AccessibilityInfo } from 'react-native';
 
 interface FormInputProps {
   label: string;
@@ -34,9 +34,17 @@ export default function FormInput({
 }: FormInputProps) {
   const [isFocused, setIsFocused] = useState(false);
 
+  useEffect(() => {
+    if (error) {
+      AccessibilityInfo.announceForAccessibility(error);
+    }
+  }, [error]);
+
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>{label}</Text>
+      <Text style={styles.label} nativeID={`${testID}-label`}>
+        {label}
+      </Text>
       <TextInput
         style={[
           styles.input,
@@ -59,8 +67,22 @@ export default function FormInput({
         testID={testID}
         multiline={multiline}
         numberOfLines={numberOfLines}
+        accessible
+        accessibilityLabel={label}
+        accessibilityHint={error ?? undefined}
+        accessibilityState={{ disabled: !editable }}
       />
-      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+      {error ? (
+        <Text
+          style={styles.errorText}
+          accessible
+          accessibilityRole="text"
+          accessibilityLiveRegion="polite"
+          testID={testID ? `${testID}-error` : undefined}
+        >
+          {error}
+        </Text>
+      ) : null}
     </View>
   );
 }
@@ -90,7 +112,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   inputError: {
-    borderColor: '#FF3B30',
+    borderColor: '#D63228',
     backgroundColor: '#FFF5F5',
   },
   inputDisabled: {
@@ -103,7 +125,7 @@ const styles = StyleSheet.create({
   },
   errorText: {
     fontSize: 12,
-    color: '#FF3B30',
+    color: '#D63228',
     marginTop: 4,
   },
 });

--- a/nftopia-mobile-app/screens/Auth/components/ValidationError.tsx
+++ b/nftopia-mobile-app/screens/Auth/components/ValidationError.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet, AccessibilityInfo } from 'react-native';
 
 interface ValidationErrorProps {
   message: string | null;
@@ -7,10 +7,25 @@ interface ValidationErrorProps {
 }
 
 export default function ValidationError({ message, testID }: ValidationErrorProps) {
+  useEffect(() => {
+    if (message) {
+      // Android live regions don't reliably fire on iOS, so announce explicitly
+      // to make sure VoiceOver/TalkBack both pick up the new error text.
+      AccessibilityInfo.announceForAccessibility(message);
+    }
+  }, [message]);
+
   if (!message) return null;
 
   return (
-    <View style={styles.container} testID={testID}>
+    <View
+      style={styles.container}
+      testID={testID}
+      accessible
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      importantForAccessibility="yes"
+    >
       <Text style={styles.errorText}>{message}</Text>
     </View>
   );
@@ -22,7 +37,7 @@ const styles = StyleSheet.create({
   },
   errorText: {
     fontSize: 12,
-    color: '#FF3B30',
+    color: '#D63228',
     fontWeight: '500',
   },
 });

--- a/nftopia-mobile-app/screens/Home/HomeScreen.tsx
+++ b/nftopia-mobile-app/screens/Home/HomeScreen.tsx
@@ -180,10 +180,17 @@ function HomeContent() {
       >
         <View style={styles.header}>
           <View>
-            <Text style={styles.greeting}>{t('home.greeting', { name: greetingName })}</Text>
+            <Text style={styles.greeting} accessibilityRole="header">
+              {t('home.greeting', { name: greetingName })}
+            </Text>
             <Text style={styles.subGreeting}>{t('home.title')}</Text>
           </View>
-          <View style={styles.networkBadge}>
+          <View
+            style={styles.networkBadge}
+            accessible
+            accessibilityRole="text"
+            accessibilityLabel={`Network: ${network === 'testnet' ? t('home.testnet') : t('home.mainnet')}`}
+          >
             <Text style={styles.networkBadgeText}>
               {network === 'testnet' ? t('home.testnet') : t('home.mainnet')}
             </Text>
@@ -200,7 +207,9 @@ function HomeContent() {
         />
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('home.discovery.categoriesTitle')}</Text>
+          <Text style={styles.sectionTitle} accessibilityRole="header">
+            {t('home.discovery.categoriesTitle')}
+          </Text>
           <CategorySelector
             onSelectCategory={handleSelectCategory}
             testID="home-category-selector"
@@ -208,7 +217,9 @@ function HomeContent() {
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('home.discovery.trending.title')}</Text>
+          <Text style={styles.sectionTitle} accessibilityRole="header">
+            {t('home.discovery.trending.title')}
+          </Text>
           <TrendingCarousel
             data={trendingCollections}
             loading={trendingLoading}
@@ -220,7 +231,9 @@ function HomeContent() {
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('home.discovery.newDrops.title')}</Text>
+          <Text style={styles.sectionTitle} accessibilityRole="header">
+            {t('home.discovery.newDrops.title')}
+          </Text>
           <NewDropsSection
             data={newDrops}
             loading={newDropsLoading}
@@ -234,23 +247,40 @@ function HomeContent() {
         <RecentlyViewedRow testID="home-recently-viewed" />
 
         <View style={styles.actions}>
-          <TouchableOpacity 
-            style={styles.actionCard} 
+          <TouchableOpacity
+            style={styles.actionCard}
             onPress={() => navigation.navigate('Marketplace')}
+            accessibilityRole="button"
+            accessibilityLabel={t('home.actions.marketplace')}
           >
-            <Text style={styles.actionIcon}>🛍️</Text>
+            <Text style={styles.actionIcon} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">🛍️</Text>
             <Text style={styles.actionLabel}>{t('home.actions.marketplace')}</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.actionCard} onPress={() => navigation.navigate('Send')}>
-            <Text style={styles.actionIcon}>📤</Text>
+          <TouchableOpacity
+            style={styles.actionCard}
+            onPress={() => navigation.navigate('Send')}
+            accessibilityRole="button"
+            accessibilityLabel={t('home.actions.send')}
+          >
+            <Text style={styles.actionIcon} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">📤</Text>
             <Text style={styles.actionLabel}>{t('home.actions.send')}</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.actionCard}>
-            <Text style={styles.actionIcon}>📥</Text>
+          <TouchableOpacity
+            style={styles.actionCard}
+            accessibilityRole="button"
+            accessibilityLabel={t('home.actions.receive')}
+            accessibilityHint="Coming soon"
+          >
+            <Text style={styles.actionIcon} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">📥</Text>
             <Text style={styles.actionLabel}>{t('home.actions.receive')}</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.actionCard}>
-            <Text style={styles.actionIcon}>🔄</Text>
+          <TouchableOpacity
+            style={styles.actionCard}
+            accessibilityRole="button"
+            accessibilityLabel={t('home.actions.swap')}
+            accessibilityHint="Coming soon"
+          >
+            <Text style={styles.actionIcon} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">🔄</Text>
             <Text style={styles.actionLabel}>{t('home.actions.swap')}</Text>
           </TouchableOpacity>
         </View>

--- a/nftopia-mobile-app/screens/Profile/ProfileScreen.tsx
+++ b/nftopia-mobile-app/screens/Profile/ProfileScreen.tsx
@@ -192,10 +192,14 @@ function ProfileContent({ navigation }: Props) {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      <Text style={styles.title}>{t('profile.title')}</Text>
+      <Text style={styles.title} accessibilityRole="header">
+        {t('profile.title')}
+      </Text>
 
       <View style={styles.card}>
-        <Text style={styles.cardTitle}>{t('profile.account')}</Text>
+        <Text style={styles.cardTitle} accessibilityRole="header">
+          {t('profile.account')}
+        </Text>
         <View style={styles.row}>
           <Text style={styles.rowLabel}>{t('profile.email')}</Text>
           <Text style={styles.rowValue}>{user?.email ?? t('common.noResults')}</Text>
@@ -203,7 +207,9 @@ function ProfileContent({ navigation }: Props) {
       </View>
 
       <View style={styles.card}>
-        <Text style={styles.cardTitle}>{t('profile.wallet')}</Text>
+        <Text style={styles.cardTitle} accessibilityRole="header">
+          {t('profile.wallet')}
+        </Text>
         {activeWallet ? (
           <View style={styles.row}>
             <Text style={styles.rowLabel}>{t('profile.activeWallet')}</Text>
@@ -217,18 +223,30 @@ function ProfileContent({ navigation }: Props) {
         <TouchableOpacity
           style={styles.linkRow}
           onPress={() => navigation.navigate('WalletManagement')}
+          accessibilityRole="button"
+          accessibilityLabel={t('profile.manageWallets', { count: wallets.length })}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
         >
           <Text style={styles.linkText}>
             {t('profile.manageWallets', { count: wallets.length })}
           </Text>
-          <Text style={styles.arrow}>→</Text>
+          <Text style={styles.arrow} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">→</Text>
         </TouchableOpacity>
       </View>
 
       <View style={styles.card}>
-        <Text style={styles.cardTitle}>{t('profile.settings')}</Text>
-        <TouchableOpacity accessibilityRole="button" style={styles.linkRow} onPress={() => navigation.navigate('Settings')}>
-          <Text style={styles.linkText}>App settings</Text><Text style={styles.arrow}>→</Text>
+        <Text style={styles.cardTitle} accessibilityRole="header">
+          {t('profile.settings')}
+        </Text>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="App settings"
+          style={styles.linkRow}
+          onPress={() => navigation.navigate('Settings')}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Text style={styles.linkText}>App settings</Text>
+          <Text style={styles.arrow} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">→</Text>
         </TouchableOpacity>
         <View style={styles.themeRow}>
           <Text style={styles.rowLabel}>{t('profile.theme')}</Text>
@@ -237,12 +255,18 @@ function ProfileContent({ navigation }: Props) {
       </View>
 
       <View style={styles.card}>
-        <Text style={styles.cardTitle}>Security</Text>
+        <Text style={styles.cardTitle} accessibilityRole="header">
+          Security
+        </Text>
         <View style={styles.row}>
           <Text style={styles.rowLabel}>App Lock</Text>
           <TouchableOpacity
             onPress={() => setAppLockEnabled(!appLockEnabled)}
             style={styles.switch}
+            accessibilityRole="switch"
+            accessibilityLabel="App lock"
+            accessibilityState={{ checked: appLockEnabled }}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
             <View style={[styles.switchTrack, appLockEnabled && styles.switchTrackActive]}>
               <View style={[styles.switchThumb, appLockEnabled && styles.switchThumbActive]} />
@@ -269,6 +293,10 @@ function ProfileContent({ navigation }: Props) {
                   lockTimeout === option.value && styles.timeoutOptionActive,
                 ]}
                 onPress={() => setLockTimeout(option.value)}
+                accessibilityRole="button"
+                accessibilityLabel={option.label}
+                accessibilityState={{ selected: lockTimeout === option.value }}
+                hitSlop={{ top: 6, bottom: 6, left: 4, right: 4 }}
               >
                 <Text
                   style={[
@@ -285,16 +313,25 @@ function ProfileContent({ navigation }: Props) {
       </View>
 
       <View style={styles.card}>
-        <Text style={styles.cardTitle}>{t('profile.language')}</Text>
+        <Text style={styles.cardTitle} accessibilityRole="header">
+          {t('profile.language')}
+        </Text>
         <LanguageSwitcher variant="full" />
       </View>
 
       <View style={styles.card}>
-        <Text style={styles.cardTitle}>{t('home.network')}</Text>
+        <Text style={styles.cardTitle} accessibilityRole="header">
+          {t('home.network')}
+        </Text>
         <NetworkSwitcher network={network} onSwitch={switchNetwork} />
       </View>
 
-      <TouchableOpacity style={styles.logoutButton} onPress={handleSignOut}>
+      <TouchableOpacity
+        style={styles.logoutButton}
+        onPress={handleSignOut}
+        accessibilityRole="button"
+        accessibilityLabel={t('profile.signOut')}
+      >
         <Text style={styles.logoutText}>{t('profile.signOut')}</Text>
       </TouchableOpacity>
     </ScrollView>

--- a/nftopia-mobile-app/screens/Profile/WalletManagementScreen.tsx
+++ b/nftopia-mobile-app/screens/Profile/WalletManagementScreen.tsx
@@ -221,15 +221,22 @@ export default function WalletManagementScreen({ navigation, route }: Props) {
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+          hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+        >
           <Text style={styles.backText}>← Back</Text>
         </TouchableOpacity>
-        <Text style={styles.title}>Wallets</Text>
+        <Text style={styles.title} accessibilityRole="header">
+          Wallets
+        </Text>
         <View style={styles.headerSpacer} />
       </View>
 
       {wallets.length === 0 ? (
-        <View style={styles.empty}>
+        <View style={styles.empty} accessible accessibilityLabel="No wallets. Import or create a wallet to get started.">
           <Text style={styles.emptyTitle}>No Wallets</Text>
           <Text style={styles.emptySubtitle}>
             Import or create a wallet to get started

--- a/nftopia-mobile-app/src/theme/colors.ts
+++ b/nftopia-mobile-app/src/theme/colors.ts
@@ -15,28 +15,34 @@ export const lightColors: ThemeColors = {
   // Text colors
   text: '#1a1a1a',
   textSecondary: '#666666',
-  textTertiary: '#999999',
+  // #707070 (was #999999): #999999 only reached 2.85:1 against white/surface,
+  // failing WCAG AA (4.5:1) for body text. #707070 clears 4.5:1 on both.
+  textTertiary: '#707070',
   textInverse: '#ffffff',
-  
+
   // Border colors
   border: '#e9ecef',
   borderFocused: '#007AFF',
   borderLight: '#f0f0f0',
-  
+
   // Status colors
-  error: '#FF3B30',
+  // #D63228 (was #FF3B30): the brighter red only reached 3.32:1 against
+  // errorBackground, failing WCAG AA (4.5:1) for error text/labels.
+  error: '#D63228',
   errorBackground: '#FFF5F5',
-  errorText: '#FF3B30',
-  
+  errorText: '#D63228',
+
   warning: '#FF9500',
   warningBackground: '#fff3cd',
   warningText: '#856404',
-  
+
   success: '#34C759',
   successBackground: '#E8F5E9',
   successText: '#2E7D32',
-  
-  info: '#007AFF',
+
+  // #0070EB (was #007AFF): the brighter blue only reached 4.02:1 against
+  // white, failing WCAG AA (4.5:1) for link text.
+  info: '#0070EB',
   infoBackground: '#e7f3ff',
   infoText: '#084298',
   
@@ -67,7 +73,9 @@ export const darkColors: ThemeColors = {
   // Text colors
   text: '#ffffff',
   textSecondary: '#b0b0b0',
-  textTertiary: '#808080',
+  // #8C8C8C (was #808080): #808080 only reached 4.22:1 against the surface
+  // color, failing WCAG AA (4.5:1) for body text.
+  textTertiary: '#8C8C8C',
   textInverse: '#000000',
   
   // Border colors
@@ -90,7 +98,9 @@ export const darkColors: ThemeColors = {
   
   info: '#0A84FF',
   infoBackground: '#1A2430',
-  infoText: '#0A84FF',
+  // #2B96FF (was #0A84FF): the darker blue only reached 4.30:1 against
+  // infoBackground, failing WCAG AA (4.5:1) for info text.
+  infoText: '#2B96FF',
   
   // Network colors
   testnet: '#FF9F0A',


### PR DESCRIPTION
## Summary

Implements the accessibility audit requested in #480 for the four core screens named in the issue: `EmailLoginScreen`, `HomeScreen`, `ProfileScreen`, and the Wallet Management flow (`WalletManagementScreen` + `WalletList`).

- **Accessibility labels/roles**: every interactive element (buttons, links, the App Lock switch, wallet actions) now has an explicit `accessibilityRole` and `accessibilityLabel`, plus `accessibilityState` for disabled/selected/checked/busy where relevant. Screen and section titles use `accessibilityRole="header"`.
- **Screen reader dead end fixed**: `WalletList.tsx` nested a `TouchableOpacity` (select wallet) around two more `TouchableOpacity`s (Export, Remove). Nested touchables collapse into one element for VoiceOver/TalkBack, making Export/Remove unreachable. They're now sibling controls, each independently focusable.
- **Accessible error announcements**: `ValidationError` and `FormInput`'s inline error text now use `accessibilityLiveRegion="polite"` and call `AccessibilityInfo.announceForAccessibility()` so validation errors are spoken as soon as they appear.
- **Touch targets**: controls under 44x44pt (wallet action buttons, the App Lock switch, lock-timeout chips, back/forgot-password/sign-up links) are padded with `hitSlop` (or `minHeight`) without changing their visual size.
- **Font scaling**: `EmailLoginScreen` was a non-scrolling, vertically-centered `View` that could clip content at large OS font scales. It's now wrapped in a `ScrollView`.
- **Decorative content hidden**: arrow glyphs (`→`) and emoji icons used purely for visual effect are marked `accessibilityElementsHidden` so they aren't announced twice alongside their label.
- **WCAG AA color contrast audit**: checked every `src/theme/colors.ts` token pair actually used for text against its background. Five failed AA (as low as 2.85:1) and were adjusted to pass — `textTertiary`, `error`/`errorText`, and `info`/`infoText` in both light and dark themes. Full before/after ratio table in the audit doc. The matching hardcoded literals in `EmailLoginScreen.tsx`/`FormInput.tsx`/`ValidationError.tsx` (which don't consume the theme) were updated to the same corrected hex values.
- **Docs**: added `docs/ACCESSIBILITY.md` (a short contributor checklist) and `docs/ACCESSIBILITY_AUDIT.md` (the full screen-by-screen findings and contrast table), linked from the README.

**Method note on the VoiceOver/TalkBack pass**: no physical device/simulator was available in this environment, so the "walkthrough" in the audit doc is a code-level accessibility-tree simulation (role/label/order tracing per the RN accessibility API), not a recorded live session. This is called out explicitly in the audit doc, along with a recommendation that a contributor with real devices do one live confirmation pass before release.

**Deferred / out of scope** (noted in the audit doc for follow-up): modal dialogs (`ConfirmationDialog`, `WalletExportModal`, `BiometricConfirmationDialog`), `NetworkSwitcher`/`ThemeToggle`/`LanguageSwitcher`, and automated accessibility test tooling — none were named in the original issue and each warrants its own focused pass.

## Test plan

- [x] `npx tsc --noEmit` — passes with zero errors
- [x] `npx jest` — 25 suites / 376 tests pass
- [ ] Manual VoiceOver pass on a real iOS device (see `docs/ACCESSIBILITY.md`)
- [ ] Manual TalkBack pass on a real Android device (see `docs/ACCESSIBILITY.md`)

Closes #480